### PR TITLE
[generalkim00] Map local agent tooling, skills, roots, and file grounding

### DIFF
--- a/contributor-kit/reference-notes/README.md
+++ b/contributor-kit/reference-notes/README.md
@@ -18,3 +18,6 @@ material and they are not replacements for lab pages.
   contributor-facing comparison of current OpenAI and Google deep-research
   product signals.
 - [Deep Research Source Map](./deep-research-source-map.md)
+- [Local Agent Tooling Source Map](./local-agent-tooling-source-map.md): a
+  contributor-facing source map for local runtimes, skills, MCP roots,
+  resources, and file-grounded agent workflows.

--- a/contributor-kit/reference-notes/local-agent-tooling-source-map.md
+++ b/contributor-kit/reference-notes/local-agent-tooling-source-map.md
@@ -1,0 +1,122 @@
+---
+title: Local Agent Tooling Source Map
+owner: Prompthon IO
+updated: 2026-04-23
+scope: local agent tooling, skills, roots, resources, and file-grounded workflows
+status: draft
+---
+
+# Local Agent Tooling Source Map
+
+## Summary
+
+This note gathers official source inputs for contributors writing about local
+agent systems: agents that work near a user's files, tools, project state, and
+workflow instructions rather than operating only as a remote chat surface.
+
+The durable pattern is not "local" by itself. It is the combination of:
+
+- an execution environment or local tool boundary
+- reusable skill or workflow packaging
+- explicit filesystem or document scope
+- resources that can be selected, searched, read, or refreshed
+- permission rules that make the boundary understandable to users
+
+## Why It Matters
+
+Local-agent topics are becoming easy to overstate. A useful handbook treatment
+should separate several concerns that are often mixed together:
+
+- `runtime`: where commands, scripts, files, or containers run
+- `skills`: how reusable task knowledge is packaged
+- `roots`: which local filesystem areas a tool-facing server may see
+- `resources`: which files, schemas, records, or application objects can be
+  exposed as model context
+- `connectors`: how local and remote services become callable tools
+
+That split helps contributors write case studies and starter projects without
+pretending that every integration is the same kind of agent capability.
+
+## Scope Notes
+
+Included:
+
+- official OpenAI source material on Responses API tools, file search, remote
+  MCP support, and computer environments
+- official MCP material on roots and resources
+- official Claude Code material on local stdio servers, project/user scopes,
+  and MCP resources
+
+Excluded:
+
+- third-party MCP server listings
+- unofficial prompt-injection commentary
+- vendor comparisons that do not change the handbook's local-agent mental
+  model
+- implementation details for a production email or CRM integration
+
+## Source Map
+
+- [OpenAI Responses API tools and remote MCP support](https://openai.com/index/new-tools-and-features-in-the-responses-api/):
+  a current source for remote MCP support, built-in tools, file search, and
+  background-mode style long-running agent work.
+- [OpenAI computer environment for agents](https://openai.com/index/equip-responses-api-computer-environment/):
+  a current source for the execution-environment side of agent design,
+  including shell access, hosted filesystem state, compaction, and agent
+  skills.
+- [MCP introduction](https://modelcontextprotocol.io/docs/getting-started/intro):
+  a stable entry point for MCP as a standard connection layer between AI
+  applications and external systems such as local files, databases, tools, and
+  workflows.
+- [MCP roots](https://modelcontextprotocol.io/specification/2025-06-18/client/roots):
+  the clearest official source for local filesystem boundaries. Roots define
+  which directories or files a server can understand as available.
+- [MCP resources](https://modelcontextprotocol.io/specification/draft/server/resources):
+  the clearest official source for application-driven context surfaces such as
+  files, schemas, or application-specific objects.
+- [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp):
+  a practical source for local stdio servers, project-scoped MCP
+  configuration, plugin-provided MCP servers, and MCP resources in a coding
+  agent workflow.
+
+## Synthesis
+
+The strongest local-agent spine is a layered one:
+
+1. The user or host application chooses an operating boundary.
+2. Tools and servers expose capabilities inside that boundary.
+3. Resources and roots describe which context can be read or selected.
+4. Skills package repeatable task knowledge.
+5. The agent produces an artifact or action that can be reviewed.
+
+For handbook purposes, this is more useful than saying "the agent has access to
+files." Local access should always be explained with the boundary attached:
+which files, which server, which transport, which permission, and which
+artifact.
+
+## Case-Study Hooks
+
+Good local-agent case studies should make the boundary visible:
+
+- customer-support email agent: inbound message path plus local policy
+  document path
+- coding agent: repository root plus issue, test, and branch permissions
+- operations agent: dashboard or database resource plus read-only query rules
+- research agent: source folder plus citation artifact output
+
+Each case should state what the agent may read, what it may write, and what
+requires human review.
+
+## Gaps And Follow-up
+
+- Add a production-readiness note on local-agent security risks, especially
+  prompt injection from untrusted files and connectors.
+- Add a small matrix comparing direct local scripts, local stdio MCP servers,
+  remote MCP servers, and platform-hosted tools.
+- Expand the customer-support case study once the starter code includes a real
+  mailbox or Gmail adapter.
+
+## Update Log
+
+- 2026-04-23: Added a contributor-facing source map for local agent tooling,
+  skills, roots, resources, and file-grounded workflows.

--- a/contributor-kit/reference-notes/local-agent-tooling-source-map.md
+++ b/contributor-kit/reference-notes/local-agent-tooling-source-map.md
@@ -71,7 +71,7 @@ Excluded:
 - [MCP roots](https://modelcontextprotocol.io/specification/2025-06-18/client/roots):
   the clearest official source for local filesystem boundaries. Roots define
   which directories or files a server can understand as available.
-- [MCP resources](https://modelcontextprotocol.io/specification/draft/server/resources):
+- [MCP resources](https://modelcontextprotocol.io/specification/2025-06-18/server/resources):
   the clearest official source for application-driven context surfaces such as
   files, schemas, or application-specific objects.
 - [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp):


### PR DESCRIPTION
## Summary
- add a local-agent tooling source map for contributors
- connect runtime, skills, MCP roots, resources, and file-grounded workflows
- index the new note in contributor-kit reference notes

## Verification
- python3 scripts/verify_example_projects.py

## Execution
- Commit author: generalkim00
- Push and PR executor: dprat0821