### PR TITLE
[jiafenglu0623] Add messaging transaction assistant starter

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -113,6 +113,7 @@
                   "patterns/examples/agent-memory-retrieval-starter/index",
                   "systems/examples/weather-mcp-server-starter/index",
                   "ecosystem/examples/langgraph-starter/index",
+                  "ecosystem/examples/messaging-transaction-assistant-starter/index",
                   "case-studies/examples/deep-research-agent-starter/index",
                   "case-studies/examples/customer-support-email-agent-starter/index"
                 ]
@@ -298,6 +299,7 @@
                   "zh-Hans/patterns/examples/agent-memory-retrieval-starter/index",
                   "zh-Hans/systems/examples/weather-mcp-server-starter/index",
                   "zh-Hans/ecosystem/examples/langgraph-starter/index",
+                  "zh-Hans/ecosystem/examples/messaging-transaction-assistant-starter/index",
                   "zh-Hans/case-studies/examples/deep-research-agent-starter/index",
                   "zh-Hans/case-studies/examples/customer-support-email-agent-starter/index"
                 ]

--- a/ecosystem/examples/messaging-transaction-assistant-starter/README.md
+++ b/ecosystem/examples/messaging-transaction-assistant-starter/README.md
@@ -1,0 +1,39 @@
+# Messaging Transaction Assistant Starter
+
+This starter demonstrates a compact transaction flow inside a messaging-style
+assistant. The motivating signal is WhatsApp prepaid recharge in India, but
+the implementation is repo-native and generic: it teaches intent capture, plan
+selection, user confirmation, and payment handoff boundaries without copying a
+vendor UI.
+
+## Status
+
+`starter`
+
+## What It Demonstrates
+
+- capture a user's transaction intent from a chat message
+- select a simple plan from local fixtures
+- require explicit confirmation before payment handoff
+- keep payment execution outside the assistant
+- record the source lineage that inspired the starter
+
+## Quick Start
+
+Run the repository-level smoke check:
+
+```bash
+python3 scripts/verify_example_projects.py
+```
+
+Or inspect the starter directly:
+
+```bash
+python3 ecosystem/examples/messaging-transaction-assistant-starter/src/run_demo.py
+```
+
+## Boundaries
+
+This starter does not process payments, store card data, call telecom APIs, or
+send real messages. The assistant stops at a structured handoff that a real
+payment surface would need to own.

--- a/ecosystem/examples/messaging-transaction-assistant-starter/SOURCE_NOTES.md
+++ b/ecosystem/examples/messaging-transaction-assistant-starter/SOURCE_NOTES.md
@@ -1,0 +1,25 @@
+# Source Notes
+
+## Primary Signal
+
+- Meta, "Bringing Prepaid Mobile Recharges to WhatsApp Users in India",
+  April 29, 2026:
+  https://about.fb.com/news/2026/04/bringing-prepaid-mobile-recharges-to-whatsapp-users-in-india/
+
+## Repo-Native Interpretation
+
+The source describes a messaging app flow where users can discover payments,
+select prepaid mobile recharge, choose a number, confirm an operator, select a
+plan, choose a payment method, and confirm payment.
+
+This starter does not copy WhatsApp UI or implement Meta-specific behavior. It
+uses the source as a product-shape signal for a generic messaging-native
+transaction assistant.
+
+## Attribution Boundaries
+
+- Do not copy source screenshots or UI text into the starter.
+- Do not imply the repo starter integrates with WhatsApp, UPI, Jio, Airtel, or
+  Vi.
+- Keep the code small enough to teach assistant boundaries rather than payment
+  operations.

--- a/ecosystem/examples/messaging-transaction-assistant-starter/index.mdx
+++ b/ecosystem/examples/messaging-transaction-assistant-starter/index.mdx
@@ -1,0 +1,68 @@
+---
+title: "Messaging Transaction Assistant Starter"
+---
+
+## Summary
+
+This starter shows a messaging-native transaction assistant in the smallest
+useful shape: intent capture, plan selection, user confirmation, and payment
+handoff.
+
+## Status
+
+`starter`
+
+Source code: [ecosystem/examples/messaging-transaction-assistant-starter](https://github.com/Prompthon-IO/agentic-lab/tree/main/ecosystem/examples/messaging-transaction-assistant-starter)
+
+## Why It Exists
+
+Messaging surfaces are becoming places where users complete real tasks without
+switching apps. The assistant pattern is not "let the model pay for something."
+It is a bounded flow where the assistant collects intent, presents a reviewable
+choice, and hands off to a trusted payment surface after explicit confirmation.
+
+## Related Lab Pages
+
+- [Ecosystem Overview](/ecosystem)
+- [Source Project Guidelines](/contributor-kit/source-project-guidelines)
+
+## Folder Structure
+
+```text
+messaging-transaction-assistant-starter/
+├── README.md
+├── SOURCE_NOTES.md
+├── index.mdx
+└── src/
+    ├── run_demo.py
+    └── transaction_flow.py
+```
+
+## Included Sample Files
+
+- `src/transaction_flow.py`: typed helpers for intent capture, plan selection,
+  confirmation, and payment handoff
+- `src/run_demo.py`: tiny command-line demo of the flow
+- `SOURCE_NOTES.md`: source lineage and attribution boundary
+
+## Flow Boundaries
+
+The assistant may:
+
+- infer a recharge-like intent from a message
+- ask for missing plan or recipient details
+- show a confirmation summary
+- prepare a handoff payload for a payment surface
+
+The assistant must not:
+
+- execute payment
+- store card or bank credentials
+- bypass user confirmation
+- imply vendor-specific integration that does not exist
+
+## Next Steps
+
+- Add a richer state machine for missing details.
+- Add localization fixtures for different messaging markets.
+- Add a fake payment adapter that only records handoff state for tests.

--- a/ecosystem/examples/messaging-transaction-assistant-starter/src/run_demo.py
+++ b/ecosystem/examples/messaging-transaction-assistant-starter/src/run_demo.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from transaction_flow import run_flow
+
+
+def main() -> int:
+    handoff = run_flow("Recharge my family phone with a standard data plan")
+    print(f"status: {handoff.status}")
+    print(f"recipient: {handoff.confirmation.recipient}")
+    print(f"operator: {handoff.confirmation.operator}")
+    print(f"amount_inr: {handoff.confirmation.amount_inr}")
+    print("external_payment_executed: false")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ecosystem/examples/messaging-transaction-assistant-starter/src/transaction_flow.py
+++ b/ecosystem/examples/messaging-transaction-assistant-starter/src/transaction_flow.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TransactionIntent:
+    raw_message: str
+    recipient: str
+    operator: str
+    requested_action: str
+
+
+@dataclass(frozen=True)
+class RechargePlan:
+    operator: str
+    plan_id: str
+    label: str
+    price_inr: int
+    validity_days: int
+    data_gb: float
+
+
+@dataclass(frozen=True)
+class Confirmation:
+    recipient: str
+    operator: str
+    plan_label: str
+    amount_inr: int
+    requires_user_confirmation: bool = True
+
+
+@dataclass(frozen=True)
+class PaymentHandoff:
+    status: str
+    payment_methods: tuple[str, ...]
+    confirmation: Confirmation
+
+
+PLANS = (
+    RechargePlan(
+        operator="generic-mobile",
+        plan_id="starter-199",
+        label="Starter data plan",
+        price_inr=199,
+        validity_days=28,
+        data_gb=1.5,
+    ),
+    RechargePlan(
+        operator="generic-mobile",
+        plan_id="standard-299",
+        label="Standard data plan",
+        price_inr=299,
+        validity_days=28,
+        data_gb=2.0,
+    ),
+)
+
+
+def capture_intent(message: str) -> TransactionIntent:
+    normalized = message.lower()
+    recipient = "self"
+    if "family" in normalized or "mom" in normalized or "dad" in normalized:
+        recipient = "family"
+    elif "friend" in normalized:
+        recipient = "friend"
+
+    operator = "generic-mobile"
+    if "airtel" in normalized:
+        operator = "airtel-like"
+    elif "jio" in normalized:
+        operator = "jio-like"
+    elif "vi" in normalized or "vodafone" in normalized:
+        operator = "vi-like"
+
+    return TransactionIntent(
+        raw_message=message,
+        recipient=recipient,
+        operator=operator,
+        requested_action="mobile-prepaid-recharge",
+    )
+
+
+def select_plan(intent: TransactionIntent, max_price_inr: int | None = None) -> RechargePlan:
+    candidates = [plan for plan in PLANS if plan.price_inr <= (max_price_inr or 9999)]
+    if not candidates:
+        raise ValueError("no starter plan fits the requested budget")
+    selected = candidates[-1]
+    if intent.operator != "generic-mobile":
+        return RechargePlan(
+            operator=intent.operator,
+            plan_id=selected.plan_id,
+            label=selected.label,
+            price_inr=selected.price_inr,
+            validity_days=selected.validity_days,
+            data_gb=selected.data_gb,
+        )
+    return selected
+
+
+def build_confirmation(intent: TransactionIntent, plan: RechargePlan) -> Confirmation:
+    return Confirmation(
+        recipient=intent.recipient,
+        operator=plan.operator,
+        plan_label=plan.label,
+        amount_inr=plan.price_inr,
+    )
+
+
+def prepare_payment_handoff(confirmation: Confirmation) -> PaymentHandoff:
+    if not confirmation.requires_user_confirmation:
+        raise ValueError("payment handoff must require explicit user confirmation")
+    return PaymentHandoff(
+        status="awaiting-user-confirmation",
+        payment_methods=("upi-like", "card-like"),
+        confirmation=confirmation,
+    )
+
+
+def run_flow(message: str, max_price_inr: int | None = None) -> PaymentHandoff:
+    intent = capture_intent(message)
+    plan = select_plan(intent, max_price_inr=max_price_inr)
+    confirmation = build_confirmation(intent, plan)
+    return prepare_payment_handoff(confirmation)

--- a/ecosystem/examples/messaging-transaction-assistant-starter/src/transaction_flow.py
+++ b/ecosystem/examples/messaging-transaction-assistant-starter/src/transaction_flow.py
@@ -66,12 +66,12 @@ def capture_intent(message: str) -> TransactionIntent:
         recipient = "friend"
 
     operator = "generic-mobile"
-    if "airtel" in normalized:
-        operator = "airtel-like"
-    elif "jio" in normalized:
-        operator = "jio-like"
-    elif "vi" in normalized or "vodafone" in normalized:
-        operator = "vi-like"
+    if "operator a" in normalized:
+        operator = "operator-a"
+    elif "operator b" in normalized:
+        operator = "operator-b"
+    elif "operator c" in normalized:
+        operator = "operator-c"
 
     return TransactionIntent(
         raw_message=message,
@@ -82,7 +82,10 @@ def capture_intent(message: str) -> TransactionIntent:
 
 
 def select_plan(intent: TransactionIntent, max_price_inr: int | None = None) -> RechargePlan:
-    candidates = [plan for plan in PLANS if plan.price_inr <= (max_price_inr or 9999)]
+    if max_price_inr is not None and max_price_inr <= 0:
+        raise ValueError("budget must be positive")
+    budget = max_price_inr if max_price_inr is not None else 9999
+    candidates = [plan for plan in PLANS if plan.price_inr <= budget]
     if not candidates:
         raise ValueError("no starter plan fits the requested budget")
     selected = candidates[-1]
@@ -112,7 +115,7 @@ def prepare_payment_handoff(confirmation: Confirmation) -> PaymentHandoff:
         raise ValueError("payment handoff must require explicit user confirmation")
     return PaymentHandoff(
         status="awaiting-user-confirmation",
-        payment_methods=("upi-like", "card-like"),
+        payment_methods=("instant-transfer-like", "card-like"),
         confirmation=confirmation,
     )
 

--- a/scripts/verify_example_projects.py
+++ b/scripts/verify_example_projects.py
@@ -202,6 +202,30 @@ def check_langgraph_starter() -> None:
     assert "Route: tool" in summary
 
 
+def check_messaging_transaction_starter() -> None:
+    module = load_module(
+        "messaging_transaction_flow",
+        "ecosystem/examples/messaging-transaction-assistant-starter/src/transaction_flow.py",
+    )
+    handoff = module.run_flow(
+        "Recharge my family phone with a standard data plan",
+        max_price_inr=300,
+    )
+
+    assert handoff.status == "awaiting-user-confirmation"
+    assert handoff.confirmation.recipient == "family"
+    assert handoff.confirmation.requires_user_confirmation is True
+    assert handoff.confirmation.amount_inr <= 300
+    assert "upi-like" in handoff.payment_methods
+
+    try:
+        module.select_plan(module.capture_intent("recharge me"), max_price_inr=100)
+    except ValueError as exc:
+        assert "no starter plan" in str(exc)
+    else:
+        raise AssertionError("too-small budget should reject all starter plans")
+
+
 def check_research_starter() -> None:
     module = load_module(
         "research_loop",
@@ -285,6 +309,10 @@ def main() -> int:
         ("patterns/examples/agent-memory-retrieval-starter", check_memory_starter),
         ("systems/examples/weather-mcp-server-starter", check_weather_starter),
         ("ecosystem/examples/langgraph-starter", check_langgraph_starter),
+        (
+            "ecosystem/examples/messaging-transaction-assistant-starter",
+            check_messaging_transaction_starter,
+        ),
         ("case-studies/examples/deep-research-agent-starter", check_research_starter),
         (
             "case-studies/examples/customer-support-email-agent-starter",

--- a/scripts/verify_example_projects.py
+++ b/scripts/verify_example_projects.py
@@ -216,7 +216,14 @@ def check_messaging_transaction_starter() -> None:
     assert handoff.confirmation.recipient == "family"
     assert handoff.confirmation.requires_user_confirmation is True
     assert handoff.confirmation.amount_inr <= 300
-    assert "upi-like" in handoff.payment_methods
+    assert "instant-transfer-like" in handoff.payment_methods
+
+    try:
+        module.select_plan(module.capture_intent("recharge me"), max_price_inr=0)
+    except ValueError as exc:
+        assert "budget must be positive" in str(exc)
+    else:
+        raise AssertionError("non-positive budget should be rejected")
 
     try:
         module.select_plan(module.capture_intent("recharge me"), max_price_inr=100)

--- a/zh-Hans/ecosystem/examples/messaging-transaction-assistant-starter/index.mdx
+++ b/zh-Hans/ecosystem/examples/messaging-transaction-assistant-starter/index.mdx
@@ -1,0 +1,23 @@
+---
+title: "消息交易助手入门项目"
+---
+
+## 摘要
+
+这个入门项目展示了消息界面中的交易助手最小形态：意图捕获、套餐选择、用户确认和支付交接。
+
+## 状态
+
+`starter`
+
+Source code: [ecosystem/examples/messaging-transaction-assistant-starter](https://github.com/Prompthon-IO/agentic-lab/tree/main/ecosystem/examples/messaging-transaction-assistant-starter)
+
+## 为什么存在
+
+消息界面正在成为用户完成实际任务的地方。这个模式不是让模型直接付款，而是让助手收集意图、展示可审阅的选择，并在用户明确确认后交接给可信的支付界面。
+
+## 边界
+
+助手可以推断充值类意图、补齐缺失信息、展示确认摘要，并准备支付交接载荷。
+
+助手不能执行支付、保存银行卡或银行凭据、绕过用户确认，或暗示并不存在的供应商集成。


### PR DESCRIPTION
## Summary
- Adds the messaging-transaction-assistant-starter source project under ecosystem examples
- Includes README, source notes, MDX pages, starter code, and Chinese mirror page
- Adds smoke-test coverage to verify_example_projects.py

## Validation
- python3 -m py_compile ecosystem/examples/messaging-transaction-assistant-starter/src/*.py
- python3 ecosystem/examples/messaging-transaction-assistant-starter/src/run_demo.py
- python3 scripts/verify_example_projects.py
- python3 -m json.tool docs.json >/dev/null
- git diff --check
- PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npx mint validate

Closes #53