### PR TITLE
Add a customer support email agent case study and local policy grounded starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,102 +1,129 @@
-<div align="center">
-  <a href="https://github.com/Prompthon-IO">
-    <img src="https://github.com/Prompthon-IO.png?size=160" alt="Prompthon IO" width="96" height="96" />
-  </a>
+# Prompthon Agentic Lab
 
-  <h1>Prompthon Agentic Lab</h1>
+> **Evolve Through Prompting. Learn Through Building.**
 
-  <p>
-    A public working lab from <strong>Prompthon IO</strong> for organizing
-    practical knowledge about modern agent systems, from core concepts to
-    production-minded implementation patterns.
-  </p>
+A public field guide for AI-native learners, early builders, and practitioners
+exploring how modern agent systems are understood, used, built, evaluated, and
+operated in practice.
 
-  <p>
-    <a href="https://github.com/Prompthon-IO">Organization</a>
-    ·
-    <a href="https://github.com/Prompthon-IO/agent-systems-handbook">Repository</a>
-    ·
-    <a href="https://github.com/Prompthon-IO/agent-systems-handbook/issues">Issues</a>
-    ·
-    <a href="https://discord.gg/sDE2HhGTg4">Discord</a>
-  </p>
-
-  <p>
-    <img src="https://img.shields.io/github/last-commit/Prompthon-IO/agent-systems-handbook?style=flat-square" alt="Last commit" />
-    <img src="https://img.shields.io/github/stars/Prompthon-IO/agent-systems-handbook?style=flat-square" alt="GitHub stars" />
-    <img src="https://img.shields.io/github/forks/Prompthon-IO/agent-systems-handbook?style=flat-square" alt="GitHub forks" />
-    <img src="https://img.shields.io/github/issues/Prompthon-IO/agent-systems-handbook?style=flat-square" alt="GitHub issues" />
-  </p>
-</div>
+[**Organization**](https://github.com/Prompthon-IO) ·
+[**Repository**](https://github.com/Prompthon-IO/agentic-lab) ·
+[**Issues**](https://github.com/Prompthon-IO/agentic-lab/issues) ·
+[**Discord**](https://discord.gg/sDE2HhGTg4)
 
 ---
 
 ## Overview
 
-Prompthon Agentic Lab is a public repository for understanding how agent
-systems are
-designed, compared, built, evaluated, and operated in practice. It is
-structured as a field guide rather than a single linear course, so explorers can
-move between foundations, patterns, systems, ecosystem coverage, and case
-studies without losing the thread.
+Prompthon Agentic Lab is an AI-native field guide for students,
+practitioners, and builders exploring modern agent systems from different
+angles.
 
-The repository is organized around durable public surfaces. Lab pages live
-in the lane folders, audience guides live under `reading-paths/`, contribution
-support lives in the contributor docs, and mature outward-facing extensions can
-be tracked in `publications/`. The goal is to keep articles, notes, and example
-projects in the place where contributors and explorers would actually expect to
-find them.
+Built on **learn, question, and innovate**, the lab is shaped by learners and
+grounded in real industry practice. It helps readers understand the space,
+apply AI effectively, or build real systems through parallel paths rather than
+a single track.
 
+## Why This Lab Fits AI-Native Learners, Practitioners, And Builders
+
+### Built on learn, question, and innovate
+
+This repository encourages active learning, critical thinking, and
+experimentation rather than passive consumption.
+
+### Built by learners, not only for learners
+
+Many contributors are learners themselves. That keeps the material close to the
+questions, habits, and learning paths that students, new grads, and
+next-generation AI-native builders actually have.
+
+### Guided by real industry practice
+
+Through Prompthon programs and industry-facing guidance, the lab remains
+connected to how frontier teams think, build, iterate, and evaluate in real
+settings.
+
+### AI-native by design
+
+The content is created through an AI-native workflow that combines
+AI-assisted drafting, synthesis, iteration, and refinement with expert guidance
+and review.
+
+### Designed for different paths, not a single track
+
+The lab is organized for different kinds of learners and different intentions.
+Some people want broad understanding and trend awareness. Some want to apply AI
+tools to daily work and study. Some want to build real systems and
+applications. This repository supports all three without forcing one sequence.
 
 ## Start Here
 
-Choose the guide that matches what you want to do first.
+Choose the path that best matches what you want from AI right now. These are
+parallel tracks for different types of learners and builders, not a required
+sequence.
 
-<table>
-  <tr>
-    <td valign="top" width="50%">
-      <h3>Explorer</h3>
-      <p>For people who want a clear, high-level understanding of the space before getting into implementation detail.</p>
-      <p><strong>What you get:</strong> A curated set of recommended reads across the lab without a fixed sequence.</p>
-      <p><a href="./reading-paths/explorer.md">Open the Explorer guide</a></p>
-    </td>
-    <td valign="top" width="50%">
-      <h3>Practitioner</h3>
-      <p>For people who want to use agent tools and skills in daily life or real work without becoming professional agent builders.</p>
-      <p><strong>What you get:</strong> A linear orientation path for understanding use cases, choosing the right tool surfaces, and knowing where to go deeper later.</p>
-      <p><a href="./reading-paths/practitioner.md">Open the Practitioner guide</a></p>
-    </td>
-  </tr>
-  <tr>
-    <td valign="top" width="50%">
-      <h3>Builder</h3>
-      <p>For engineers who want to design and build professional agent applications.</p>
-      <p><strong>What you get:</strong> A linear build-oriented path through concepts, patterns, systems, and concrete examples.</p>
-      <p><a href="./reading-paths/builder.md">Open the Builder guide</a></p>
-    </td>
-    <td valign="top" width="50%">
-      <h3>Contributor</h3>
-      <p>For people who want to shape the lab by adding, revising, curating, or maintaining pages, notes, and starter projects.</p>
-      <p><strong>What you get:</strong> A public contributor path into the editorial workflow, templates, review rules, and the correct published surface for each contribution type.</p>
-      <p><a href="./reading-paths/contributor.md">Open the Contributor guide</a></p>
-    </td>
-  </tr>
-</table>
+### Explorer
+
+For students, newcomers, and curious AI-native readers who want a broad view of
+AI, agents, trends, and foundational ideas without needing to become engineers.
+
+**What you get:** a curated set of high-signal reads that help you learn core
+concepts, follow important shifts, test ideas with your own thinking, and build
+a grounded first-hand understanding of the space.
+
+[**Open the Explorer guide**](./reading-paths/explorer.md)
+
+### Practitioner
+
+For people who want to use AI tools, agents, and workflows to enhance daily
+life, study, and real work without needing to become full-time engineers.
+
+**What you get:** a practical path for learning how to apply AI effectively,
+choose the right tools and workflows, and operate with leverage in real
+scenarios, including one-person-company style use cases where AI expands what
+one person can do without requiring full builder depth.
+
+[**Open the Practitioner guide**](./reading-paths/practitioner.md)
+
+### Builder
+
+For engineering-minded learners, new grads, and developers who want to build
+with AI more directly, from agent applications and workflows to startup-style
+products and technically deeper implementations.
+
+**What you get:** a build-oriented path through concepts, patterns, systems,
+architecture choices, technical details, and concrete examples for people who
+want to create their own applications and go deeper into implementation.
+
+[**Open the Builder guide**](./reading-paths/builder.md)
+
+### Contributor
+
+For people who want to shape the lab by adding, revising, curating, or
+maintaining pages, notes, examples, and outward-facing extensions.
+
+**What you get:** a public path into the editorial workflow, templates, review
+rules, placement standards, and portfolio-relevant open-source contribution.
+
+[**Open the Contributor guide**](./reading-paths/contributor.md)
 
 ## Contributor Guide
 
 If you want to contribute to Prompthon Agentic Lab, start from the contributor
-docs rather than from ad hoc internal working material.
+docs rather than ad hoc internal working material.
 
 Public contributions in this repository currently fit into these paths:
 
-- lab articles in `foundations/`, `patterns/`, `systems/`, `ecosystem/`, or `case-studies/`
+- lab articles in `foundations/`, `patterns/`, `systems/`, `ecosystem/`, or
+  `case-studies/`
 - radar notes in [`radar/`](./radar/)
 - source projects in lane-local `examples/` folders
-- curated reference notes in [`contributor-kit/reference-notes/`](./contributor-kit/reference-notes/README.md)
-- publication extensions in [`publications/`](./publications/README.md) once a lab page is ready for an outward-facing article or distribution surface
+- curated reference notes in
+  [`contributor-kit/reference-notes/`](./contributor-kit/reference-notes/README.md)
+- publication extensions in [`publications/`](./publications/README.md) once a
+  lab page is ready for an outward-facing article or distribution surface
 
-Start with [Contributing](./CONTRIBUTING.md) and
+Start with [Contributing](./CONTRIBUTING.md) and the
 [Contributor Kit](./contributor-kit/README.md). Those pages define the public
-workflow, templates, review standards, and placement rules for lab
-articles, notes, and code that belong in this repository.
+workflow, templates, review standards, and placement rules for lab articles,
+notes, and code that belong in this repository.

--- a/case-studies/README.md
+++ b/case-studies/README.md
@@ -23,8 +23,13 @@ modes.
 
 - [Deep Research Agents](./deep-research-agents.md): a bounded look at
   planning, evidence collection, synthesis, and citation discipline.
+- [Customer Support Agents](./customer-support-agents.md): a local-first case
+  study for email triage and policy-grounded reply drafting.
 
 ## Example starters
 
 - [Deep Research Agent Starter](./examples/deep-research-agent-starter/README.md):
   a small project scaffold for planning, evidence collection, and cited output.
+- [Customer Support Email Agent Starter](./examples/customer-support-email-agent-starter/README.md):
+  a small local-document workflow for triaging customer emails and drafting
+  policy-grounded replies.

--- a/case-studies/customer-support-agents.md
+++ b/case-studies/customer-support-agents.md
@@ -1,0 +1,159 @@
+---
+title: Customer Support Agents
+owner: Prompthon IO
+updated: 2026-04-23
+depth: intermediate
+region_tags:
+  - global
+coding_required: optional
+external_readings:
+  - https://openai.com/index/equip-responses-api-computer-environment/
+  - https://openai.com/index/new-tools-and-features-in-the-responses-api/
+  - https://code.claude.com/docs/en/mcp
+  - https://modelcontextprotocol.io/specification/2025-06-18/client/roots
+  - https://modelcontextprotocol.io/specification/draft/server/resources
+status: draft
+---
+
+# Customer Support Agents
+
+## Summary
+
+Customer support agents help turn inbound customer messages into classified
+cases, grounded answers, draft replies, and human handoffs. The safest version
+is not an autonomous "reply to everything" bot. It is a local, policy-grounded
+workflow that reads a customer input, consults approved support material, and
+drafts a response that a human can review.
+
+## Why It Matters
+
+Support work is repetitive enough to benefit from agents, but sensitive enough
+to require tight boundaries.
+
+Useful, because many messages share patterns:
+
+- product questions
+- billing questions
+- complaints
+- refund or replacement requests
+- account and privacy requests
+
+Risky, because a bad reply can promise the wrong remedy, expose private
+information, mishandle angry customers, or ignore escalation rules.
+
+## Mental Model
+
+A durable customer-support agent has five steps:
+
+- `ingest`: read the inbound message from an email, form, chat export, or CRM
+  record
+- `classify`: identify the case type, urgency, sentiment, and requested outcome
+- `ground`: retrieve the relevant local policy, FAQ, refund rule, or escalation
+  note
+- `draft`: produce a customer-facing reply that cites only approved support
+  material
+- `gate`: decide whether the reply is safe to send or needs human review
+
+The local document path is important. It makes the policy source explicit:
+
+```text
+EMAIL_PATH=/Users/example/inbox/customer-complaint.txt
+POLICY_PATH=/Users/example/support/refund-and-escalation-policy.md
+```
+
+That is a clearer system than asking a model to "answer like support" from
+general memory.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+  Email["Inbound email path"] --> Triage["Triage"]
+  Policy["Local policy document path"] --> Grounding["Policy grounding"]
+  Triage --> Draft["Reply draft"]
+  Grounding --> Draft
+  Draft --> Guardrails["Guardrails"]
+  Guardrails --> Human["Human review or send queue"]
+```
+
+## Tool Landscape
+
+Support agents usually combine a small set of capabilities:
+
+- local file reading for approved policy and FAQ documents
+- mailbox or CRM connectors for inbound customer messages
+- classification logic for routing and escalation
+- retrieval or search over support material
+- draft generation with tone and policy constraints
+- audit output that shows which policy evidence informed the reply
+
+For a starter workflow, a local path is enough. The agent can read one inbound
+message file and one policy document file. Production systems can later replace
+those local paths with Gmail, helpdesk, CRM, or MCP-backed resources.
+
+MCP-style roots and resources are useful here because they force the system to
+say what the agent may access. A policy folder root is different from full disk
+access. A selected policy resource is different from crawling every customer
+record.
+
+## Guardrails
+
+Good support agents should not send replies automatically unless the operating
+rules are extremely narrow.
+
+Useful defaults:
+
+- never promise refunds, credits, replacements, legal outcomes, or account
+  changes unless the local policy explicitly allows them
+- always escalate chargebacks, safety issues, abusive messages, privacy
+  requests, and regulatory questions
+- include the policy evidence used to draft the reply
+- keep the reply calm, short, and customer-facing
+- treat "not enough policy evidence" as a valid reason for human review
+
+## Tradeoffs
+
+- Local policy grounding improves control, but the policy document must be kept
+  current.
+- A narrow draft-only workflow is safer, but it still needs review capacity.
+- Rich mailbox integrations reduce copy-paste work, but they expand privacy
+  and permission risks.
+- Automated replies improve speed, but they can harm trust if classification or
+  policy grounding is weak.
+
+Practical default:
+
+- start with draft-only replies from explicit local document paths
+- add mailbox integration only after the policy-grounded draft loop is reliable
+- add auto-send only for low-risk, high-confidence cases with clear audit logs
+
+## Starter Project
+
+The accompanying starter lives at
+[Customer Support Email Agent Starter](./examples/customer-support-email-agent-starter/README.md).
+It demonstrates a small standard-library workflow for:
+
+- loading a customer email from a local path
+- loading a support policy from a local path
+- classifying complaints, queries, refund requests, and handoff cases
+- drafting a safe policy-grounded reply
+- marking uncertain or sensitive cases for human review
+
+## Citations
+
+- Official source: [OpenAI computer environment for agents](https://openai.com/index/equip-responses-api-computer-environment/)
+- Official source: [OpenAI Responses API tools and file search](https://openai.com/index/new-tools-and-features-in-the-responses-api/)
+- Official source: [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp)
+- Official source: [MCP roots](https://modelcontextprotocol.io/specification/2025-06-18/client/roots)
+- Official source: [MCP resources](https://modelcontextprotocol.io/specification/draft/server/resources)
+
+## Reading Extensions
+
+- [Protocols And Interoperability](../systems/protocols-and-interoperability.md)
+- [Agent Memory And Retrieval](../patterns/agent-memory-and-retrieval.md)
+- [Case Studies Overview](./README.md)
+
+## Update Log
+
+- 2026-04-23: Added a local-first customer-support case study with a
+  policy-grounded email reply starter.

--- a/case-studies/customer-support-agents.md
+++ b/case-studies/customer-support-agents.md
@@ -7,11 +7,16 @@ region_tags:
   - global
 coding_required: optional
 external_readings:
-  - https://openai.com/index/equip-responses-api-computer-environment/
-  - https://openai.com/index/new-tools-and-features-in-the-responses-api/
-  - https://code.claude.com/docs/en/mcp
-  - https://modelcontextprotocol.io/specification/2025-06-18/client/roots
-  - https://modelcontextprotocol.io/specification/draft/server/resources
+  - title: OpenAI Responses API computer environment
+    url: https://openai.com/index/equip-responses-api-computer-environment/
+  - title: OpenAI Responses API tools and features
+    url: https://openai.com/index/new-tools-and-features-in-the-responses-api/
+  - title: Claude Code MCP documentation
+    url: https://code.claude.com/docs/en/mcp
+  - title: Model Context Protocol client roots specification
+    url: https://modelcontextprotocol.io/specification/2025-06-18/client/roots
+  - title: Model Context Protocol server resources specification
+    url: https://modelcontextprotocol.io/specification/draft/server/resources
 status: draft
 ---
 

--- a/case-studies/examples/customer-support-email-agent-starter/README.md
+++ b/case-studies/examples/customer-support-email-agent-starter/README.md
@@ -1,0 +1,83 @@
+# Customer Support Email Agent Starter
+
+## Summary
+
+This starter turns the customer-support case study into a small local workflow:
+read an inbound customer email, read a local support policy document, classify
+the case, and draft a safe reply for human review.
+
+## Status
+
+`starter`
+
+## Why It Exists
+
+Customer support is a practical local-agent shape because the useful context is
+often already nearby: an email export, a policy document, a refund rule, or an
+FAQ file. This starter keeps that boundary visible by requiring explicit local
+paths instead of pretending the agent knows the policy from memory.
+
+## Related Lab Pages
+
+- [Customer Support Agents](../../customer-support-agents.md)
+- [Case Studies Overview](../../README.md)
+- [Protocols And Interoperability](../../../systems/protocols-and-interoperability.md)
+
+## Folder Structure
+
+```text
+customer-support-email-agent-starter/
+├── README.md
+├── SOURCE_NOTES.md
+├── skill/
+│   └── SKILL.md
+└── src/
+    ├── email_triage.py
+    ├── policy_loader.py
+    └── reply_guardrails.py
+```
+
+## Quick Start
+
+This is a starter, not a finished helpdesk integration. The code sketch uses
+only the Python standard library and focuses on the local-path boundary.
+
+Example:
+
+```python
+from reply_guardrails import draft_policy_grounded_reply
+
+result = draft_policy_grounded_reply(
+    email_text="Subject: Refund request\nI received the wrong item.",
+    policy_path="/Users/example/support/refund-policy.md",
+)
+
+print(result.reply_subject)
+print(result.reply_body)
+print(result.needs_human_review)
+```
+
+For a repo-level smoke check, run `python3 scripts/verify_example_projects.py`
+from the repository root.
+
+## Included Sample Files
+
+- `skill/SKILL.md`: skill instructions for checking customer email and drafting
+  policy-grounded replies from a local document path
+- `src/email_triage.py`: lightweight classification and summary helpers
+- `src/policy_loader.py`: local policy loading and evidence extraction helpers
+- `src/reply_guardrails.py`: draft generation and human-review guardrails
+
+## Constraints
+
+- No mailbox, Gmail, CRM, or helpdesk adapter is implemented.
+- The starter reads local text-like policy files only.
+- Drafts are intended for human review, not automatic sending.
+- Classification is keyword-based and intentionally small.
+
+## Next Steps
+
+- Add a mailbox adapter that writes inbound messages to explicit local paths.
+- Add structured policy sections with stronger retrieval.
+- Add evaluation fixtures for refunds, billing, complaints, and escalation.
+- Add an audit artifact that records policy evidence and reviewer decision.

--- a/case-studies/examples/customer-support-email-agent-starter/SOURCE_NOTES.md
+++ b/case-studies/examples/customer-support-email-agent-starter/SOURCE_NOTES.md
@@ -1,0 +1,32 @@
+# Source Notes
+
+## Purpose
+
+This starter converts the customer-support case-study guidance into a small
+local-path workflow for email triage and policy-grounded reply drafting.
+
+## Official Inputs
+
+- [OpenAI computer environment for agents](https://openai.com/index/equip-responses-api-computer-environment/)
+- [OpenAI Responses API tools and file search](https://openai.com/index/new-tools-and-features-in-the-responses-api/)
+- [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp)
+- [MCP roots](https://modelcontextprotocol.io/specification/2025-06-18/client/roots)
+- [MCP resources](https://modelcontextprotocol.io/specification/draft/server/resources)
+
+## Repo-Native Changes
+
+- Reduced the workflow to local email text plus local policy text.
+- Kept the first version draft-only rather than auto-send.
+- Used a skill file to show how a reusable local-agent workflow can be packaged.
+
+## Attribution Boundary
+
+This folder does not copy upstream code or documentation. It uses official
+sources as conceptual grounding for local tool boundaries, file context, and
+workflow packaging.
+
+## Open Questions
+
+- Should a v2 include a real Gmail or helpdesk adapter?
+- Should policies become structured YAML/JSON sections instead of plain text?
+- Which escalation cases should be represented as evaluation fixtures first?

--- a/case-studies/examples/customer-support-email-agent-starter/skill/SKILL.md
+++ b/case-studies/examples/customer-support-email-agent-starter/skill/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: local-customer-email-reply
+description: Review inbound customer email, ground the reply in a local policy or FAQ document, and draft a safe response for complaints and queries.
+---
+
+# Local Customer Email Reply
+
+Use this skill when a user wants an agent to review customer email and draft a
+response based on a local document path such as
+`/Users/example/support-policy.md`.
+
+## Required Inputs
+
+- `EMAIL_PATH`: local `.txt`, `.md`, `.json`, or `.eml` file containing the
+  inbound customer message
+- `POLICY_PATH`: local `.md`, `.txt`, or other text-readable file containing
+  support policy, FAQ, refund rules, or escalation guidance
+- optional `DRAFT_PATH`: local path where the reply draft should be written
+
+## Workflow
+
+1. Read the inbound email from `EMAIL_PATH`.
+2. Read the grounding document from `POLICY_PATH`.
+3. Extract customer name, issue, requested outcome, order or account
+   identifiers, urgency, and sentiment.
+4. Classify the message as one of:
+   - `complaint`
+   - `query`
+   - `refund_request`
+   - `billing_issue`
+   - `handoff_required`
+5. Draft a reply grounded only in the local document.
+6. If the requested action is not supported by the document, do not invent
+   policy. Mark the case `handoff_required`.
+7. Return:
+   - `summary`
+   - `classification`
+   - `policy_evidence`
+   - `reply_subject`
+   - `reply_body`
+   - `needs_human_review`
+
+## Guardrails
+
+- Never promise refunds, credits, replacements, or legal outcomes unless the
+  local document explicitly allows them.
+- Never expose internal notes or hidden reasoning.
+- Keep the reply short, calm, and customer-facing.
+- Escalate abusive, safety, chargeback, regulatory, privacy, or deletion cases
+  for human review.
+- Treat missing or weak policy evidence as a handoff case.

--- a/case-studies/examples/customer-support-email-agent-starter/src/email_triage.py
+++ b/case-studies/examples/customer-support-email-agent-starter/src/email_triage.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+SENSITIVE_TERMS = (
+    "chargeback",
+    "lawyer",
+    "legal",
+    "sue",
+    "privacy",
+    "delete my data",
+    "unsafe",
+    "injury",
+    "fraud",
+)
+
+
+@dataclass
+class TriageResult:
+    classification: str
+    summary: str
+    urgency: str
+    sentiment: str
+    needs_human_review: bool
+
+
+def classify_email(email_text: str) -> TriageResult:
+    normalized = " ".join(email_text.lower().split())
+    classification = "query"
+
+    if any(term in normalized for term in SENSITIVE_TERMS):
+        classification = "handoff_required"
+    elif any(term in normalized for term in ("refund", "return", "money back")):
+        classification = "refund_request"
+    elif any(term in normalized for term in ("invoice", "charge", "billing", "payment")):
+        classification = "billing_issue"
+    elif any(term in normalized for term in ("angry", "upset", "complaint", "terrible", "wrong item")):
+        classification = "complaint"
+
+    urgency = "high" if any(term in normalized for term in ("urgent", "asap", "immediately")) else "normal"
+    sentiment = "negative" if classification in {"complaint", "handoff_required"} else "neutral"
+    needs_review = classification == "handoff_required"
+
+    return TriageResult(
+        classification=classification,
+        summary=summarize_email(email_text),
+        urgency=urgency,
+        sentiment=sentiment,
+        needs_human_review=needs_review,
+    )
+
+
+def summarize_email(email_text: str, max_words: int = 28) -> str:
+    words = " ".join(email_text.split()).split(" ")
+    summary = " ".join(words[:max_words]).strip()
+    if len(words) > max_words:
+        return f"{summary}..."
+    return summary

--- a/case-studies/examples/customer-support-email-agent-starter/src/policy_loader.py
+++ b/case-studies/examples/customer-support-email-agent-starter/src/policy_loader.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+
+@dataclass
+class PolicyDocument:
+    path: Path
+    text: str
+
+
+def load_policy_document(policy_path: str | Path) -> PolicyDocument:
+    path = Path(policy_path).expanduser()
+    if not path.exists():
+        raise FileNotFoundError(f"policy document not found: {path}")
+    if not path.is_file():
+        raise ValueError(f"policy path is not a file: {path}")
+
+    text = path.read_text(encoding="utf-8")
+    if not text.strip():
+        raise ValueError(f"policy document is empty: {path}")
+
+    return PolicyDocument(path=path, text=text)
+
+
+def find_policy_evidence(policy: PolicyDocument, query_terms: list[str], limit: int = 3) -> list[str]:
+    sentences = split_sentences(policy.text)
+    selected: list[str] = []
+    lowered_terms = [term.lower() for term in query_terms if term.strip()]
+
+    for sentence in sentences:
+        normalized = sentence.lower()
+        if any(term in normalized for term in lowered_terms):
+            selected.append(sentence)
+        if len(selected) >= limit:
+            break
+
+    return selected
+
+
+def split_sentences(text: str) -> list[str]:
+    chunks = re.split(r"(?<=[.!?])\s+|\n+", text)
+    return [chunk.strip() for chunk in chunks if chunk.strip()]

--- a/case-studies/examples/customer-support-email-agent-starter/src/reply_guardrails.py
+++ b/case-studies/examples/customer-support-email-agent-starter/src/reply_guardrails.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from email_triage import TriageResult, classify_email
+from policy_loader import find_policy_evidence, load_policy_document
+
+
+ESCALATION_CLASSIFICATIONS = {"handoff_required"}
+
+
+@dataclass
+class DraftReply:
+    summary: str
+    classification: str
+    policy_evidence: list[str]
+    reply_subject: str
+    reply_body: str
+    needs_human_review: bool
+
+
+def draft_policy_grounded_reply(email_text: str, policy_path: str) -> DraftReply:
+    triage = classify_email(email_text)
+    policy = load_policy_document(policy_path)
+    query_terms = terms_for_classification(triage)
+    evidence = find_policy_evidence(policy, query_terms)
+    needs_review = triage.needs_human_review or not evidence
+
+    subject = subject_for_classification(triage.classification)
+    body = build_reply_body(triage, evidence, needs_review)
+
+    return DraftReply(
+        summary=triage.summary,
+        classification=triage.classification,
+        policy_evidence=evidence,
+        reply_subject=subject,
+        reply_body=body,
+        needs_human_review=needs_review,
+    )
+
+
+def terms_for_classification(triage: TriageResult) -> list[str]:
+    terms = [triage.classification.replace("_", " ")]
+    if triage.classification == "refund_request":
+        terms.extend(["refund", "return", "replacement"])
+    elif triage.classification == "billing_issue":
+        terms.extend(["billing", "invoice", "payment", "charge"])
+    elif triage.classification == "complaint":
+        terms.extend(["complaint", "wrong item", "damaged", "support"])
+    elif triage.classification == "handoff_required":
+        terms.extend(["escalate", "human review", "privacy", "chargeback"])
+    else:
+        terms.extend(["faq", "question", "support"])
+    return terms
+
+
+def subject_for_classification(classification: str) -> str:
+    labels = {
+        "refund_request": "Re: Your refund request",
+        "billing_issue": "Re: Your billing question",
+        "complaint": "Re: Your support concern",
+        "handoff_required": "Re: Your support request",
+        "query": "Re: Your question",
+    }
+    return labels.get(classification, "Re: Your support request")
+
+
+def build_reply_body(
+    triage: TriageResult,
+    evidence: list[str],
+    needs_human_review: bool,
+) -> str:
+    if needs_human_review:
+        return (
+            "Thanks for reaching out. I want to make sure we handle this "
+            "correctly, so I am routing your request to our support team for "
+            "human review. We will follow up after checking the relevant "
+            "policy and account details."
+        )
+
+    policy_line = evidence[0]
+    return (
+        "Thanks for reaching out. Based on our support policy, "
+        f"{policy_line} "
+        "If you can share any missing order or account details, our team can "
+        "continue from there."
+    )

--- a/reading-paths/sample-projects.md
+++ b/reading-paths/sample-projects.md
@@ -11,6 +11,7 @@ surface.
 | Systems | [Weather MCP Server Starter](../systems/examples/weather-mcp-server-starter/README.md) | `starter` | request validation and protocol-facing tool boundaries |
 | Ecosystem | [LangGraph Starter](../ecosystem/examples/langgraph-starter/README.md) | `starter` | a minimal graph-shaped plan, route, synthesize flow |
 | Case Studies | [Deep Research Agent Starter](../case-studies/examples/deep-research-agent-starter/README.md) | `starter` | planning, evidence collection, and citation-aware synthesis |
+| Case Studies | [Customer Support Email Agent Starter](../case-studies/examples/customer-support-email-agent-starter/README.md) | `starter` | email triage, local policy grounding, and safe reply drafting |
 
 ## How to use these starters
 

--- a/scripts/verify_example_projects.py
+++ b/scripts/verify_example_projects.py
@@ -16,7 +16,12 @@ def load_module(name: str, relative_path: str) -> ModuleType:
     if spec is None or spec.loader is None:
         raise RuntimeError(f"unable to load module from {module_path}")
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(name, None)
+        raise
     return module
 
 
@@ -201,12 +206,58 @@ def check_research_starter() -> None:
     assert not review_module.is_ready_to_publish(len(task.evidence), gaps)
 
 
+def check_customer_support_starter() -> None:
+    src_dir = (
+        REPO_ROOT
+        / "case-studies/examples/customer-support-email-agent-starter/src"
+    )
+    sys.path.insert(0, str(src_dir))
+    try:
+        module = load_module(
+            "customer_support_reply_guardrails",
+            "case-studies/examples/customer-support-email-agent-starter/src/reply_guardrails.py",
+        )
+    finally:
+        sys.path.remove(str(src_dir))
+
+    policy_path = REPO_ROOT / ".tmp-customer-support-policy.md"
+    policy_path.write_text(
+        "Refunds are available within 30 days when the customer received the "
+        "wrong item. Chargebacks and privacy requests must escalate to human "
+        "review.",
+        encoding="utf-8",
+    )
+    try:
+        result = module.draft_policy_grounded_reply(
+            "Subject: Refund request\nI received the wrong item yesterday.",
+            str(policy_path),
+        )
+        handoff = module.draft_policy_grounded_reply(
+            "Subject: Privacy request\nPlease delete my data immediately.",
+            str(policy_path),
+        )
+    finally:
+        policy_path.unlink(missing_ok=True)
+
+    assert result.classification == "refund_request"
+    assert result.policy_evidence
+    assert result.needs_human_review is False
+    assert "refund" in result.reply_subject.lower()
+    assert "wrong item" in result.reply_body.lower()
+    assert handoff.classification == "handoff_required"
+    assert handoff.needs_human_review is True
+
+
 def main() -> int:
     checks = [
         ("patterns/examples/agent-memory-retrieval-starter", check_memory_starter),
         ("systems/examples/weather-mcp-server-starter", check_weather_starter),
         ("ecosystem/examples/langgraph-starter", check_langgraph_starter),
         ("case-studies/examples/deep-research-agent-starter", check_research_starter),
+        (
+            "case-studies/examples/customer-support-email-agent-starter",
+            check_customer_support_starter,
+        ),
     ]
 
     failures = 0


### PR DESCRIPTION
## Summary
- add a customer-support agent case study focused on local email and policy document paths
- add a starter skill plus Python modules for email triage, policy loading, and safe reply drafting
- update the top-level README with the AI-native field-guide framing
- index the new case study and sample project

## Verification
- git diff --check
- python3 scripts/verify_example_projects.py
- python3 -m py_compile case-studies/examples/customer-support-email-agent-starter/src/*.py

## Execution
- Commit author: jiafenglu0623
- Push and PR executor: dprat0821