### PR TITLE
Track local-agent runtime and skills signals for March-April 2026

### DIFF
--- a/radar/2026-04-local-agent-watch.md
+++ b/radar/2026-04-local-agent-watch.md
@@ -1,0 +1,76 @@
+---
+title: Local Agent Watch
+owner: Prompthon IO
+updated: 2026-04-23
+time_scope: 2026-04
+status: draft
+---
+
+# Local Agent Watch
+
+## Summary
+
+The most useful local-agent signal across March and April 2026 is not a single
+model or framework launch. It is the way several official sources are starting
+to converge on the same shape: a nearby execution environment, explicit skill
+or workflow packaging, and grounded access to documents, files, or business
+systems.
+
+## Why It Matters
+
+"Local agent" is easy to flatten into a vague idea about running models close
+to the user. The more durable product question is narrower:
+
+- where the agent runs
+- which tools or integrations it can reach
+- how it finds the right local documents or operating context
+- how reusable workflow knowledge is packaged
+
+That combination matters more than a raw chat loop for practical internal
+agents, support agents, and coding agents.
+
+## Evidence And Sources
+
+- [From model to agent: Equipping the Responses API with a computer environment](https://openai.com/index/equip-responses-api-computer-environment/):
+  OpenAI's March 11, 2026 engineering post frames agent execution around a
+  computer environment, persistent files, shell access, compaction, and skill
+  bundles that help produce durable artifacts.
+- [Closing the knowledge gap with agent skills](https://developers.googleblog.com/en/closing-the-knowledge-gap-with-agent-skills/):
+  Google's March 25, 2026 post treats skills as lightweight instruction
+  packages that close knowledge gaps while still pushing agents back toward
+  fresh documentation as the source of truth.
+- [Supercharge your AI agents: The New ADK Integrations Ecosystem](https://developers.googleblog.com/supercharge-your-ai-agents-adk-integrations-ecosystem/):
+  Google's February 27, 2026 post expands ADK around direct integrations for
+  code, project tools, databases, email, and messaging, which makes "agent"
+  feel less like a chat abstraction and more like a connected worker surface.
+
+## Signals To Watch
+
+- Whether local-agent products settle on a stable split between reusable skill
+  instructions and executable tool integrations.
+- Whether file-grounded work becomes more explicit, with clearer rules for
+  local document paths, nearby artifacts, and inspectable context boundaries.
+- Whether support and operations workflows become the clearest local-agent
+  product surfaces because they naturally combine inbox events, policy
+  documents, and bounded reply actions.
+- Whether vendors keep local execution narrow and permissioned, or drift back
+  toward broad environment access that is harder to trust and govern.
+
+## Editorial Take
+
+The shared direction is more important than any one vendor term. OpenAI is
+making the runtime and skill stack more explicit. Google is separating skill
+knowledge from live integrations. Together they point toward a practical
+pattern for local agents:
+
+- keep execution close to the working environment
+- keep workflow knowledge reusable
+- keep business grounding tied to real documents and systems
+
+That is a better planning lens for handbook contributors than treating local
+agents as a pure model or framework category.
+
+## Update Log
+
+- 2026-04-23: Added a radar note focused on local runtimes, skill packaging,
+  and file-grounded agent workflows.

--- a/radar/2026-04-local-agent-watch.md
+++ b/radar/2026-04-local-agent-watch.md
@@ -1,12 +1,12 @@
 ---
-title: Local Agent Watch
+title: April 2026 Local Agent Watch
 owner: Prompthon IO
 updated: 2026-04-23
 time_scope: 2026-04
 status: draft
 ---
 
-# Local Agent Watch
+# April 2026 Local Agent Watch
 
 ## Summary
 

--- a/radar/2026-04-local-agent-watch.md
+++ b/radar/2026-04-local-agent-watch.md
@@ -10,11 +10,10 @@ status: draft
 
 ## Summary
 
-The most useful local-agent signal across March and April 2026 is not a single
-model or framework launch. It is the way several official sources are starting
-to converge on the same shape: a nearby execution environment, explicit skill
-or workflow packaging, and grounded access to documents, files, or business
-systems.
+The most useful local-agent signal in April 2026 is not a single model or
+framework launch. It is the way several official sources converge on the same
+shape: a nearby execution environment, explicit skill or workflow packaging,
+and grounded access to documents, files, or business systems.
 
 ## Why It Matters
 

--- a/radar/README.md
+++ b/radar/README.md
@@ -19,6 +19,9 @@ without destabilizing the evergreen structure.
 
 ## Current notes
 
+- [Local Agent Watch](./2026-04-local-agent-watch.md): a time-scoped note on
+  how local runtimes, skill bundles, and file-grounded context are converging
+  into a more concrete agent product shape.
 - [April 2026 Interoperability Watch](./2026-04-interoperability-watch.md):
   a current field note on how A2A, A2UI, and MCP are separating into different
   interoperability layers.

--- a/radar/README.md
+++ b/radar/README.md
@@ -19,7 +19,7 @@ without destabilizing the evergreen structure.
 
 ## Current notes
 
-- [Local Agent Watch](./2026-04-local-agent-watch.md): a time-scoped note on
+- [April 2026 Local Agent Watch](./2026-04-local-agent-watch.md): a time-scoped note on
   how local runtimes, skill bundles, and file-grounded context are converging
   into a more concrete agent product shape.
 - [April 2026 Interoperability Watch](./2026-04-interoperability-watch.md):


### PR DESCRIPTION
## Summary
- add a new April 2026 local-agent watch note
- connect local runtimes, skill bundles, and file-grounded workflows
- index the new note from the radar README

## Verification
- python3 scripts/verify_example_projects.py