### PR TITLE
[generalkim00] Add enterprise agent control planes reference note

### DIFF
--- a/contributor-kit/reference-notes/README.md
+++ b/contributor-kit/reference-notes/README.md
@@ -14,6 +14,9 @@ material and they are not replacements for lab pages.
 
 ## Current notes
 
+- [Enterprise Agent Control Planes](./enterprise-agent-control-planes.mdx): a
+  contributor-facing note on treating observability, governance, and security
+  as a separate enterprise control-plane layer for agent systems.
 - [Deep Research Product Signals](./deep-research-product-signals.mdx): a
   contributor-facing comparison of current OpenAI and Google deep-research
   product signals.

--- a/contributor-kit/reference-notes/enterprise-agent-control-planes.mdx
+++ b/contributor-kit/reference-notes/enterprise-agent-control-planes.mdx
@@ -1,0 +1,91 @@
+---
+title: Enterprise Agent Control Planes
+owner: Prompthon IO
+updated: 2026-04-29
+scope: current control-plane framing for enterprise agents through April 2026
+status: draft
+---
+
+## Summary
+
+This note gives contributors a compact source map for a newer enterprise-agent
+comparison axis: the control plane around agents, not only the model or runtime
+inside them.
+
+The immediate trigger is Microsoft's April 28, 2026 framing around
+`Intelligence + Trust`, where Microsoft IQ carries business context and Agent
+365 carries observability, governance, and security across both Microsoft's own
+agent surfaces and third-party environments.
+
+## Why It Matters
+
+Agent-platform comparisons often collapse into model access, orchestration UX,
+or framework ergonomics. That misses a different buying question: how does an
+organization observe, govern, and secure a growing set of agents that span
+multiple runtimes and vendors?
+
+This note helps contributors keep two layers separate:
+
+- the runtime layer that plans, retrieves, calls tools, and produces outputs
+- the control-plane layer that enforces trust, visibility, and policy across
+  many agents and environments
+
+That split is becoming more useful than a simple "which model?" comparison.
+
+## Scope Notes
+
+Included:
+
+- Microsoft's current commercial framing for `Intelligence + Trust`
+- Microsoft IQ as the context and intelligence layer
+- Agent 365 as the observability, governance, and security layer
+- implications for later ecosystem and systems refreshes in this repo
+
+Excluded:
+
+- detailed product implementation walkthroughs
+- a broad vendor scorecard across every agent platform
+- protocol-level interoperability analysis, which belongs elsewhere in
+  `radar/`
+
+## Source Map
+
+- [Unlocking human ambition to drive business growth with AI](https://blogs.microsoft.com/blog/2026/04/28/unlocking-human-ambition-to-drive-business-growth-with-ai/):
+  Microsoft's April 28, 2026 post says the two most important elements in an
+  AI solution are `Intelligence + Trust`, positions Microsoft IQ as the context
+  layer around data and agent development, and positions Agent 365 as the
+  observability, governance, and security layer across Microsoft and
+  third-party agent environments.
+
+## Synthesis
+
+Three contributor-facing takeaways matter most:
+
+- Enterprise agent discussion is shifting beyond model choice. Microsoft's
+  framing makes the control plane a product surface in its own right.
+- Trust is being positioned as cross-environment infrastructure, not only as a
+  property of one assistant or one runtime. That suggests contributors should
+  separate local runtime capability from fleet-level governance.
+- A useful lab comparison axis is emerging: context and execution on one side,
+  observability and policy control on the other. That split can sharpen both
+  systems pages and ecosystem pages without hard-coding one vendor's naming.
+
+For the handbook, the durable lesson is not the vendor label. It is the
+category boundary that contributors should preserve when comparing agent
+platforms and enterprise deployment stories.
+
+## Gaps And Follow-up
+
+- Revisit [Systems: Evaluation and Observability](/systems/evaluation-and-observability)
+  with a short section that distinguishes runtime instrumentation from
+  organization-level control planes.
+- Revisit [Agent Platforms And Low-Code Builders](/ecosystem/agent-platforms-and-low-code-builders)
+  if more official sources begin using this split as a stable comparison frame.
+- Add future sources when other first-party platforms describe comparable
+  fleet-level governance surfaces explicitly enough to compare without guesswork.
+
+## Update Log
+
+- 2026-04-29: Added a contributor-facing note on enterprise agent control
+  planes using Microsoft's `Intelligence + Trust` framing as the current source
+  spine.

--- a/contributor-kit/reference-notes/index.mdx
+++ b/contributor-kit/reference-notes/index.mdx
@@ -16,6 +16,9 @@ material and they are not replacements for lab pages.
 
 ## Current notes
 
+- [Enterprise Agent Control Planes](/contributor-kit/reference-notes/enterprise-agent-control-planes):
+  a contributor-facing note on treating observability, governance, and security
+  as a separate enterprise control-plane layer for agent systems.
 - [Deep Research Product Signals](/contributor-kit/reference-notes/deep-research-product-signals): a
   contributor-facing comparison of current OpenAI and Google deep-research
   product signals.

--- a/zh-Hans/contributor-kit/reference-notes/README.md
+++ b/zh-Hans/contributor-kit/reference-notes/README.md
@@ -13,8 +13,7 @@
 
 ## 当前说明
 
-- [企业级智能体控制平面](./enterprise-agent-control-planes.mdx)：
-  一份面向贡献者的 note，说明在智能体系统里应把 observability、governance 和 security 视为独立的企业级 control-plane layer。
+- [企业级智能体控制平面](./enterprise-agent-control-planes.mdx): 一份面向贡献者的 note，说明在智能体系统里应把 observability、governance 和 security 视为独立的企业级 control-plane layer。
 - [Deep Research Product Signals](./deep-research-product-signals.mdx): 面向贡献者的当前 OpenAI 和 Google deep-research 产品信号对比。
 - [Deep Research Source Map](./deep-research-source-map.mdx)
 - [Local Agent Tooling Source Map](./local-agent-tooling-source-map.mdx): 一份面向贡献者的简报，用于在未来草稿中保持本地运行时、技能、MCP roots、resources、connectors 和基于文件的工作流彼此区分。

--- a/zh-Hans/contributor-kit/reference-notes/README.md
+++ b/zh-Hans/contributor-kit/reference-notes/README.md
@@ -13,6 +13,8 @@
 
 ## 当前说明
 
+- [企业级智能体控制平面](./enterprise-agent-control-planes.mdx)：
+  一份面向贡献者的 note，说明在智能体系统里应把 observability、governance 和 security 视为独立的企业级 control-plane layer。
 - [Deep Research Product Signals](./deep-research-product-signals.mdx): 面向贡献者的当前 OpenAI 和 Google deep-research 产品信号对比。
 - [Deep Research Source Map](./deep-research-source-map.mdx)
 - [Local Agent Tooling Source Map](./local-agent-tooling-source-map.mdx): 一份面向贡献者的简报，用于在未来草稿中保持本地运行时、技能、MCP roots、resources、connectors 和基于文件的工作流彼此区分。

--- a/zh-Hans/contributor-kit/reference-notes/enterprise-agent-control-planes.mdx
+++ b/zh-Hans/contributor-kit/reference-notes/enterprise-agent-control-planes.mdx
@@ -2,7 +2,7 @@
 title: 企业级智能体控制平面
 owner: Prompthon IO
 updated: 2026-04-29
-scope: 截至 2026 年 4 月的企业级智能体控制平面 framing
+scope: enterprise agent control-plane framing through April 2026
 status: draft
 ---
 

--- a/zh-Hans/contributor-kit/reference-notes/enterprise-agent-control-planes.mdx
+++ b/zh-Hans/contributor-kit/reference-notes/enterprise-agent-control-planes.mdx
@@ -1,0 +1,64 @@
+---
+title: 企业级智能体控制平面
+owner: Prompthon IO
+updated: 2026-04-29
+scope: 截至 2026 年 4 月的企业级智能体控制平面 framing
+status: draft
+---
+
+## 摘要
+
+这份 note 为贡献者提供一个更紧凑的 source map，用来理解企业级智能体里一个更新的比较轴：围绕智能体的控制平面，而不只是智能体内部使用的模型或运行时。
+
+直接触发点是 Microsoft 在 2026 年 4 月 28 日提出的 `Intelligence + Trust` framing：Microsoft IQ 承载业务上下文，Agent 365 承载 observability、governance 和 security，并且覆盖 Microsoft 自家智能体表面以及第三方环境。
+
+## 为什么这很重要
+
+智能体平台比较很容易被压缩成模型访问、编排体验或框架人体工学。但这会漏掉一个不同的采购问题：当组织中的智能体横跨多个运行时和供应商时，谁来负责观察、治理和保护这整个 agent fleet？
+
+这份 note 帮助贡献者把两个层次分开：
+
+- 负责规划、检索、调用工具和产生产出的 runtime layer
+- 负责跨多个智能体和环境执行 trust、visibility 与 policy 的 control-plane layer
+
+这个拆分正在变得比简单的“用哪个模型”更有用。
+
+## 范围说明
+
+包含：
+
+- Microsoft 当前关于 `Intelligence + Trust` 的商业 framing
+- Microsoft IQ 作为 context 和 intelligence layer
+- Agent 365 作为 observability、governance 和 security layer
+- 对本仓库后续 ecosystem 与 systems 刷新的启发
+
+不包含：
+
+- 详细的产品实现 walkthrough
+- 覆盖所有 agent platform 的宽泛厂商评分卡
+- 协议层互操作分析；那部分更适合放在 `radar/`
+
+## 来源地图
+
+- [Unlocking human ambition to drive business growth with AI](https://blogs.microsoft.com/blog/2026/04/28/unlocking-human-ambition-to-drive-business-growth-with-ai/)：
+  Microsoft 在 2026 年 4 月 28 日的文章中表示，AI 解决方案最重要的两个元素是 `Intelligence + Trust`；其中 Microsoft IQ 被定位为围绕数据和 agent development 的 context layer，而 Agent 365 被定位为覆盖 Microsoft 与第三方 agent environment 的 observability、governance 和 security layer。
+
+## 综合判断
+
+对贡献者来说，有三个最值得保留的结论：
+
+- 企业级智能体讨论正在超出模型选择本身。Microsoft 的 framing 把 control plane 变成了独立产品表面。
+- Trust 正被定位成跨环境基础设施，而不只是某一个 assistant 或某一个 runtime 的属性。这意味着贡献者在写作时应把本地运行时能力与全局治理能力分开。
+- 一个更有用的实验室比较轴正在出现：一边是 context 与 execution，另一边是 observability 与 policy control。这个拆分可以同时强化 systems 页面与 ecosystem 页面，而不必硬编码某个厂商自己的命名。
+
+对于 handbook，真正持久的收获不是某个厂商标签，而是这个类别边界本身。未来比较 agent platform 或企业部署路径时，贡献者应保留这个边界。
+
+## 缺口与后续
+
+- 未来可以刷新 [Systems: Evaluation and Observability](/zh-Hans/systems/evaluation-and-observability)，加入一小段区分 runtime instrumentation 与 organization-level control plane。
+- 如果更多官方来源开始稳定地使用这条分界线，可以再刷新 [Agent Platforms And Low-Code Builders](/zh-Hans/ecosystem/agent-platforms-and-low-code-builders)。
+- 当其他第一方平台足够明确地描述相近的 fleet-level governance surface 时，再补入后续来源，避免靠猜测做比较。
+
+## 更新日志
+
+- 2026-04-29：新增一份面向贡献者的企业级智能体控制平面 note，以 Microsoft 的 `Intelligence + Trust` framing 作为当前 source spine。

--- a/zh-Hans/contributor-kit/reference-notes/index.mdx
+++ b/zh-Hans/contributor-kit/reference-notes/index.mdx
@@ -15,6 +15,8 @@ title: "参考说明"
 
 ## 当前说明
 
+- [企业级智能体控制平面](/zh-Hans/contributor-kit/reference-notes/enterprise-agent-control-planes)：
+  一份面向贡献者的 note，说明在智能体系统里应把 observability、governance 和 security 视为独立的企业级 control-plane layer。
 - [Deep Research Product Signals](/zh-Hans/contributor-kit/reference-notes/deep-research-product-signals): 面向贡献者的当前 OpenAI 和 Google deep-research 产品信号对比。
 - [Deep Research Source Map](/zh-Hans/contributor-kit/reference-notes/deep-research-source-map)
 - [Local Agent Tooling Source Map](/zh-Hans/contributor-kit/reference-notes/local-agent-tooling-source-map): 一份面向贡献者的简报，用于在未来草稿中保持本地运行时、技能、MCP roots、resources、connectors 和基于文件的工作流彼此区分。

--- a/zh-Hans/contributor-kit/reference-notes/index.mdx
+++ b/zh-Hans/contributor-kit/reference-notes/index.mdx
@@ -15,8 +15,7 @@ title: "参考说明"
 
 ## 当前说明
 
-- [企业级智能体控制平面](/zh-Hans/contributor-kit/reference-notes/enterprise-agent-control-planes)：
-  一份面向贡献者的 note，说明在智能体系统里应把 observability、governance 和 security 视为独立的企业级 control-plane layer。
+- [企业级智能体控制平面](/zh-Hans/contributor-kit/reference-notes/enterprise-agent-control-planes): 一份面向贡献者的 note，说明在智能体系统里应把 observability、governance 和 security 视为独立的企业级 control-plane layer。
 - [Deep Research Product Signals](/zh-Hans/contributor-kit/reference-notes/deep-research-product-signals): 面向贡献者的当前 OpenAI 和 Google deep-research 产品信号对比。
 - [Deep Research Source Map](/zh-Hans/contributor-kit/reference-notes/deep-research-source-map)
 - [Local Agent Tooling Source Map](/zh-Hans/contributor-kit/reference-notes/local-agent-tooling-source-map): 一份面向贡献者的简报，用于在未来草稿中保持本地运行时、技能、MCP roots、resources、connectors 和基于文件的工作流彼此区分。


### PR DESCRIPTION
Closes #43

Adds a contributor-facing reference note in English and Chinese, plus index updates, so later ecosystem and systems refreshes can point to a stable control-plane source spine.

executor_account: dprat0821