### PR TITLE
[dprat0821] Add assistant safety escalation radar note

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -96,6 +96,7 @@
                 "pages": [
                   "radar/index",
                   "radar/2026-04-assistant-safety-escalation-watch",
+                  "radar/2026-04-portable-assistant-memory-watch",
                   "radar/2026-04-local-agent-watch",
                   "radar/2026-04-interoperability-watch",
                   "radar/2026-04-protocol-watch"

--- a/docs.json
+++ b/docs.json
@@ -95,6 +95,7 @@
                 "group": "Radar",
                 "pages": [
                   "radar/index",
+                  "radar/2026-04-assistant-safety-escalation-watch",
                   "radar/2026-04-local-agent-watch",
                   "radar/2026-04-interoperability-watch",
                   "radar/2026-04-protocol-watch"

--- a/radar/2026-04-assistant-safety-escalation-watch.mdx
+++ b/radar/2026-04-assistant-safety-escalation-watch.mdx
@@ -1,0 +1,95 @@
+---
+title: April 2026 Assistant Safety Escalation Watch
+owner: Prompthon IO
+updated: 2026-04-29
+time_scope: 2026-04
+status: draft
+---
+
+## Summary
+
+The April 2026 lawsuits around the Tumbler Ridge school shooting make one
+agent-systems question unusually concrete: when an assistant provider detects
+credible real-world violence signals, the product problem is no longer just
+content moderation. It becomes escalation design.
+
+For handbook readers, the practical takeaway is to separate normal privacy
+expectations from the narrow cases where a risk review may need to preserve
+evidence, override routine retention assumptions, and involve a named human
+owner.
+
+## Why It Matters
+
+Assistant safety can be described too vaguely as "the model should refuse bad
+requests." That is not enough for deployed systems. High-risk interactions
+create operational questions that need explicit answers:
+
+- what gets logged when the system detects violent intent
+- who owns the review after an automated or human flag
+- which threshold triggers internal escalation
+- which threshold triggers external reporting or legal review
+- how repeat policy violators are recognized without turning every user record
+  into an unbounded surveillance surface
+- how later reviewers can reconstruct what the assistant did, what the user
+  said, and what the operator decided
+
+Those questions sit between privacy, trust and safety, legal, incident
+response, and product operations. They should not be left as an implicit model
+behavior.
+
+## Evidence And Sources
+
+- [Families of Canada school shooting victims sue OpenAI over shooter's use of ChatGPT](https://apnews.com/article/openai-chatgpt-tumbler-ridge-26d632a065e8420a263655c8ee29f961):
+  AP reported that families filed U.S. lawsuits alleging OpenAI should have
+  alerted authorities after earlier account activity was flagged. OpenAI said
+  it had strengthened safeguards around distress responses, threat escalation,
+  and repeat policy violators.
+- [School-shooting lawsuits accuse OpenAI of hiding violent ChatGPT users](https://arstechnica.com/tech-policy/2026/04/school-shooting-lawsuits-accuse-openai-of-hiding-violent-chatgpt-users/):
+  Ars Technica framed the allegation around internal review, external warning
+  thresholds, and whether safety flags were acted on before a later attack.
+
+## Signals To Watch
+
+- Whether assistant providers publish clearer thresholds for violent-threat
+  escalation without exposing detection playbooks that bad actors can evade.
+- Whether products create auditable internal handoff records instead of leaving
+  escalations buried in chat logs or ad hoc moderation queues.
+- Whether repeat-offender detection becomes a distinct trust boundary from
+  ordinary personalization, memory, and account analytics.
+- Whether enterprise assistant deployments require customers to name legal,
+  security, and trust-and-safety owners before risky workflows go live.
+- Whether regulators and courts treat failure-to-warn claims as product design
+  failures, operational negligence, or something closer to platform-liability
+  doctrine.
+
+## Design Implications
+
+Builders should treat safety escalation as a workflow surface:
+
+- keep the model refusal path separate from the human escalation path
+- write down who can view retained high-risk evidence
+- preserve just enough context for later audit
+- require human review before external reporting unless law or policy requires
+  immediate action
+- make duty-to-report language specific to jurisdiction, organization policy,
+  and deployment setting
+
+The important design move is not to make every assistant conversation more
+visible. It is to define the rare conditions under which a credible risk signal
+becomes an accountable operational case.
+
+## Editorial Take
+
+This belongs in `radar/` because the legal and policy details will continue to
+move. The durable handbook lesson is narrower: assistant systems need an
+escalation contract, not only a refusal policy.
+
+That contract should say what is detected, what is preserved, who reviews it,
+what threshold changes the privacy expectation, and how the decision is later
+audited. Without that shape, "safety" remains a model-level aspiration instead
+of a system-level workflow.
+
+## Update Log
+
+- 2026-04-29: Added a radar note on assistant threat escalation, duty-to-report
+  boundaries, and audit-ready safety handoffs.

--- a/radar/README.md
+++ b/radar/README.md
@@ -19,6 +19,9 @@ without destabilizing the evergreen structure.
 
 ## Current notes
 
+- [April 2026 Assistant Safety Escalation Watch](./2026-04-assistant-safety-escalation-watch.mdx):
+  a current signal on credible violence flags, duty-to-report boundaries,
+  repeat policy violators, and audit-ready safety handoffs.
 - [April 2026 Portable Assistant Memory Watch](./2026-04-portable-assistant-memory-watch.mdx):
   a time-scoped note on imported personal context, default-on assistant memory,
   and chat-history transfer as a separate trust boundary from retrieval and

--- a/radar/index.mdx
+++ b/radar/index.mdx
@@ -21,6 +21,9 @@ without destabilizing the evergreen structure.
 
 ## Current notes
 
+- [April 2026 Assistant Safety Escalation Watch](/radar/2026-04-assistant-safety-escalation-watch):
+  a current signal on credible violence flags, duty-to-report boundaries,
+  repeat policy violators, and audit-ready safety handoffs.
 - [April 2026 Portable Assistant Memory Watch](/radar/2026-04-portable-assistant-memory-watch):
   a time-scoped note on imported personal context, default-on assistant memory,
   and chat-history transfer as a separate trust boundary from retrieval and


### PR DESCRIPTION
## Summary
- Adds an April 2026 radar note on assistant safety escalation and duty-to-report boundaries
- Links the note from the radar index and README
- Adds the page to English Mintlify navigation

## Validation
- python3 scripts/verify_example_projects.py
- python3 -m json.tool docs.json >/dev/null
- git diff --check
- PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npx mint validate

Closes #50