### PR TITLE
[generalkim00] Add defense agent training loop radar note

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -96,6 +96,7 @@
                 "pages": [
                   "radar/index",
                   "radar/2026-04-assistant-safety-escalation-watch",
+                  "radar/2026-04-defense-agent-training-loop-watch",
                   "radar/2026-04-portable-assistant-memory-watch",
                   "radar/2026-04-local-agent-watch",
                   "radar/2026-04-interoperability-watch",

--- a/radar/2026-04-defense-agent-training-loop-watch.mdx
+++ b/radar/2026-04-defense-agent-training-loop-watch.mdx
@@ -1,0 +1,91 @@
+---
+title: April 2026 Defense Agent Training Loop Watch
+owner: Prompthon IO
+updated: 2026-04-29
+time_scope: 2026-04
+status: draft
+---
+
+## Summary
+
+Scout AI's April 2026 funding and field-training coverage point to a sharper
+defense-agent pattern: start from general model capability, then adapt it
+through domain-specific simulation, physical-world trials, and operational
+feedback loops.
+
+For handbook readers, the signal is not simply "agents for defense." It is the
+emergence of training environments where the model is evaluated against field
+conditions, commander intent, logistics constraints, and autonomous-system
+coordination rather than only against chat or coding benchmarks.
+
+## Why It Matters
+
+Most agent-system examples in public developer material stay near office work:
+research, support, code, retrieval, and workflow automation. Defense autonomy
+pushes the same architecture questions into much harsher conditions:
+
+- partially observed environments
+- mixed fleets of robotic or unmanned systems
+- short decision windows
+- simulation-to-field transfer
+- human command intent translated into bounded action
+- high-risk escalation rules when support workflows approach weaponized action
+
+That makes it a useful radar signal even for readers who never build defense
+systems. It shows how quickly agent design shifts when the deployment setting
+is physical, contested, and safety-critical.
+
+## Evidence And Sources
+
+- [Colby Adcock's Scout AI raises $100M to train its models for war](https://techcrunch.com/2026/04/29/coby-adcocks-scout-ai-raises-100-million-to-train-models-for-war-we-visited-its-bootcamp/):
+  TechCrunch reported from a Scout training operation where autonomous ATVs
+  were used to train and test models for conflict-zone conditions.
+- [Scout AI Raises $100M Series A to Build the AI Brain for Unmanned Warfare](https://www.prnewswire.com/news-releases/scout-ai-raises-100m-series-a-to-build-the-ai-brain-for-unmanned-warfare-302756871.html):
+  Scout's announcement described Fury as a foundation model for unmanned
+  warfare and emphasized coordinated autonomous action across mixed fleets.
+
+## Signals To Watch
+
+- Whether defense-agent companies describe their advantage as model weights,
+  training environments, operational data, or integration with deployed
+  platforms.
+- Whether logistics and support remain the entry point, or whether public
+  positioning moves directly toward autonomous weapon workflows.
+- Whether evaluation artifacts become more important than demos: mission
+  traces, simulator results, field-test logs, after-action reviews, and
+  commander-approval records.
+- Whether human command intent is represented as a structured control surface
+  rather than a vague natural-language prompt.
+- Whether safety cases distinguish support, reconnaissance, and weaponized
+  action instead of treating all autonomy as one category.
+
+## Design Implications
+
+The reusable pattern is a domain training loop:
+
+1. start with a general model or robotics stack
+2. wrap it in a task-specific control surface
+3. test it in simulation and constrained field settings
+4. log decisions against explicit mission constraints
+5. tighten human approval points around higher-risk actions
+6. feed failures back into evaluation and training
+
+For non-defense builders, the same pattern applies to hospitals, factories,
+financial operations, and emergency response. The more consequential the
+deployment context, the more the agent needs a real evaluation environment and
+not just a prompt library.
+
+## Editorial Take
+
+This signal belongs in `radar/`, not in evergreen system guidance yet. The
+category is moving quickly, and the ethical and legal boundaries are unsettled.
+
+The durable lesson is that field training changes the architecture. Agent
+systems that operate in physical or high-risk settings need simulation,
+evidence logs, operator approval surfaces, and failure review as first-class
+parts of the system.
+
+## Update Log
+
+- 2026-04-29: Added a radar note on defense-specific agent training loops,
+  field evaluation, and high-risk autonomy boundaries.

--- a/radar/README.md
+++ b/radar/README.md
@@ -22,6 +22,9 @@ without destabilizing the evergreen structure.
 - [April 2026 Assistant Safety Escalation Watch](./2026-04-assistant-safety-escalation-watch.mdx):
   a current signal on credible violence flags, duty-to-report boundaries,
   repeat policy violators, and audit-ready safety handoffs.
+- [April 2026 Defense Agent Training Loop Watch](./2026-04-defense-agent-training-loop-watch.mdx):
+  a current signal on domain-specific field training, simulation-to-deployment
+  loops, and high-risk autonomy boundaries.
 - [April 2026 Portable Assistant Memory Watch](./2026-04-portable-assistant-memory-watch.mdx):
   a time-scoped note on imported personal context, default-on assistant memory,
   and chat-history transfer as a separate trust boundary from retrieval and

--- a/radar/index.mdx
+++ b/radar/index.mdx
@@ -24,6 +24,9 @@ without destabilizing the evergreen structure.
 - [April 2026 Assistant Safety Escalation Watch](/radar/2026-04-assistant-safety-escalation-watch):
   a current signal on credible violence flags, duty-to-report boundaries,
   repeat policy violators, and audit-ready safety handoffs.
+- [April 2026 Defense Agent Training Loop Watch](/radar/2026-04-defense-agent-training-loop-watch):
+  a current signal on domain-specific field training, simulation-to-deployment
+  loops, and high-risk autonomy boundaries.
 - [April 2026 Portable Assistant Memory Watch](/radar/2026-04-portable-assistant-memory-watch):
   a time-scoped note on imported personal context, default-on assistant memory,
   and chat-history transfer as a separate trust boundary from retrieval and


### PR DESCRIPTION
## Summary
- Adds an April 2026 radar note on defense-specific agent training loops
- Links the note from the radar index and README
- Adds the page to English Mintlify navigation

## Validation
- python3 scripts/verify_example_projects.py
- python3 -m json.tool docs.json >/dev/null
- git diff --check
- PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npx mint validate

Closes #51