### PR TITLE
docs(handbook): restore README hero and path cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,35 @@
-# Prompthon Agentic Lab
+<div align="center">
+  <a href="https://github.com/Prompthon-IO">
+    <img src="https://github.com/Prompthon-IO.png?size=160" alt="Prompthon IO" width="96" height="96" />
+  </a>
 
-> **Evolve Through Prompting. Learn Through Building.**
+  <h1>Prompthon Agentic Lab</h1>
 
-A public field guide for AI-native learners, early builders, and practitioners
-exploring how modern agent systems are understood, used, built, evaluated, and
-operated in practice.
+  <p><strong>Evolve Through Prompting. Learn Through Building.</strong></p>
 
-[**Organization**](https://github.com/Prompthon-IO) ·
-[**Repository**](https://github.com/Prompthon-IO/agentic-lab) ·
-[**Issues**](https://github.com/Prompthon-IO/agentic-lab/issues) ·
-[**Discord**](https://discord.gg/sDE2HhGTg4)
+  <p>
+    A public field guide for AI-native learners, early builders, and
+    practitioners exploring how modern agent systems are understood, used,
+    built, evaluated, and operated in practice.
+  </p>
+
+  <p>
+    <a href="https://github.com/Prompthon-IO"><strong>Organization</strong></a>
+    ·
+    <a href="https://github.com/Prompthon-IO/agentic-lab"><strong>Repository</strong></a>
+    ·
+    <a href="https://github.com/Prompthon-IO/agentic-lab/issues"><strong>Issues</strong></a>
+    ·
+    <a href="https://discord.gg/sDE2HhGTg4"><strong>Discord</strong></a>
+  </p>
+
+  <p>
+    <img src="https://img.shields.io/github/last-commit/Prompthon-IO/agentic-lab?style=flat-square" alt="Last commit" />
+    <img src="https://img.shields.io/github/stars/Prompthon-IO/agentic-lab?style=flat-square" alt="GitHub stars" />
+    <img src="https://img.shields.io/github/forks/Prompthon-IO/agentic-lab?style=flat-square" alt="GitHub forks" />
+    <img src="https://img.shields.io/github/issues/Prompthon-IO/agentic-lab?style=flat-square" alt="GitHub issues" />
+  </p>
+</div>
 
 ---
 
@@ -62,50 +82,36 @@ Choose the path that best matches what you want from AI right now. These are
 parallel tracks for different types of learners and builders, not a required
 sequence.
 
-### Explorer
-
-For students, newcomers, and curious AI-native readers who want a broad view of
-AI, agents, trends, and foundational ideas without needing to become engineers.
-
-**What you get:** a curated set of high-signal reads that help you learn core
-concepts, follow important shifts, test ideas with your own thinking, and build
-a grounded first-hand understanding of the space.
-
-[**Open the Explorer guide**](./reading-paths/explorer.md)
-
-### Practitioner
-
-For people who want to use AI tools, agents, and workflows to enhance daily
-life, study, and real work without needing to become full-time engineers.
-
-**What you get:** a practical path for learning how to apply AI effectively,
-choose the right tools and workflows, and operate with leverage in real
-scenarios, including one-person-company style use cases where AI expands what
-one person can do without requiring full builder depth.
-
-[**Open the Practitioner guide**](./reading-paths/practitioner.md)
-
-### Builder
-
-For engineering-minded learners, new grads, and developers who want to build
-with AI more directly, from agent applications and workflows to startup-style
-products and technically deeper implementations.
-
-**What you get:** a build-oriented path through concepts, patterns, systems,
-architecture choices, technical details, and concrete examples for people who
-want to create their own applications and go deeper into implementation.
-
-[**Open the Builder guide**](./reading-paths/builder.md)
-
-### Contributor
-
-For people who want to shape the lab by adding, revising, curating, or
-maintaining pages, notes, examples, and outward-facing extensions.
-
-**What you get:** a public path into the editorial workflow, templates, review
-rules, placement standards, and portfolio-relevant open-source contribution.
-
-[**Open the Contributor guide**](./reading-paths/contributor.md)
+<table>
+  <tr>
+    <td valign="top" width="50%">
+      <h3>Explorer</h3>
+      <p>For students, newcomers, and curious AI-native readers who want a broad view of AI, agents, trends, and foundational ideas without needing to become engineers.</p>
+      <p><strong>What you get:</strong> a curated set of high-signal reads that help you learn core concepts, follow important shifts, test ideas with your own thinking, and build a grounded first-hand understanding of the space.</p>
+      <p><a href="./reading-paths/explorer.md"><strong>Open the Explorer guide</strong></a></p>
+    </td>
+    <td valign="top" width="50%">
+      <h3>Practitioner</h3>
+      <p>For people who want to use AI tools, agents, and workflows to enhance daily life, study, and real work without needing to become full-time engineers.</p>
+      <p><strong>What you get:</strong> a practical path for learning how to apply AI effectively, choose the right tools and workflows, and operate with leverage in real scenarios, including one-person-company style use cases where AI expands what one person can do without requiring full builder depth.</p>
+      <p><a href="./reading-paths/practitioner.md"><strong>Open the Practitioner guide</strong></a></p>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top" width="50%">
+      <h3>Builder</h3>
+      <p>For engineering-minded learners, new grads, and developers who want to build with AI more directly, from agent applications and workflows to startup-style products and technically deeper implementations.</p>
+      <p><strong>What you get:</strong> a build-oriented path through concepts, patterns, systems, architecture choices, technical details, and concrete examples for people who want to create their own applications and go deeper into implementation.</p>
+      <p><a href="./reading-paths/builder.md"><strong>Open the Builder guide</strong></a></p>
+    </td>
+    <td valign="top" width="50%">
+      <h3>Contributor</h3>
+      <p>For people who want to shape the lab by adding, revising, curating, or maintaining pages, notes, examples, and outward-facing extensions.</p>
+      <p><strong>What you get:</strong> a public path into the editorial workflow, templates, review rules, placement standards, and portfolio-relevant open-source contribution.</p>
+      <p><a href="./reading-paths/contributor.md"><strong>Open the Contributor guide</strong></a></p>
+    </td>
+  </tr>
+</table>
 
 ## Contributor Guide
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@
 
   <p><strong>Evolve Through Prompting. Learn Through Building.</strong></p>
 
-  <p>
-    A public field guide for AI-native learners, early builders, and
-    practitioners exploring how modern agent systems are understood, used,
-    built, evaluated, and operated in practice.
-  </p>
+  <p>A public field guide for AI-native learners, early builders, and practitioners exploring how modern agent systems are understood, used, built, evaluated, and operated in practice.</p>
 
   <p>
     <a href="https://github.com/Prompthon-IO"><strong>Organization</strong></a>
@@ -35,52 +31,35 @@
 
 ## Overview
 
-Prompthon Agentic Lab is an AI-native field guide for students,
-practitioners, and builders exploring modern agent systems from different
-angles.
+Prompthon Agentic Lab is an AI-native field guide for students, practitioners, and builders exploring modern agent systems from different angles.
 
-Built on **learn, question, and innovate**, the lab is shaped by learners and
-grounded in real industry practice. It helps readers understand the space,
-apply AI effectively, or build real systems through parallel paths rather than
-a single track.
+Built on **learn, question, and innovate**, the lab is shaped by learners and grounded in real industry practice. It helps readers understand the space, apply AI effectively, or build real systems through parallel paths rather than a single track.
 
 ## Why This Lab Fits AI-Native Learners, Practitioners, And Builders
 
 ### Built on learn, question, and innovate
 
-This repository encourages active learning, critical thinking, and
-experimentation rather than passive consumption.
+This repository encourages active learning, critical thinking, and experimentation rather than passive consumption.
 
 ### Built by learners, not only for learners
 
-Many contributors are learners themselves. That keeps the material close to the
-questions, habits, and learning paths that students, new grads, and
-next-generation AI-native builders actually have.
+Many contributors are learners themselves. That keeps the material close to the questions, habits, and learning paths that students, new grads, and next-generation AI-native builders actually have.
 
 ### Guided by real industry practice
 
-Through Prompthon programs and industry-facing guidance, the lab remains
-connected to how frontier teams think, build, iterate, and evaluate in real
-settings.
+Through Prompthon programs and industry-facing guidance, the lab remains connected to how frontier teams think, build, iterate, and evaluate in real settings.
 
 ### AI-native by design
 
-The content is created through an AI-native workflow that combines
-AI-assisted drafting, synthesis, iteration, and refinement with expert guidance
-and review.
+The content is created through an AI-native workflow that combines AI-assisted drafting, synthesis, iteration, and refinement with expert guidance and review.
 
 ### Designed for different paths, not a single track
 
-The lab is organized for different kinds of learners and different intentions.
-Some people want broad understanding and trend awareness. Some want to apply AI
-tools to daily work and study. Some want to build real systems and
-applications. This repository supports all three without forcing one sequence.
+The lab is organized for different kinds of learners and different intentions. Some people want broad understanding and trend awareness. Some want to apply AI tools to daily work and study. Some want to build real systems and applications. This repository supports all three without forcing one sequence.
 
 ## Start Here
 
-Choose the path that best matches what you want from AI right now. These are
-parallel tracks for different types of learners and builders, not a required
-sequence.
+Choose the path that best matches what you want from AI right now. These are parallel tracks for different types of learners and builders, not a required sequence.
 
 <table>
   <tr>
@@ -115,8 +94,7 @@ sequence.
 
 ## Contributor Guide
 
-If you want to contribute to Prompthon Agentic Lab, start from the contributor
-docs rather than ad hoc internal working material.
+If you want to contribute to Prompthon Agentic Lab, start from the contributor docs rather than ad hoc internal working material.
 
 Public contributions in this repository currently fit into these paths:
 
@@ -129,7 +107,4 @@ Public contributions in this repository currently fit into these paths:
 - publication extensions in [`publications/`](./publications/README.md) once a
   lab page is ready for an outward-facing article or distribution surface
 
-Start with [Contributing](./CONTRIBUTING.md) and the
-[Contributor Kit](./contributor-kit/README.md). Those pages define the public
-workflow, templates, review standards, and placement rules for lab articles,
-notes, and code that belong in this repository.
+Start with [Contributing](./CONTRIBUTING.md) and the [Contributor Kit](./contributor-kit/README.md). Those pages define the public workflow, templates, review standards, and placement rules for lab articles, notes, and code that belong in this repository.


### PR DESCRIPTION
## Summary
- restore the centered README hero with org avatar, CTA links, and dynamic GitHub badges
- restore Start Here to the card/table layout instead of a plain list
- keep the new AI-native field-guide copy and Explorer/Practitioner/Builder/Contributor paths

## Verification
- git diff --check origin/main..HEAD
- python3 scripts/verify_example_projects.py

## Execution
- Commit author: jiafenglu0623
- Push and PR executor: dprat0821