### PR TITLE
[generalkim00] Refine the local-agent source map for contributor comprehension

### DIFF
--- a/contributor-kit/reference-notes/README.md
+++ b/contributor-kit/reference-notes/README.md
@@ -19,5 +19,5 @@ material and they are not replacements for lab pages.
   product signals.
 - [Deep Research Source Map](./deep-research-source-map.md)
 - [Local Agent Tooling Source Map](./local-agent-tooling-source-map.md): a
-  contributor-facing source map for local runtimes, skills, MCP roots,
-  resources, and file-grounded agent workflows.
+  contributor briefing for keeping local runtimes, skills, MCP roots,
+  resources, connectors, and file-grounded workflows distinct in future drafts.

--- a/contributor-kit/reference-notes/local-agent-tooling-source-map.md
+++ b/contributor-kit/reference-notes/local-agent-tooling-source-map.md
@@ -1,7 +1,7 @@
 ---
 title: Local Agent Tooling Source Map
 owner: Prompthon IO
-updated: 2026-04-23
+updated: 2026-04-24
 scope: local agent tooling, skills, roots, resources, and file-grounded workflows
 status: draft
 ---
@@ -14,13 +14,23 @@ This note gathers official source inputs for contributors writing about local
 agent systems: agents that work near a user's files, tools, project state, and
 workflow instructions rather than operating only as a remote chat surface.
 
-The durable pattern is not "local" by itself. It is the combination of:
+Use it when a draft needs to explain what "local" actually means. The durable
+pattern is not the location of one model. It is the combination of:
 
 - an execution environment or local tool boundary
 - reusable skill or workflow packaging
 - explicit filesystem or document scope
 - resources that can be selected, searched, read, or refreshed
 - permission rules that make the boundary understandable to users
+
+## How To Use This Note
+
+This is a source map, not a full article. Future contributors should use it to:
+
+- define the boundary before describing the agent
+- choose the right source for the claim they are making
+- keep local files, selected resources, skills, and connectors separate
+- add case-study examples that show what the agent may read, write, and review
 
 ## Why It Matters
 
@@ -36,6 +46,14 @@ should separate several concerns that are often mixed together:
 
 That split helps contributors write case studies and starter projects without
 pretending that every integration is the same kind of agent capability.
+
+| Term | Reader question | Common mistake |
+| --- | --- | --- |
+| `runtime` | Where does the work execute? | Treating all agent work as a chat reply |
+| `skills` | What reusable task knowledge is packaged? | Hiding stale instructions inside one long prompt |
+| `roots` | Which filesystem boundaries are in scope? | Saying "file access" without naming the boundary |
+| `resources` | Which selected objects can become context? | Assuming every backend object is automatically available |
+| `connectors` | Which systems can be called as tools? | Treating integration access as permission to use all data |
 
 ## Scope Notes
 
@@ -58,26 +76,23 @@ Excluded:
 ## Source Map
 
 - [OpenAI Responses API tools and remote MCP support](https://openai.com/index/new-tools-and-features-in-the-responses-api/):
-  a current source for remote MCP support, built-in tools, file search, and
-  background-mode style long-running agent work.
+  use this for claims about hosted tools, remote MCP support, file search, and
+  long-running background work.
 - [OpenAI computer environment for agents](https://openai.com/index/equip-responses-api-computer-environment/):
-  a current source for the execution-environment side of agent design,
-  including shell access, hosted filesystem state, compaction, and agent
-  skills.
+  use this for claims about execution environments, persistent files, shell
+  access, compaction, and agent skills as runtime support.
 - [MCP introduction](https://modelcontextprotocol.io/docs/getting-started/intro):
-  a stable entry point for MCP as a standard connection layer between AI
-  applications and external systems such as local files, databases, tools, and
-  workflows.
+  use this for a stable, high-level explanation of MCP as a connection layer
+  between AI applications and external systems.
 - [MCP roots](https://modelcontextprotocol.io/specification/2025-06-18/client/roots):
-  the clearest official source for local filesystem boundaries. Roots define
-  which directories or files a server can understand as available.
+  use this when the draft needs to explain local filesystem boundaries.
 - [MCP resources](https://modelcontextprotocol.io/specification/2025-06-18/server/resources):
-  the clearest official source for application-driven context surfaces such as
-  files, schemas, or application-specific objects.
+  use this when the draft needs to explain application-controlled context
+  surfaces such as files, schemas, or application-specific objects.
 - [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp):
-  a practical source for local stdio servers, project-scoped MCP
-  configuration, plugin-provided MCP servers, and MCP resources in a coding
-  agent workflow.
+  use this as a practical example of local stdio servers, project-scoped MCP
+  configuration, plugin-provided servers, and resources in a coding-agent
+  workflow.
 
 ## Synthesis
 
@@ -93,6 +108,11 @@ For handbook purposes, this is more useful than saying "the agent has access to
 files." Local access should always be explained with the boundary attached:
 which files, which server, which transport, which permission, and which
 artifact.
+
+The same discipline applies to skills and connectors. A skill can tell the
+agent how to perform a task, but it should not be treated as current evidence.
+A connector can expose a useful system, but it should not imply permission to
+read or act on every object in that system.
 
 ## Case-Study Hooks
 
@@ -118,5 +138,7 @@ requires human review.
 
 ## Update Log
 
+- 2026-04-24: Refined the note for contributor comprehension with usage
+  guidance, term boundaries, and clearer source-to-claim mapping.
 - 2026-04-23: Added a contributor-facing source map for local agent tooling,
   skills, roots, resources, and file-grounded workflows.

--- a/contributor-kit/reference-notes/local-agent-tooling-source-map.md
+++ b/contributor-kit/reference-notes/local-agent-tooling-source-map.md
@@ -2,7 +2,7 @@
 title: Local Agent Tooling Source Map
 owner: Prompthon IO
 updated: 2026-04-24
-scope: local agent tooling, skills, roots, resources, and file-grounded workflows
+scope: local agent tooling, skills, roots, resources, connectors, and file-grounded workflows
 status: draft
 ---
 

--- a/contributor-kit/reference-notes/local-agent-tooling-source-map.md
+++ b/contributor-kit/reference-notes/local-agent-tooling-source-map.md
@@ -86,7 +86,7 @@ Excluded:
   between AI applications and external systems.
 - [MCP roots](https://modelcontextprotocol.io/specification/2025-06-18/client/roots):
   use this when the draft needs to explain local filesystem boundaries.
-- [MCP resources](https://modelcontextprotocol.io/specification/2025-06-18/server/resources):
+- [MCP resources](https://modelcontextprotocol.io/specification/draft/server/resources):
   use this when the draft needs to explain application-controlled context
   surfaces such as files, schemas, or application-specific objects.
 - [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp):


### PR DESCRIPTION
## Summary
- refines the local-agent tooling source map into a clearer contributor briefing
- adds usage guidance and a term-boundary table for runtime, skills, roots, resources, and connectors
- tightens the source-to-claim mapping while preserving the official-source boundary

## Identity
- Commit author: generalkim00
- Push/PR executor: dprat0821

## Verification
- git diff --check
- python3 scripts/verify_example_projects.py