### PR TITLE
[dprat0821] Refine local-agent radar readability and editorial take

### DIFF
--- a/radar/2026-04-local-agent-watch.md
+++ b/radar/2026-04-local-agent-watch.md
@@ -1,7 +1,7 @@
 ---
 title: April 2026 Local Agent Watch
 owner: Prompthon IO
-updated: 2026-04-23
+updated: 2026-04-24
 time_scope: 2026-04
 status: draft
 ---
@@ -10,38 +10,45 @@ status: draft
 
 ## Summary
 
-The most useful local-agent signal in April 2026 is not a single model or
-framework launch. It is the way several official sources converge on the same
-shape: a nearby execution environment, explicit skill or workflow packaging,
-and grounded access to documents, files, or business systems.
+The clearest local-agent signal in April 2026 is a product shape, not one
+vendor launch. Official sources are converging on agents that can work near a
+user's files, tools, and business systems while carrying reusable workflow
+knowledge in skills or integrations.
+
+For readers, the useful question is simple: does the agent have a clear working
+environment, a clear permission boundary, and a clear way to turn local context
+into a reviewable artifact?
 
 ## Why It Matters
 
-"Local agent" is easy to flatten into a vague idea about running models close
-to the user. The more durable product question is narrower:
+"Local agent" can sound like a location claim: the model runs nearby, so the
+agent is local. That is too shallow for product and system design. The durable
+question is about the work boundary:
 
 - where the agent runs
 - which tools or integrations it can reach
-- how it finds the right local documents or operating context
-- how reusable workflow knowledge is packaged
+- which files, documents, or resources are in scope
+- how reusable workflow knowledge is packaged and refreshed
+- what the user can inspect before the work is trusted
 
 That combination matters more than a raw chat loop for practical internal
-agents, support agents, and coding agents.
+agents, support agents, coding agents, and operations workflows.
 
 ## Evidence And Sources
 
 - [From model to agent: Equipping the Responses API with a computer environment](https://openai.com/index/equip-responses-api-computer-environment/):
-  OpenAI's March 11, 2026 engineering post frames agent execution around a
-  computer environment, persistent files, shell access, compaction, and skill
-  bundles that help produce durable artifacts.
+  OpenAI's March 11, 2026 engineering post makes the execution environment
+  explicit: persistent files, shell access, compaction, and skill bundles are
+  treated as part of the agent runtime, not as side notes.
 - [Closing the knowledge gap with agent skills](https://developers.googleblog.com/en/closing-the-knowledge-gap-with-agent-skills/):
-  Google's March 25, 2026 post treats skills as lightweight instruction
-  packages that close knowledge gaps while still pushing agents back toward
-  fresh documentation as the source of truth.
+  Google's March 25, 2026 post frames skills as lightweight instruction
+  packages. The important detail for handbook readers is that skills do not
+  replace source material; they help the agent know when to seek current
+  documentation.
 - [Supercharge your AI agents: The New ADK Integrations Ecosystem](https://developers.googleblog.com/supercharge-your-ai-agents-adk-integrations-ecosystem/):
-  Google's February 27, 2026 post expands ADK around direct integrations for
-  code, project tools, databases, email, and messaging, which makes "agent"
-  feel less like a chat abstraction and more like a connected worker surface.
+  Google's February 27, 2026 post expands ADK around integrations for code,
+  project tools, databases, email, and messaging. That moves the discussion
+  from "agent as chat surface" toward "agent as connected worker surface."
 
 ## Signals To Watch
 
@@ -54,22 +61,28 @@ agents, support agents, and coding agents.
   documents, and bounded reply actions.
 - Whether vendors keep local execution narrow and permissioned, or drift back
   toward broad environment access that is harder to trust and govern.
+- Whether users get better review surfaces for the artifacts, tool calls, and
+  files that local agents produce.
 
 ## Editorial Take
 
 The shared direction is more important than any one vendor term. OpenAI is
 making the runtime and skill stack more explicit. Google is separating skill
-knowledge from live integrations. Together they point toward a practical
+knowledge from live integrations. Together they suggest a practical handbook
 pattern for local agents:
 
 - keep execution close to the working environment
 - keep workflow knowledge reusable
 - keep business grounding tied to real documents and systems
+- keep review artifacts visible enough that a user can check the result
 
 That is a better planning lens for handbook contributors than treating local
-agents as a pure model or framework category.
+agents as a pure model, framework, or deployment-location category.
 
 ## Update Log
 
+- 2026-04-24: Refined the note for readability and added a clearer reader
+  takeaway around working environments, permission boundaries, and reviewable
+  artifacts.
 - 2026-04-23: Added a radar note focused on local runtimes, skill packaging,
   and file-grounded agent workflows.

--- a/radar/README.md
+++ b/radar/README.md
@@ -19,9 +19,10 @@ without destabilizing the evergreen structure.
 
 ## Current notes
 
-- [April 2026 Local Agent Watch](./2026-04-local-agent-watch.md): a time-scoped note on
-  how local runtimes, skill bundles, and file-grounded context are converging
-  into a more concrete agent product shape.
+- [April 2026 Local Agent Watch](./2026-04-local-agent-watch.md): a
+  time-scoped note on local agents as a concrete product shape: nearby working
+  environments, reusable skills or integrations, explicit context boundaries,
+  and reviewable artifacts.
 - [April 2026 Interoperability Watch](./2026-04-interoperability-watch.md):
   a current field note on how A2A, A2UI, and MCP are separating into different
   interoperability layers.


### PR DESCRIPTION
## Summary
- refines the April 2026 local-agent radar note for clearer reader takeaway
- tightens the evidence summaries without changing the official source boundary
- updates the radar index description for the note

## Verification
- git diff --check
- python3 scripts/verify_example_projects.py