### PR TITLE
[jiafenglu0623] Refine customer-support case study and starter readability

### DIFF
--- a/case-studies/customer-support-agents.md
+++ b/case-studies/customer-support-agents.md
@@ -1,7 +1,7 @@
 ---
 title: Customer Support Agents
 owner: Prompthon IO
-updated: 2026-04-23
+updated: 2026-04-24
 depth: intermediate
 region_tags:
   - global
@@ -16,7 +16,7 @@ external_readings:
   - title: Model Context Protocol client roots specification
     url: https://modelcontextprotocol.io/specification/2025-06-18/client/roots
   - title: Model Context Protocol server resources specification
-    url: https://modelcontextprotocol.io/specification/draft/server/resources
+    url: https://modelcontextprotocol.io/specification/2025-06-18/server/resources
 status: draft
 ---
 
@@ -26,9 +26,11 @@ status: draft
 
 Customer support agents help turn inbound customer messages into classified
 cases, grounded answers, draft replies, and human handoffs. The safest version
-is not an autonomous "reply to everything" bot. It is a local, policy-grounded
-workflow that reads a customer input, consults approved support material, and
-drafts a response that a human can review.
+is not an autonomous "reply to everything" bot.
+
+Start with a local, policy-grounded workflow: read one customer input, consult
+approved support material, draft a response, and leave the final send decision
+to a human.
 
 ## Why It Matters
 
@@ -69,6 +71,13 @@ POLICY_PATH=/Users/example/support/refund-and-escalation-policy.md
 That is a clearer system than asking a model to "answer like support" from
 general memory.
 
+For this case study, the boundary is the main lesson:
+
+- the email path is the customer input
+- the policy path is the approved source of truth
+- the draft is an artifact for review
+- the human owns the final decision
+
 ## Architecture Diagram
 
 ```mermaid
@@ -94,7 +103,8 @@ Support agents usually combine a small set of capabilities:
 
 For a starter workflow, a local path is enough. The agent can read one inbound
 message file and one policy document file. Production systems can later replace
-those local paths with Gmail, helpdesk, CRM, or MCP-backed resources.
+those local paths with Gmail, helpdesk, CRM, or MCP-backed resources, but the
+same boundary should stay visible.
 
 MCP-style roots and resources are useful here because they force the system to
 say what the agent may access. A policy folder root is different from full disk
@@ -150,7 +160,7 @@ It demonstrates a small standard-library workflow for:
 - Official source: [OpenAI Responses API tools and file search](https://openai.com/index/new-tools-and-features-in-the-responses-api/)
 - Official source: [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp)
 - Official source: [MCP roots](https://modelcontextprotocol.io/specification/2025-06-18/client/roots)
-- Official source: [MCP resources](https://modelcontextprotocol.io/specification/draft/server/resources)
+- Official source: [MCP resources](https://modelcontextprotocol.io/specification/2025-06-18/server/resources)
 
 ## Reading Extensions
 
@@ -160,5 +170,7 @@ It demonstrates a small standard-library workflow for:
 
 ## Update Log
 
+- 2026-04-24: Refined the case study for readability and made the local input,
+  policy source, review artifact, and human decision boundary more explicit.
 - 2026-04-23: Added a local-first customer-support case study with a
   policy-grounded email reply starter.

--- a/case-studies/examples/customer-support-email-agent-starter/README.md
+++ b/case-studies/examples/customer-support-email-agent-starter/README.md
@@ -6,6 +6,9 @@ This starter turns the customer-support case study into a small local workflow:
 read an inbound customer email, read a local support policy document, classify
 the case, and draft a safe reply for human review.
 
+The point is not helpdesk automation yet. The point is to make the support
+agent's boundary inspectable before adding mailbox or CRM integrations.
+
 ## Status
 
 `starter`
@@ -40,7 +43,12 @@ customer-support-email-agent-starter/
 ## Quick Start
 
 This is a starter, not a finished helpdesk integration. The code sketch uses
-only the Python standard library and focuses on the local-path boundary.
+only the Python standard library and focuses on the local-path boundary:
+
+- customer message text in
+- local policy file path in
+- classified case plus draft reply out
+- human-review flag out
 
 Example:
 
@@ -60,6 +68,14 @@ print(result.needs_human_review)
 For a repo-level smoke check, run `python3 scripts/verify_example_projects.py`
 from the repository root.
 
+## What To Inspect First
+
+- Read `src/reply_guardrails.py` for the draft and review decision.
+- Read `src/policy_loader.py` for how local policy evidence is extracted.
+- Read `src/email_triage.py` for the intentionally small case classification.
+- Read `skill/SKILL.md` for how the same workflow can be packaged as reusable
+  instructions.
+
 ## Included Sample Files
 
 - `skill/SKILL.md`: skill instructions for checking customer email and drafting
@@ -74,6 +90,7 @@ from the repository root.
 - The starter reads local text-like policy files only.
 - Drafts are intended for human review, not automatic sending.
 - Classification is keyword-based and intentionally small.
+- The code does not claim to be a production support policy engine.
 
 ## Next Steps
 

--- a/case-studies/examples/customer-support-email-agent-starter/SOURCE_NOTES.md
+++ b/case-studies/examples/customer-support-email-agent-starter/SOURCE_NOTES.md
@@ -11,13 +11,15 @@ local-path workflow for email triage and policy-grounded reply drafting.
 - [OpenAI Responses API tools and file search](https://openai.com/index/new-tools-and-features-in-the-responses-api/)
 - [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp)
 - [MCP roots](https://modelcontextprotocol.io/specification/2025-06-18/client/roots)
-- [MCP resources](https://modelcontextprotocol.io/specification/draft/server/resources)
+- [MCP resources](https://modelcontextprotocol.io/specification/2025-06-18/server/resources)
 
 ## Repo-Native Changes
 
 - Reduced the workflow to local email text plus local policy text.
 - Kept the first version draft-only rather than auto-send.
 - Used a skill file to show how a reusable local-agent workflow can be packaged.
+- Clarified the starter's review boundary: local input, local policy, draft
+  artifact, and human send decision.
 
 ## Attribution Boundary
 


### PR DESCRIPTION
## Summary
- makes the customer-support agent boundary clearer: local input, policy source, review artifact, and human decision
- improves starter README readability with first-inspection guidance and explicit input/output expectations
- updates MCP resources links to the stable 2025-06-18 specification path

## Identity
- Commit author: jiafenglu0623
- Push/PR executor: dprat0821

## Verification
- git diff --check
- python3 scripts/verify_example_projects.py