### PR TITLE
[gongxiaojing0825] Add safety escalation review skill package

### DIFF
--- a/skills/index.mdx
+++ b/skills/index.mdx
@@ -13,6 +13,7 @@ installable package with a human-facing `README.md`, an agent-facing
 | --- | --- | --- |
 | Agent Runtime Cache Benchmark | [`skills/agent-runtime-cache-benchmark/README.md`](https://github.com/Prompthon-IO/agentic-lab/blob/main/skills/agent-runtime-cache-benchmark/README.md) | Local-first comparison of cold and warm agent runs, cache-break detection from structured run artifacts, and report-driven prompt-cache tuning |
 | Garbage Collector | [`skills/garbage-collector/README.md`](https://github.com/Prompthon-IO/agentic-lab/blob/main/skills/garbage-collector/README.md) | Preview-first local cleanup, readable CSV rules, reversible duplicate cleanup, and explicit approval before destructive actions |
+| Safety Escalation Review | [`skills/safety-escalation-review/README.md`](https://github.com/Prompthon-IO/agentic-lab/blob/main/skills/safety-escalation-review/README.md) | Local evidence review, redacted escalation memos, and human-owned safety handoff checklists without external reporting |
 
 ## Skill Package Shape
 

--- a/skills/safety-escalation-review/README.md
+++ b/skills/safety-escalation-review/README.md
@@ -1,0 +1,72 @@
+# Safety Escalation Review
+
+## Why This Skill Exists
+
+Assistant systems sometimes produce or receive evidence that suggests credible
+harm, violence, self-harm, stalking, extortion, or other high-risk behavior.
+Those cases should not be handled as ordinary summarization tasks.
+
+This practitioner skill teaches a local-first review pattern:
+
+1. collect a local evidence bundle
+2. normalize and redact obvious private details
+3. extract timeline and risk signals
+4. draft an escalation memo and checklist
+5. hand the result to the human legal, trust-and-safety, security, or incident
+   owner
+
+The skill does not contact authorities, submit reports, or decide legal duties.
+It creates a review artifact that helps humans make the next decision.
+
+## Who It Is For
+
+This package is for students, contributors, operators, and builders who need a
+small example of safety-review workflow design. It is useful when someone has a
+transcript, local incident note, or JSON evidence bundle and needs a consistent
+way to summarize what happened without moving sensitive data off-machine.
+
+## End-to-End Workflow
+
+1. Save the transcript or evidence bundle locally.
+2. Run the helper script against that local file.
+3. Review the generated Markdown memo.
+4. Give the memo to the responsible human owner.
+5. Keep runtime evidence and reports out of git.
+
+Example:
+
+```bash
+python3 scripts/escalation_review.py \
+  review \
+  --input /path/to/evidence.md \
+  --output ~/.codex/state/safety-escalation-review/memos/case-001.md
+```
+
+## What The Helper Checks
+
+The helper looks for basic textual signals such as:
+
+- explicit violence or weapon terms
+- named targets, locations, or timing cues
+- self-harm or distress language
+- evasion, repeat-account, or ban-circumvention clues
+- privacy-sensitive identifiers that should be redacted in the memo
+
+These checks are intentionally simple. They make the review repeatable, not
+authoritative.
+
+## What It Does Not Do
+
+This package does not:
+
+- contact law enforcement or external services
+- upload evidence to a model provider
+- make legal determinations
+- replace trust-and-safety, legal, security, or clinical judgment
+- store private transcripts in the public repository
+
+## How To Read It In The Handbook
+
+Treat this package as a code-plus-docs example of an escalation workflow. The
+important pattern is the split between deterministic local preparation and
+human ownership of the final decision.

--- a/skills/safety-escalation-review/SKILL.md
+++ b/skills/safety-escalation-review/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: safety-escalation-review
+description: Review a local evidence bundle or assistant transcript for credible harm signals, produce a redacted escalation memo and checklist, and stop before any external reporting or authority contact. Use when a user asks Codex to prepare a safety, legal, trust-and-safety, or incident handoff from local evidence.
+---
+
+# Safety Escalation Review
+
+For the human-facing explanation, read `README.md` first. This file is the
+Codex invocation contract.
+
+## Overview
+
+Use this skill when the user provides a local transcript, incident note, or
+evidence bundle that may require safety escalation. The workflow is local-first
+and review-first:
+
+1. read the local input file
+2. redact obvious direct identifiers for the memo copy
+3. extract timeline cues and risk signals
+4. generate a Markdown escalation memo and checklist
+5. hand off to the responsible human owner
+
+Do not contact external authorities, submit reports, message involved parties,
+or upload sensitive evidence to external services unless the user gives a
+separate explicit instruction and the organization policy allows it. In the
+normal workflow, stop at the local memo.
+
+## Inputs
+
+Supported input files:
+
+- Markdown or plain text transcripts
+- JSON objects or arrays with message-like fields
+- short local incident notes
+
+Keep original evidence in the user's chosen location. Do not rewrite or move
+source evidence.
+
+## Commands
+
+Run the helper relative to this skill directory:
+
+```bash
+python3 scripts/escalation_review.py review --input /path/to/evidence.md
+```
+
+Write to an explicit output:
+
+```bash
+python3 scripts/escalation_review.py review \
+  --input /path/to/evidence.json \
+  --output ~/.codex/state/safety-escalation-review/memos/case-001.md
+```
+
+Show the CLI:
+
+```bash
+python3 scripts/escalation_review.py --help
+```
+
+## Safety Rules
+
+- Keep evidence local unless the user explicitly requests otherwise.
+- Never contact law enforcement, emergency services, platform trust-and-safety
+  teams, or other external parties from this skill.
+- Do not decide whether the organization has a legal duty to report.
+- Redact obvious emails, phone numbers, bearer tokens, and API-like secrets in
+  the generated memo.
+- Preserve enough source references for a human reviewer to find the original
+  evidence.
+- Treat a generated memo as a preparation artifact, not as the final incident
+  decision.
+
+## Human Handoff Owners
+
+Use the user's organization language if they provide it. Otherwise suggest one
+or more of:
+
+- trust and safety
+- legal
+- security or incident response
+- clinical or student-safety owner
+- executive duty officer for urgent credible harm cases
+
+## Outputs
+
+By default, runtime outputs should live outside git:
+
+```text
+~/.codex/state/safety-escalation-review/
+  memos/
+```
+
+The memo includes:
+
+- case summary
+- severity estimate
+- detected risk signals
+- timeline cues
+- privacy handling notes
+- human handoff checklist
+- source reference
+
+## Response Pattern
+
+When reporting back, include:
+
+- input path reviewed
+- output memo path
+- severity estimate
+- key signal categories
+- reminder that the memo is for human review and no external action was taken

--- a/skills/safety-escalation-review/agents/openai.yaml
+++ b/skills/safety-escalation-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Safety Escalation Review"
+  short_description: "Prepare a local harm-risk escalation memo"
+  default_prompt: "Use $safety-escalation-review to review this local evidence bundle and prepare a human handoff memo without contacting external parties."

--- a/skills/safety-escalation-review/references/escalation-checklist.md
+++ b/skills/safety-escalation-review/references/escalation-checklist.md
@@ -1,0 +1,26 @@
+# Escalation Checklist
+
+Use this checklist when reviewing generated memos.
+
+## Evidence Handling
+
+- Confirm the source evidence path is local.
+- Confirm obvious identifiers are redacted in the memo copy.
+- Confirm the original evidence has not been moved or rewritten.
+- Confirm the memo does not include API keys, bearer tokens, or private account
+  identifiers.
+
+## Risk Review
+
+- Identify whether the concern involves violence, self-harm, stalking,
+  extortion, abuse, or another high-risk category.
+- Note any named target, location, date, time, weapon, method, or repeated
+  evasion signal.
+- Separate direct evidence from interpretation.
+- Record what is unknown.
+
+## Human Ownership
+
+- Name the human owner or team that should review the memo.
+- Check organization policy before any external notification.
+- Preserve the reviewer decision and timestamp outside the public repository.

--- a/skills/safety-escalation-review/scripts/escalation_review.py
+++ b/skills/safety-escalation-review/scripts/escalation_review.py
@@ -226,12 +226,16 @@ def default_output_path(source_path: Path) -> Path:
     return base / f"{safe_name}-{stamp}.md"
 
 
+def expanded_path(value: str) -> Path:
+    return Path(value).expanduser().resolve()
+
+
 def command_review(args: argparse.Namespace) -> int:
-    source_path = args.input.expanduser().resolve()
+    source_path = args.input
     if not source_path.exists():
         raise FileNotFoundError(f"input file does not exist: {source_path}")
     review = build_review(source_path)
-    output_path = args.output.expanduser().resolve() if args.output else default_output_path(source_path)
+    output_path = args.output if args.output else default_output_path(source_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(render_memo(review), encoding="utf-8")
     print(f"memo: {output_path}")
@@ -245,8 +249,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Prepare a local safety escalation memo.")
     subparsers = parser.add_subparsers(dest="command", required=True)
     review = subparsers.add_parser("review", help="review a local evidence file")
-    review.add_argument("--input", required=True, type=Path, help="local transcript, note, or JSON evidence file")
-    review.add_argument("--output", type=Path, help="Markdown memo path; defaults under ~/.codex/state")
+    review.add_argument("--input", required=True, type=expanded_path, help="local transcript, note, or JSON evidence file")
+    review.add_argument("--output", type=expanded_path, help="Markdown memo path; defaults under ~/.codex/state")
     review.set_defaults(func=command_review)
     return parser
 

--- a/skills/safety-escalation-review/scripts/escalation_review.py
+++ b/skills/safety-escalation-review/scripts/escalation_review.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+RISK_TERMS = {
+    "violence": [
+        "attack",
+        "bomb",
+        "gun",
+        "kill",
+        "mass shooting",
+        "shoot",
+        "stab",
+        "weapon",
+    ],
+    "self_harm": [
+        "end my life",
+        "hurt myself",
+        "self harm",
+        "suicide",
+        "suicidal",
+    ],
+    "targeting": [
+        "address",
+        "at school",
+        "at work",
+        "target",
+        "tomorrow",
+        "tonight",
+    ],
+    "evasion": [
+        "banned account",
+        "evade",
+        "new account",
+        "policy bypass",
+        "work around",
+    ],
+}
+
+
+REDACTIONS = [
+    (re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I), "[redacted-email]"),
+    (re.compile(r"\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b"), "[redacted-phone]"),
+    (re.compile(r"\b(?:sk|gho|ghp|xoxb|pat)_[A-Za-z0-9_\-]{16,}\b"), "[redacted-token]"),
+    (re.compile(r"\b(?:api[_-]?key|token|secret)\s*[:=]\s*[A-Za-z0-9_\-]{12,}\b", re.I), "[redacted-secret]"),
+]
+
+
+@dataclass
+class Review:
+    source_path: Path
+    severity: str
+    signals: dict[str, list[str]]
+    timeline_cues: list[str]
+    redacted_excerpt: str
+    reviewed_at: str
+
+
+def read_input(path: Path) -> str:
+    raw = path.read_text(encoding="utf-8")
+    if path.suffix.lower() != ".json":
+        return raw
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+    lines: list[str] = []
+
+    def walk(value: object, prefix: str = "") -> None:
+        if isinstance(value, dict):
+            for key, item in value.items():
+                walk(item, f"{prefix}{key}.")
+        elif isinstance(value, list):
+            for index, item in enumerate(value, start=1):
+                walk(item, f"{prefix}{index}.")
+        elif value is not None:
+            label = prefix[:-1] if prefix else "value"
+            lines.append(f"{label}: {value}")
+
+    walk(data)
+    return "\n".join(lines)
+
+
+def redact(text: str) -> str:
+    redacted = text
+    for pattern, replacement in REDACTIONS:
+        redacted = pattern.sub(replacement, redacted)
+    return redacted
+
+
+def find_signals(text: str) -> dict[str, list[str]]:
+    lowered = text.lower()
+    findings: dict[str, list[str]] = {}
+    for category, terms in RISK_TERMS.items():
+        hits = sorted({term for term in terms if term in lowered})
+        if hits:
+            findings[category] = hits
+    return findings
+
+
+def find_timeline_cues(text: str) -> list[str]:
+    patterns = [
+        r"\b\d{4}-\d{2}-\d{2}\b",
+        r"\b(?:today|tonight|tomorrow|yesterday)\b",
+        r"\b(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b",
+        r"\b\d{1,2}:\d{2}\s?(?:am|pm)?\b",
+    ]
+    cues: list[str] = []
+    for pattern in patterns:
+        cues.extend(match.group(0) for match in re.finditer(pattern, text, re.I))
+    return sorted(set(cues))
+
+
+def estimate_severity(signals: dict[str, list[str]], timeline_cues: Iterable[str]) -> str:
+    categories = set(signals)
+    has_time = bool(list(timeline_cues))
+    if {"violence", "targeting"} <= categories and has_time:
+        return "critical-review"
+    if "violence" in categories and ("targeting" in categories or "evasion" in categories):
+        return "high-review"
+    if "self_harm" in categories or "violence" in categories:
+        return "elevated-review"
+    if categories:
+        return "screening-review"
+    return "no-obvious-risk-signal"
+
+
+def excerpt(text: str, limit: int = 1200) -> str:
+    compact = "\n".join(line.rstrip() for line in text.strip().splitlines())
+    if len(compact) <= limit:
+        return compact
+    return compact[:limit].rstrip() + "\n[excerpt truncated]"
+
+
+def build_review(source_path: Path) -> Review:
+    text = read_input(source_path)
+    redacted = redact(text)
+    signals = find_signals(redacted)
+    timeline_cues = find_timeline_cues(redacted)
+    return Review(
+        source_path=source_path,
+        severity=estimate_severity(signals, timeline_cues),
+        signals=signals,
+        timeline_cues=timeline_cues,
+        redacted_excerpt=excerpt(redacted),
+        reviewed_at=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+    )
+
+
+def render_memo(review: Review) -> str:
+    signal_lines = [
+        f"- {category}: {', '.join(terms)}"
+        for category, terms in review.signals.items()
+    ]
+    if not signal_lines:
+        signal_lines.append("- none detected by the deterministic keyword pass")
+
+    timeline_lines = [f"- {cue}" for cue in review.timeline_cues]
+    if not timeline_lines:
+        timeline_lines.append("- no explicit date or time cues detected")
+
+    return "\n".join(
+        [
+            "# Safety Escalation Review Memo",
+            "",
+            "## Case Summary",
+            "",
+            f"- Source evidence: `{review.source_path}`",
+            f"- Reviewed at: {review.reviewed_at}",
+            f"- Severity estimate: `{review.severity}`",
+            "- External action taken: none",
+            "",
+            "This memo is a local preparation artifact for human review. It does",
+            "not determine legal duties and does not contact external parties.",
+            "",
+            "## Detected Risk Signals",
+            "",
+            *signal_lines,
+            "",
+            "## Timeline Cues",
+            "",
+            *timeline_lines,
+            "",
+            "## Redacted Evidence Excerpt",
+            "",
+            "```text",
+            review.redacted_excerpt or "[no text extracted]",
+            "```",
+            "",
+            "## Privacy And Handling Notes",
+            "",
+            "- Keep the original evidence in its current local location.",
+            "- Do not commit private transcripts, reports, or runtime artifacts.",
+            "- Review the redaction before sharing this memo internally.",
+            "- Apply organization policy before any external notification.",
+            "",
+            "## Human Handoff Checklist",
+            "",
+            "- [ ] Name the responsible human owner or team.",
+            "- [ ] Separate direct evidence from interpretation.",
+            "- [ ] Confirm whether any immediate safety action is required.",
+            "- [ ] Confirm whether legal, trust-and-safety, security, or clinical",
+            "      review owns the next decision.",
+            "- [ ] Record the final human decision outside the public repository.",
+            "",
+        ]
+    )
+
+
+def default_output_path(source_path: Path) -> Path:
+    safe_name = re.sub(r"[^a-zA-Z0-9_.-]+", "-", source_path.stem).strip("-")
+    if not safe_name:
+        safe_name = "evidence"
+    base = Path.home() / ".codex" / "state" / "safety-escalation-review" / "memos"
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return base / f"{safe_name}-{stamp}.md"
+
+
+def command_review(args: argparse.Namespace) -> int:
+    source_path = Path(args.input).expanduser().resolve()
+    if not source_path.exists():
+        raise FileNotFoundError(f"input file does not exist: {source_path}")
+    review = build_review(source_path)
+    output_path = Path(args.output).expanduser().resolve() if args.output else default_output_path(source_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(render_memo(review), encoding="utf-8")
+    print(f"memo: {output_path}")
+    print(f"severity: {review.severity}")
+    print(f"signal_categories: {', '.join(review.signals) if review.signals else 'none'}")
+    print("external_action_taken: none")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prepare a local safety escalation memo.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    review = subparsers.add_parser("review", help="review a local evidence file")
+    review.add_argument("--input", required=True, help="local transcript, note, or JSON evidence file")
+    review.add_argument("--output", help="Markdown memo path; defaults under ~/.codex/state")
+    review.set_defaults(func=command_review)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/safety-escalation-review/scripts/escalation_review.py
+++ b/skills/safety-escalation-review/scripts/escalation_review.py
@@ -7,7 +7,7 @@ import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable
+from typing import Sequence
 
 
 RISK_TERMS = {
@@ -49,8 +49,8 @@ RISK_TERMS = {
 REDACTIONS = [
     (re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.I), "[redacted-email]"),
     (re.compile(r"\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b"), "[redacted-phone]"),
-    (re.compile(r"\b(?:sk|gho|ghp|xoxb|pat)_[A-Za-z0-9_\-]{16,}\b"), "[redacted-token]"),
-    (re.compile(r"\b(?:api[_-]?key|token|secret)\s*[:=]\s*[A-Za-z0-9_\-]{12,}\b", re.I), "[redacted-secret]"),
+    (re.compile(r"(?<![A-Za-z0-9_])(?:sk[-_][A-Za-z0-9_-]{16,}|gh(?:o|p)[_-][A-Za-z0-9_-]{16,}|pat[_-][A-Za-z0-9_-]{16,}|xoxb-[A-Za-z0-9-]{16,})\b"), "[redacted-token]"),
+    (re.compile(r"\b(?:api[_-]?key|token|secret)\b\s*[:=]\s*(?:['\"])?[A-Za-z0-9][A-Za-z0-9_-]{11,}(?:['\"])?", re.I), "[redacted-secret]"),
 ]
 
 
@@ -121,9 +121,9 @@ def find_timeline_cues(text: str) -> list[str]:
     return sorted(set(cues))
 
 
-def estimate_severity(signals: dict[str, list[str]], timeline_cues: Iterable[str]) -> str:
+def estimate_severity(signals: dict[str, list[str]], timeline_cues: Sequence[str]) -> str:
     categories = set(signals)
-    has_time = bool(list(timeline_cues))
+    has_time = bool(timeline_cues)
     if {"violence", "targeting"} <= categories and has_time:
         return "critical-review"
     if "violence" in categories and ("targeting" in categories or "evasion" in categories):
@@ -227,11 +227,11 @@ def default_output_path(source_path: Path) -> Path:
 
 
 def command_review(args: argparse.Namespace) -> int:
-    source_path = Path(args.input).expanduser().resolve()
+    source_path = args.input.expanduser().resolve()
     if not source_path.exists():
         raise FileNotFoundError(f"input file does not exist: {source_path}")
     review = build_review(source_path)
-    output_path = Path(args.output).expanduser().resolve() if args.output else default_output_path(source_path)
+    output_path = args.output.expanduser().resolve() if args.output else default_output_path(source_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(render_memo(review), encoding="utf-8")
     print(f"memo: {output_path}")
@@ -245,8 +245,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Prepare a local safety escalation memo.")
     subparsers = parser.add_subparsers(dest="command", required=True)
     review = subparsers.add_parser("review", help="review a local evidence file")
-    review.add_argument("--input", required=True, help="local transcript, note, or JSON evidence file")
-    review.add_argument("--output", help="Markdown memo path; defaults under ~/.codex/state")
+    review.add_argument("--input", required=True, type=Path, help="local transcript, note, or JSON evidence file")
+    review.add_argument("--output", type=Path, help="Markdown memo path; defaults under ~/.codex/state")
     review.set_defaults(func=command_review)
     return parser
 

--- a/zh-Hans/skills/index.mdx
+++ b/zh-Hans/skills/index.mdx
@@ -10,6 +10,7 @@ title: "实践者技能"
 | --- | --- | --- |
 | Agent Runtime Cache Benchmark | [`skills/agent-runtime-cache-benchmark/README.md`](https://github.com/Prompthon-IO/agentic-lab/blob/main/skills/agent-runtime-cache-benchmark/README.md) | 面向本地运行的冷启动与热启动对比、基于结构化运行产物的缓存断点识别，以及报告驱动的 prompt cache 调优 |
 | Garbage Collector | [`skills/garbage-collector/README.md`](https://github.com/Prompthon-IO/agentic-lab/blob/main/skills/garbage-collector/README.md) | 预览优先的本地清理、可读 CSV 规则、可撤销的重复文件清理，以及破坏性操作前的明确批准 |
+| Safety Escalation Review | [`skills/safety-escalation-review/README.md`](https://github.com/Prompthon-IO/agentic-lab/blob/main/skills/safety-escalation-review/README.md) | 本地证据审查、脱敏升级备忘录，以及由人工负责的安全交接清单，不执行外部报告 |
 
 ## 技能包结构
 


### PR DESCRIPTION
## Summary
- Adds the safety-escalation-review practitioner skill package
- Includes README, SKILL.md, metadata, reference checklist, and deterministic memo helper
- Lists the package in English and Chinese skill indexes

## Validation
- python3 -m py_compile skills/safety-escalation-review/scripts/escalation_review.py
- python3 skills/safety-escalation-review/scripts/escalation_review.py review --input /tmp/safety-escalation-sample.txt --output /tmp/safety-escalation-memo.md
- rg -n "\[redacted-email\]|critical-review|External action taken: none" /tmp/safety-escalation-memo.md
- python3 scripts/verify_example_projects.py
- git diff --check
- PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npx mint validate

Closes #52