### PR TITLE
Add Discord lab update announcements

### DIFF
--- a/.github/discord-lab-updates.md
+++ b/.github/discord-lab-updates.md
@@ -3,9 +3,8 @@
 This repository enqueues Discord announcement jobs for Agentic Labs GitHub
 events: issue `good-first-issue` labels, PR coordination, PR merges, and direct
 pushes to `main`.
-The local worker in `/Users/liqingpan/Projects/agent_skills/agent_skills`
-drains those jobs from Postgres and posts them to the Agentic Labs Discord
-channels.
+A separate local announcer worker drains those jobs from Postgres and posts
+them to the Agentic Labs Discord channels.
 
 ## Required GitHub Secret
 
@@ -15,12 +14,8 @@ Create this repository secret in GitHub Actions:
 PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL
 ```
 
-Use the same remote Postgres URL stored locally as
-`PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL` in:
-
-```txt
-~/.codex/state/pathway-discord-announcer/.env
-```
+Use the same remote Postgres URL configured for the local announcer worker's
+`PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL` value.
 
 Do not commit the value.
 

--- a/.github/discord-lab-updates.md
+++ b/.github/discord-lab-updates.md
@@ -1,9 +1,11 @@
 # Discord Lab Updates Automation
 
-This repository enqueues Discord announcement jobs after pushes to `main`.
+This repository enqueues Discord announcement jobs for Agentic Labs GitHub
+events: issue `good-first-issue` labels, PR coordination, PR merges, and direct
+pushes to `main`.
 The local worker in `/Users/liqingpan/Projects/agent_skills/agent_skills`
-drains those jobs from Postgres and posts them to the lab-updates Discord
-channel.
+drains those jobs from Postgres and posts them to the Agentic Labs Discord
+channels.
 
 ## Required GitHub Secret
 
@@ -22,13 +24,17 @@ Use the same remote Postgres URL stored locally as
 
 Do not commit the value.
 
-## Optional GitHub Variable
+## Required GitHub Variables
 
-The workflow defaults to channel `1347671631295811595`. To change it without a
-code change, add a repository variable:
+After CaraP creates the Agentic Labs channels, sync routes from the
+`agent_skills` repo and copy the printed values into GitHub repository
+variables:
 
 ```txt
-DISCORD_LAB_UPDATES_CHANNEL_ID
+DISCORD_REPO_UPDATES_CHANNEL_ID
+DISCORD_GOOD_FIRST_ISSUES_CHANNEL_ID
+DISCORD_CONTRIBUTE_FORUM_CHANNEL_ID
+DISCORD_CODE_REVIEW_CHANNEL_ID
 ```
 
 ## Local Workflow Test
@@ -39,18 +45,16 @@ From this repository root:
 node .github/scripts/enqueue-discord-announcement.mjs --dry-run
 ```
 
-The dry run prints only job metadata and changed paths. It does not connect to
+The dry run prints only job metadata and channel targets. It does not connect to
 Postgres and does not post to Discord.
 
 ## Runtime Flow
 
-1. A push lands on `main`.
+1. A matching issue, PR, or direct `main` push event lands in GitHub.
 2. `.github/workflows/discord-lab-updates.yml` checks out the repo and runs the
    enqueue script.
-3. The script filters for lab content paths such as `skills/`, `foundations/`,
-   `patterns/`, `systems/`, `ecosystem/`, `case-studies/`, `radar/`, and
-   `zh-Hans/`.
-4. If relevant paths changed, it inserts one deduped row into
+3. The script inserts one or more deduped rows into
    `discord_announcement_jobs`.
-5. The local announcer worker claims the pending row, formats the update, posts
-   it to Discord, and marks the row `sent`.
+4. Nova P posts regular feed/forum/PR messages and archives the forum threads
+   it created after mapped GitHub issues close.
+5. CaraP handles channel setup and settings changes.

--- a/.github/discord-lab-updates.md
+++ b/.github/discord-lab-updates.md
@@ -1,0 +1,56 @@
+# Discord Lab Updates Automation
+
+This repository enqueues Discord announcement jobs after pushes to `main`.
+The local worker in `/Users/liqingpan/Projects/agent_skills/agent_skills`
+drains those jobs from Postgres and posts them to the lab-updates Discord
+channel.
+
+## Required GitHub Secret
+
+Create this repository secret in GitHub Actions:
+
+```txt
+PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL
+```
+
+Use the same remote Postgres URL stored locally as
+`PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL` in:
+
+```txt
+~/.codex/state/pathway-discord-announcer/.env
+```
+
+Do not commit the value.
+
+## Optional GitHub Variable
+
+The workflow defaults to channel `1347671631295811595`. To change it without a
+code change, add a repository variable:
+
+```txt
+DISCORD_LAB_UPDATES_CHANNEL_ID
+```
+
+## Local Workflow Test
+
+From this repository root:
+
+```bash
+node .github/scripts/enqueue-discord-announcement.mjs --dry-run
+```
+
+The dry run prints only job metadata and changed paths. It does not connect to
+Postgres and does not post to Discord.
+
+## Runtime Flow
+
+1. A push lands on `main`.
+2. `.github/workflows/discord-lab-updates.yml` checks out the repo and runs the
+   enqueue script.
+3. The script filters for lab content paths such as `skills/`, `foundations/`,
+   `patterns/`, `systems/`, `ecosystem/`, `case-studies/`, `radar/`, and
+   `zh-Hans/`.
+4. If relevant paths changed, it inserts one deduped row into
+   `discord_announcement_jobs`.
+5. The local announcer worker claims the pending row, formats the update, posts
+   it to Discord, and marks the row `sent`.

--- a/.github/scripts/enqueue-discord-announcement.mjs
+++ b/.github/scripts/enqueue-discord-announcement.mjs
@@ -90,7 +90,11 @@ function truncate(value, maxLength) {
   if (text.length <= maxLength) {
     return text;
   }
-  return `${text.slice(0, Math.max(0, maxLength - 1)).trim()}...`;
+  const ellipsis = "...";
+  if (maxLength <= ellipsis.length) {
+    return ellipsis.slice(0, Math.max(0, maxLength));
+  }
+  return `${text.slice(0, maxLength - ellipsis.length).trim()}${ellipsis}`;
 }
 
 function channelIdFor(key) {
@@ -109,13 +113,22 @@ function channelIdFor(key) {
   return null;
 }
 
+function normalizeGitHubRepoFullName(value) {
+  return String(value || "")
+    .trim()
+    .replace(/\.git$/, "")
+    .replace(/^https?:\/\/github\.com\//, "")
+    .replace(/^git@github\.com:/, "")
+    .replace(/^ssh:\/\/git@github\.com\//, "")
+    .replace(/\/$/, "");
+}
+
 function baseRepoInfo(event) {
-  const repoFullName =
+  const repoFullName = normalizeGitHubRepoFullName(
     process.env.GITHUB_REPOSITORY ||
     event.repository?.full_name ||
-    runGit(["config", "--get", "remote.origin.url"], "Prompthon-IO/agentic-lab")
-      .replace(/^https:\/\/github.com\//, "")
-      .replace(/\.git$/, "");
+    runGit(["config", "--get", "remote.origin.url"], "Prompthon-IO/agentic-lab"),
+  );
   return {
     repoFullName,
     repoUrl: event.repository?.html_url || `https://github.com/${repoFullName}`,
@@ -442,6 +455,11 @@ function wantsSsl(databaseUrl) {
 async function enqueueJob(job) {
   const databaseUrl = process.env.PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL;
   if (!databaseUrl) {
+    const message = "Missing required PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL secret; cannot enqueue Discord announcement job.";
+    if (process.env.GITHUB_ACTIONS === "true") {
+      console.error(`::error::${message}`);
+      throw new Error(message);
+    }
     return { skipped: true, reason: "missing_database_secret" };
   }
   if (!job.discordChannelId && job.eventType !== "github_issue_closed_archive_thread") {
@@ -449,9 +467,10 @@ async function enqueueJob(job) {
   }
 
   const { Client } = require("pg");
+  const allowInsecureSsl = process.env.PATHWAY_DISCORD_ANNOUNCER_ALLOW_INSECURE_SSL === "true";
   const client = new Client({
     connectionString: databaseUrl,
-    ssl: wantsSsl(databaseUrl) ? { rejectUnauthorized: false } : undefined,
+    ssl: wantsSsl(databaseUrl) ? { rejectUnauthorized: !allowInsecureSsl } : undefined,
   });
 
   await client.connect();

--- a/.github/scripts/enqueue-discord-announcement.mjs
+++ b/.github/scripts/enqueue-discord-announcement.mjs
@@ -4,8 +4,8 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
 
-const DEFAULT_CHANNEL_ID = "1347671631295811595";
 const require = createRequire(import.meta.url);
+const GOOD_FIRST_LABEL = "good-first-issue";
 const ELIGIBLE_PREFIXES = [
   "case-studies/",
   "contributor-kit/",
@@ -49,8 +49,11 @@ function readEventPayload() {
   if (!eventPath || !fs.existsSync(eventPath)) {
     return {};
   }
-
   return JSON.parse(fs.readFileSync(eventPath, "utf8"));
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
 }
 
 function isZeroSha(value) {
@@ -66,10 +69,6 @@ function changedPathsFromGit({ before, sha }) {
   return output ? output.split(/\r?\n/).filter(Boolean) : [];
 }
 
-function unique(values) {
-  return [...new Set(values.filter(Boolean))];
-}
-
 function isEligiblePath(filePath) {
   return ELIGIBLE_FILES.has(filePath) ||
     ELIGIBLE_PREFIXES.some((prefix) => filePath.startsWith(prefix));
@@ -80,11 +79,10 @@ function firstLine(value) {
 }
 
 function firstParagraph(value) {
-  const normalized = String(value || "")
+  return String(value || "")
     .split(/\r?\n\r?\n/)
     .map((part) => part.replace(/\s+/g, " ").trim())
-    .find(Boolean);
-  return normalized || "";
+    .find(Boolean) || "";
 }
 
 function truncate(value, maxLength) {
@@ -93,6 +91,35 @@ function truncate(value, maxLength) {
     return text;
   }
   return `${text.slice(0, Math.max(0, maxLength - 1)).trim()}...`;
+}
+
+function channelIdFor(key) {
+  if (key === "repo-updates") {
+    return process.env.DISCORD_REPO_UPDATES_CHANNEL_ID || process.env.DISCORD_LAB_UPDATES_CHANNEL_ID || null;
+  }
+  if (key === "good-first-issues-feed") {
+    return process.env.DISCORD_GOOD_FIRST_ISSUES_CHANNEL_ID || null;
+  }
+  if (key === "contribute") {
+    return process.env.DISCORD_CONTRIBUTE_FORUM_CHANNEL_ID || null;
+  }
+  if (key === "code-review") {
+    return process.env.DISCORD_CODE_REVIEW_CHANNEL_ID || process.env.DISCORD_PULL_REQUESTS_CHANNEL_ID || null;
+  }
+  return null;
+}
+
+function baseRepoInfo(event) {
+  const repoFullName =
+    process.env.GITHUB_REPOSITORY ||
+    event.repository?.full_name ||
+    runGit(["config", "--get", "remote.origin.url"], "Prompthon-IO/agentic-lab")
+      .replace(/^https:\/\/github.com\//, "")
+      .replace(/\.git$/, "");
+  return {
+    repoFullName,
+    repoUrl: event.repository?.html_url || `https://github.com/${repoFullName}`,
+  };
 }
 
 function summarizeAreas(paths) {
@@ -112,6 +139,16 @@ function summarizeAreas(paths) {
     return areas[0];
   }
   return `${areas.slice(0, -1).join(", ")} and ${areas.at(-1)}`;
+}
+
+function labels(issue) {
+  return (issue?.labels ?? [])
+    .map((label) => typeof label === "string" ? label : label?.name)
+    .filter(Boolean);
+}
+
+function hasGoodFirstLabel(issue) {
+  return labels(issue).some((label) => label.toLowerCase() === GOOD_FIRST_LABEL);
 }
 
 async function fetchAssociatedPullRequest({ repoFullName, sha, token }) {
@@ -134,98 +171,265 @@ async function fetchAssociatedPullRequest({ repoFullName, sha, token }) {
   if (!response.ok) {
     return null;
   }
-
   const pulls = await response.json();
   return Array.isArray(pulls) && pulls.length ? pulls[0] : null;
 }
 
-function buildAnnouncementJob({ event, pullRequest }) {
-  const repoFullName =
-    process.env.GITHUB_REPOSITORY ||
-    event.repository?.full_name ||
-    runGit(["config", "--get", "remote.origin.url"], "Prompthon-IO/agentic-lab")
-      .replace(/^https:\/\/github.com\//, "")
-      .replace(/\.git$/, "");
-  const sha = process.env.GITHUB_SHA || event.after || runGit(["rev-parse", "HEAD"]);
-  const branch =
-    process.env.GITHUB_REF_NAME ||
-    event.ref?.replace("refs/heads/", "") ||
-    runGit(["branch", "--show-current"], "main");
-  const before = event.before || runGit(["rev-parse", `${sha}^`], "");
-  const changedPaths = changedPathsFromGit({ before, sha });
-  const eligiblePaths = unique(changedPaths.filter(isEligiblePath));
-  const headCommit = event.head_commit || {};
-  const commitMessage = headCommit.message || runGit(["log", "-1", "--pretty=%B"]);
-  const commitTitle = firstLine(commitMessage) || "Repository update";
-  const prTitle = pullRequest?.title || "";
-  const summarySource = firstParagraph(pullRequest?.body) || firstParagraph(commitMessage);
-  const areaSummary = summarizeAreas(eligiblePaths);
-  const changeSummary = truncate(
-    [
-      `Updated ${areaSummary}.`,
-      summarySource || `Latest merged change: ${commitTitle}`,
-    ].join(" "),
-    700,
-  );
-  const repoUrl =
-    event.repository?.html_url ||
-    `https://github.com/${repoFullName}`;
-  const prNumber = pullRequest?.number ?? null;
-  const commitUrl = headCommit.url || `${repoUrl}/commit/${sha}`;
-  const sourceUrl = pullRequest?.html_url || commitUrl;
-
+function makeJob({
+  authorLogin = null,
+  branch = process.env.GITHUB_REF_NAME || "main",
+  changeSummary = null,
+  changedPaths = [],
+  channelKey,
+  commitSha = process.env.GITHUB_SHA || null,
+  dedupeKey,
+  eventType,
+  mergedByLogin = null,
+  payloadJson = {},
+  prNumber = null,
+  prTitle = null,
+  prUrl = null,
+  repoFullName,
+  repoUrl,
+}) {
   return {
-    authorLogin:
-      headCommit.author?.username ||
-      pullRequest?.user?.login ||
-      process.env.GITHUB_ACTOR ||
-      null,
+    authorLogin,
     branch,
     changeSummary,
-    changedPaths: eligiblePaths,
-    channelKey: "lab-updates",
-    commitSha: sha,
-    dedupeKey: `${repoFullName}:${branch}:${sha}:lab-updates`,
-    discordChannelId:
-      process.env.DISCORD_LAB_UPDATES_CHANNEL_ID || DEFAULT_CHANNEL_ID,
-    eligiblePathCount: eligiblePaths.length,
-    eventType: "github_push_main",
+    changedPaths,
+    channelKey,
+    commitSha,
+    dedupeKey,
+    discordChannelId: channelIdFor(channelKey),
+    eligiblePathCount: changedPaths.length,
+    eventType,
     maxAttempts: Number.parseInt(process.env.ANNOUNCER_MAX_ATTEMPTS || "5", 10),
-    mergedByLogin:
-      pullRequest?.merged_by?.login ||
-      headCommit.committer?.username ||
-      process.env.GITHUB_ACTOR ||
-      null,
+    mergedByLogin,
     payloadJson: {
-      allChangedPaths: changedPaths,
-      eventName: process.env.GITHUB_EVENT_NAME || "push",
+      eventName: process.env.GITHUB_EVENT_NAME || null,
       githubRunId: process.env.GITHUB_RUN_ID || null,
-      headCommitUrl: commitUrl,
-      sourceUrl,
       workflow: process.env.GITHUB_WORKFLOW || null,
+      ...payloadJson,
     },
     prNumber,
-    prTitle: prTitle || commitTitle,
-    prUrl: pullRequest?.html_url || null,
+    prTitle,
+    prUrl,
     repoFullName,
     repoUrl,
   };
 }
 
+async function buildPushJobs(event) {
+  const { repoFullName, repoUrl } = baseRepoInfo(event);
+  const sha = process.env.GITHUB_SHA || event.after || runGit(["rev-parse", "HEAD"]);
+  const branch =
+    process.env.GITHUB_REF_NAME ||
+    event.ref?.replace("refs/heads/", "") ||
+    runGit(["branch", "--show-current"], "main");
+  const pullRequest = await fetchAssociatedPullRequest({
+    repoFullName,
+    sha,
+    token: process.env.GITHUB_TOKEN,
+  });
+
+  if (pullRequest) {
+    return [];
+  }
+
+  const before = event.before || runGit(["rev-parse", `${sha}^`], "");
+  const changedPaths = changedPathsFromGit({ before, sha });
+  const eligiblePaths = unique(changedPaths.filter(isEligiblePath));
+  if (!eligiblePaths.length) {
+    return [];
+  }
+
+  const headCommit = event.head_commit || {};
+  const commitMessage = headCommit.message || runGit(["log", "-1", "--pretty=%B"]);
+  const commitTitle = firstLine(commitMessage) || "Repository update";
+  const changeSummary = truncate(
+    [
+      `Updated ${summarizeAreas(eligiblePaths)}.`,
+      firstParagraph(commitMessage) || `Latest direct main update: ${commitTitle}`,
+    ].join(" "),
+    700,
+  );
+  const commitUrl = headCommit.url || `${repoUrl}/commit/${sha}`;
+
+  return [
+    makeJob({
+      authorLogin: headCommit.author?.username || process.env.GITHUB_ACTOR || null,
+      branch,
+      changeSummary,
+      changedPaths: eligiblePaths,
+      channelKey: "repo-updates",
+      commitSha: sha,
+      dedupeKey: `${repoFullName}:${branch}:${sha}:repo-updates`,
+      eventType: "github_push_main",
+      mergedByLogin: headCommit.committer?.username || process.env.GITHUB_ACTOR || null,
+      payloadJson: {
+        allChangedPaths: changedPaths,
+        headCommitUrl: commitUrl,
+        sourceUrl: commitUrl,
+      },
+      prTitle: commitTitle,
+      repoFullName,
+      repoUrl,
+    }),
+  ];
+}
+
+function buildIssueJobs(event) {
+  const action = event.action;
+  const issue = event.issue;
+  if (!issue || !hasGoodFirstLabel(issue)) {
+    return [];
+  }
+
+  const { repoFullName, repoUrl } = baseRepoInfo(event);
+  const issueNumber = issue.number;
+  const issueSummary = truncate(firstParagraph(issue.body), 700);
+  const commonPayload = {
+    forumTagNames: ["good-first-issue"],
+    issue,
+    issueSummary,
+    issueUrl: issue.html_url,
+  };
+
+  if (["opened", "labeled", "edited", "reopened"].includes(action)) {
+    return [
+      makeJob({
+        authorLogin: event.sender?.login || issue.user?.login || null,
+        changeSummary: issueSummary || "A new contributor-friendly issue is ready.",
+        channelKey: "good-first-issues-feed",
+        dedupeKey: `${repoFullName}:issue:${issueNumber}:good-first-feed`,
+        eventType: "github_issue_good_first_feed",
+        payloadJson: commonPayload,
+        prNumber: issueNumber,
+        prTitle: issue.title,
+        prUrl: issue.html_url,
+        repoFullName,
+        repoUrl,
+      }),
+      makeJob({
+        authorLogin: event.sender?.login || issue.user?.login || null,
+        changeSummary: issueSummary || "A new contributor-friendly issue is ready.",
+        channelKey: "contribute",
+        dedupeKey: `${repoFullName}:issue:${issueNumber}:contribute-thread`,
+        eventType: "github_issue_contribute_thread",
+        payloadJson: commonPayload,
+        prNumber: issueNumber,
+        prTitle: issue.title,
+        prUrl: issue.html_url,
+        repoFullName,
+        repoUrl,
+      }),
+    ];
+  }
+
+  if (action === "closed") {
+    return [
+      makeJob({
+        authorLogin: event.sender?.login || null,
+        changeSummary: `Issue closed: ${issue.title}`,
+        channelKey: "contribute",
+        dedupeKey: `${repoFullName}:issue:${issueNumber}:archive:${issue.closed_at || process.env.GITHUB_RUN_ID || "closed"}`,
+        eventType: "github_issue_closed_archive_thread",
+        payloadJson: {
+          ...commonPayload,
+          sourceDedupeKey: `${repoFullName}:issue:${issueNumber}:contribute-thread`,
+        },
+        prNumber: issueNumber,
+        prTitle: issue.title,
+        prUrl: issue.html_url,
+        repoFullName,
+        repoUrl,
+      }),
+    ];
+  }
+
+  return [];
+}
+
+function buildPullRequestJobs(event) {
+  const action = event.action;
+  const pullRequest = event.pull_request;
+  if (!pullRequest) {
+    return [];
+  }
+
+  const { repoFullName, repoUrl } = baseRepoInfo(event);
+  if (["opened", "reopened", "ready_for_review"].includes(action)) {
+    return [
+      makeJob({
+        authorLogin: event.sender?.login || pullRequest.user?.login || null,
+        changeSummary: truncate(firstParagraph(pullRequest.body), 700),
+        channelKey: "code-review",
+        commitSha: pullRequest.head?.sha || process.env.GITHUB_SHA || null,
+        dedupeKey: `${repoFullName}:pr:${pullRequest.number}:${action}:code-review`,
+        eventType: `github_pull_request_${action}`,
+        payloadJson: {
+          pull_request: pullRequest,
+          sourceUrl: pullRequest.html_url,
+        },
+        prNumber: pullRequest.number,
+        prTitle: pullRequest.title,
+        prUrl: pullRequest.html_url,
+        repoFullName,
+        repoUrl,
+      }),
+    ];
+  }
+
+  if (action === "closed" && pullRequest.merged) {
+    const changedPaths = [];
+    return [
+      makeJob({
+        authorLogin: pullRequest.user?.login || null,
+        changeSummary: truncate(firstParagraph(pullRequest.body), 700) || `Merged PR #${pullRequest.number}.`,
+        changedPaths,
+        channelKey: "repo-updates",
+        commitSha: pullRequest.merge_commit_sha || process.env.GITHUB_SHA || null,
+        dedupeKey: `${repoFullName}:pr:${pullRequest.number}:merged:repo-updates`,
+        eventType: "github_pr_merged",
+        mergedByLogin: pullRequest.merged_by?.login || event.sender?.login || null,
+        payloadJson: {
+          pull_request: pullRequest,
+          sourceUrl: pullRequest.html_url,
+        },
+        prNumber: pullRequest.number,
+        prTitle: pullRequest.title,
+        prUrl: pullRequest.html_url,
+        repoFullName,
+        repoUrl,
+      }),
+    ];
+  }
+
+  return [];
+}
+
+async function buildJobs(event) {
+  const eventName = process.env.GITHUB_EVENT_NAME || event.event_name || "";
+  if (eventName === "issues") {
+    return buildIssueJobs(event);
+  }
+  if (eventName === "pull_request") {
+    return buildPullRequestJobs(event);
+  }
+  return buildPushJobs(event);
+}
+
 function publicJobSummary(job) {
   return {
-    branch: job.branch,
-    changedPaths: job.changedPaths,
     channelKey: job.channelKey,
     commitSha: job.commitSha,
     dedupeKey: job.dedupeKey,
     discordChannelId: job.discordChannelId,
-    eligiblePathCount: job.eligiblePathCount,
     eventType: job.eventType,
     prNumber: job.prNumber,
     prTitle: job.prTitle,
     repoFullName: job.repoFullName,
-    sourceUrl: job.payloadJson?.sourceUrl ?? null,
+    sourceUrl: job.payloadJson?.sourceUrl || job.payloadJson?.issueUrl || null,
   };
 }
 
@@ -238,10 +442,10 @@ function wantsSsl(databaseUrl) {
 async function enqueueJob(job) {
   const databaseUrl = process.env.PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL;
   if (!databaseUrl) {
-    console.log(
-      "Skipping Discord announcement enqueue: missing PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL secret.",
-    );
     return { skipped: true, reason: "missing_database_secret" };
+  }
+  if (!job.discordChannelId && job.eventType !== "github_issue_closed_archive_thread") {
+    return { skipped: true, reason: "missing_discord_channel_id" };
   }
 
   const { Client } = require("pg");
@@ -329,27 +533,10 @@ async function enqueueJob(job) {
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const event = readEventPayload();
-  const repoFullName = process.env.GITHUB_REPOSITORY || event.repository?.full_name;
-  const sha = process.env.GITHUB_SHA || event.after || runGit(["rev-parse", "HEAD"]);
-  const pullRequest = await fetchAssociatedPullRequest({
-    repoFullName,
-    sha,
-    token: process.env.GITHUB_TOKEN,
-  });
-  const job = buildAnnouncementJob({ event, pullRequest });
+  const jobs = await buildJobs(event);
 
-  if (!job.eligiblePathCount) {
-    console.log(
-      JSON.stringify(
-        {
-          skipped: true,
-          reason: "no_eligible_paths",
-          summary: publicJobSummary(job),
-        },
-        null,
-        2,
-      ),
-    );
+  if (!jobs.length) {
+    console.log(JSON.stringify({ skipped: true, reason: "no_matching_event" }, null, 2));
     return;
   }
 
@@ -358,7 +545,7 @@ async function main() {
       JSON.stringify(
         {
           dryRun: true,
-          summary: publicJobSummary(job),
+          jobs: jobs.map(publicJobSummary),
         },
         null,
         2,
@@ -367,17 +554,15 @@ async function main() {
     return;
   }
 
-  const result = await enqueueJob(job);
-  console.log(
-    JSON.stringify(
-      {
-        ...result,
-        summary: publicJobSummary(job),
-      },
-      null,
-      2,
-    ),
-  );
+  const results = [];
+  for (const job of jobs) {
+    const result = await enqueueJob(job);
+    results.push({
+      ...result,
+      summary: publicJobSummary(job),
+    });
+  }
+  console.log(JSON.stringify({ results }, null, 2));
 }
 
 main().catch((error) => {

--- a/.github/scripts/enqueue-discord-announcement.mjs
+++ b/.github/scripts/enqueue-discord-announcement.mjs
@@ -171,6 +171,8 @@ function buildAnnouncementJob({ event, pullRequest }) {
     event.repository?.html_url ||
     `https://github.com/${repoFullName}`;
   const prNumber = pullRequest?.number ?? null;
+  const commitUrl = headCommit.url || `${repoUrl}/commit/${sha}`;
+  const sourceUrl = pullRequest?.html_url || commitUrl;
 
   return {
     authorLogin:
@@ -198,7 +200,8 @@ function buildAnnouncementJob({ event, pullRequest }) {
       allChangedPaths: changedPaths,
       eventName: process.env.GITHUB_EVENT_NAME || "push",
       githubRunId: process.env.GITHUB_RUN_ID || null,
-      headCommitUrl: headCommit.url || `${repoUrl}/commit/${sha}`,
+      headCommitUrl: commitUrl,
+      sourceUrl,
       workflow: process.env.GITHUB_WORKFLOW || null,
     },
     prNumber,
@@ -222,6 +225,7 @@ function publicJobSummary(job) {
     prNumber: job.prNumber,
     prTitle: job.prTitle,
     repoFullName: job.repoFullName,
+    sourceUrl: job.payloadJson?.sourceUrl ?? null,
   };
 }
 

--- a/.github/scripts/enqueue-discord-announcement.mjs
+++ b/.github/scripts/enqueue-discord-announcement.mjs
@@ -1,0 +1,382 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+
+const DEFAULT_CHANNEL_ID = "1347671631295811595";
+const require = createRequire(import.meta.url);
+const ELIGIBLE_PREFIXES = [
+  "case-studies/",
+  "contributor-kit/",
+  "ecosystem/",
+  "foundations/",
+  "patterns/",
+  "publications/",
+  "radar/",
+  "reading-paths/",
+  "skills/",
+  "systems/",
+  "zh-Hans/",
+];
+const ELIGIBLE_FILES = new Set([
+  "CODE_OF_CONDUCT.md",
+  "CONTRIBUTING.md",
+  "README.md",
+  "SECURITY.md",
+  "SUPPORT.md",
+]);
+
+function parseArgs(argv) {
+  return {
+    dryRun: argv.includes("--dry-run"),
+  };
+}
+
+function runGit(args, fallback = "") {
+  try {
+    return execFileSync("git", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return fallback;
+  }
+}
+
+function readEventPayload() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath || !fs.existsSync(eventPath)) {
+    return {};
+  }
+
+  return JSON.parse(fs.readFileSync(eventPath, "utf8"));
+}
+
+function isZeroSha(value) {
+  return typeof value === "string" && /^0+$/.test(value);
+}
+
+function changedPathsFromGit({ before, sha }) {
+  const diffArgs =
+    before && sha && !isZeroSha(before)
+      ? ["diff", "--name-only", before, sha]
+      : ["diff-tree", "--no-commit-id", "--name-only", "-r", sha || "HEAD"];
+  const output = runGit(diffArgs);
+  return output ? output.split(/\r?\n/).filter(Boolean) : [];
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function isEligiblePath(filePath) {
+  return ELIGIBLE_FILES.has(filePath) ||
+    ELIGIBLE_PREFIXES.some((prefix) => filePath.startsWith(prefix));
+}
+
+function firstLine(value) {
+  return String(value || "").split(/\r?\n/)[0]?.trim() || "";
+}
+
+function firstParagraph(value) {
+  const normalized = String(value || "")
+    .split(/\r?\n\r?\n/)
+    .map((part) => part.replace(/\s+/g, " ").trim())
+    .find(Boolean);
+  return normalized || "";
+}
+
+function truncate(value, maxLength) {
+  const text = String(value || "").trim();
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return `${text.slice(0, Math.max(0, maxLength - 1)).trim()}...`;
+}
+
+function summarizeAreas(paths) {
+  const areas = unique(
+    paths.map((filePath) => {
+      if (ELIGIBLE_FILES.has(filePath)) {
+        return filePath;
+      }
+      return filePath.split("/")[0];
+    }),
+  ).slice(0, 4);
+
+  if (!areas.length) {
+    return "lab content";
+  }
+  if (areas.length === 1) {
+    return areas[0];
+  }
+  return `${areas.slice(0, -1).join(", ")} and ${areas.at(-1)}`;
+}
+
+async function fetchAssociatedPullRequest({ repoFullName, sha, token }) {
+  if (!repoFullName || !sha || !token || !globalThis.fetch) {
+    return null;
+  }
+
+  const response = await fetch(
+    `https://api.github.com/repos/${repoFullName}/commits/${sha}/pulls`,
+    {
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "user-agent": "pathway-discord-announcer",
+        "x-github-api-version": "2022-11-28",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const pulls = await response.json();
+  return Array.isArray(pulls) && pulls.length ? pulls[0] : null;
+}
+
+function buildAnnouncementJob({ event, pullRequest }) {
+  const repoFullName =
+    process.env.GITHUB_REPOSITORY ||
+    event.repository?.full_name ||
+    runGit(["config", "--get", "remote.origin.url"], "Prompthon-IO/agentic-lab")
+      .replace(/^https:\/\/github.com\//, "")
+      .replace(/\.git$/, "");
+  const sha = process.env.GITHUB_SHA || event.after || runGit(["rev-parse", "HEAD"]);
+  const branch =
+    process.env.GITHUB_REF_NAME ||
+    event.ref?.replace("refs/heads/", "") ||
+    runGit(["branch", "--show-current"], "main");
+  const before = event.before || runGit(["rev-parse", `${sha}^`], "");
+  const changedPaths = changedPathsFromGit({ before, sha });
+  const eligiblePaths = unique(changedPaths.filter(isEligiblePath));
+  const headCommit = event.head_commit || {};
+  const commitMessage = headCommit.message || runGit(["log", "-1", "--pretty=%B"]);
+  const commitTitle = firstLine(commitMessage) || "Repository update";
+  const prTitle = pullRequest?.title || "";
+  const summarySource = firstParagraph(pullRequest?.body) || firstParagraph(commitMessage);
+  const areaSummary = summarizeAreas(eligiblePaths);
+  const changeSummary = truncate(
+    [
+      `Updated ${areaSummary}.`,
+      summarySource || `Latest merged change: ${commitTitle}`,
+    ].join(" "),
+    700,
+  );
+  const repoUrl =
+    event.repository?.html_url ||
+    `https://github.com/${repoFullName}`;
+  const prNumber = pullRequest?.number ?? null;
+
+  return {
+    authorLogin:
+      headCommit.author?.username ||
+      pullRequest?.user?.login ||
+      process.env.GITHUB_ACTOR ||
+      null,
+    branch,
+    changeSummary,
+    changedPaths: eligiblePaths,
+    channelKey: "lab-updates",
+    commitSha: sha,
+    dedupeKey: `${repoFullName}:${branch}:${sha}:lab-updates`,
+    discordChannelId:
+      process.env.DISCORD_LAB_UPDATES_CHANNEL_ID || DEFAULT_CHANNEL_ID,
+    eligiblePathCount: eligiblePaths.length,
+    eventType: "github_push_main",
+    maxAttempts: Number.parseInt(process.env.ANNOUNCER_MAX_ATTEMPTS || "5", 10),
+    mergedByLogin:
+      pullRequest?.merged_by?.login ||
+      headCommit.committer?.username ||
+      process.env.GITHUB_ACTOR ||
+      null,
+    payloadJson: {
+      allChangedPaths: changedPaths,
+      eventName: process.env.GITHUB_EVENT_NAME || "push",
+      githubRunId: process.env.GITHUB_RUN_ID || null,
+      headCommitUrl: headCommit.url || `${repoUrl}/commit/${sha}`,
+      workflow: process.env.GITHUB_WORKFLOW || null,
+    },
+    prNumber,
+    prTitle: prTitle || commitTitle,
+    prUrl: pullRequest?.html_url || null,
+    repoFullName,
+    repoUrl,
+  };
+}
+
+function publicJobSummary(job) {
+  return {
+    branch: job.branch,
+    changedPaths: job.changedPaths,
+    channelKey: job.channelKey,
+    commitSha: job.commitSha,
+    dedupeKey: job.dedupeKey,
+    discordChannelId: job.discordChannelId,
+    eligiblePathCount: job.eligiblePathCount,
+    eventType: job.eventType,
+    prNumber: job.prNumber,
+    prTitle: job.prTitle,
+    repoFullName: job.repoFullName,
+  };
+}
+
+function wantsSsl(databaseUrl) {
+  return /(?:[?&]ssl=true|[?&]sslmode=(?:require|prefer|verify-ca|verify-full))/i.test(
+    databaseUrl,
+  );
+}
+
+async function enqueueJob(job) {
+  const databaseUrl = process.env.PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL;
+  if (!databaseUrl) {
+    console.log(
+      "Skipping Discord announcement enqueue: missing PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL secret.",
+    );
+    return { skipped: true, reason: "missing_database_secret" };
+  }
+
+  const { Client } = require("pg");
+  const client = new Client({
+    connectionString: databaseUrl,
+    ssl: wantsSsl(databaseUrl) ? { rejectUnauthorized: false } : undefined,
+  });
+
+  await client.connect();
+  try {
+    const result = await client.query(
+      `
+        INSERT INTO discord_announcement_jobs (
+          dedupe_key,
+          event_type,
+          repo_full_name,
+          repo_url,
+          branch,
+          commit_sha,
+          pr_number,
+          pr_title,
+          pr_url,
+          merged_by_login,
+          author_login,
+          change_summary,
+          changed_paths,
+          eligible_path_count,
+          channel_key,
+          discord_channel_id,
+          max_attempts,
+          payload_json
+        )
+        VALUES (
+          $1, $2, $3, $4, $5, $6, $7, $8,
+          $9, $10, $11, $12, $13, $14, $15, $16,
+          $17, $18::jsonb
+        )
+        ON CONFLICT (dedupe_key) DO NOTHING
+        RETURNING id, status
+      `,
+      [
+        job.dedupeKey,
+        job.eventType,
+        job.repoFullName,
+        job.repoUrl,
+        job.branch,
+        job.commitSha,
+        job.prNumber,
+        job.prTitle,
+        job.prUrl,
+        job.mergedByLogin,
+        job.authorLogin,
+        job.changeSummary,
+        job.changedPaths,
+        job.eligiblePathCount,
+        job.channelKey,
+        job.discordChannelId,
+        job.maxAttempts,
+        JSON.stringify(job.payloadJson),
+      ],
+    );
+
+    if (result.rowCount > 0) {
+      return {
+        created: true,
+        id: result.rows[0].id,
+        status: result.rows[0].status,
+      };
+    }
+
+    const existing = await client.query(
+      "SELECT id, status FROM discord_announcement_jobs WHERE dedupe_key = $1",
+      [job.dedupeKey],
+    );
+    return {
+      created: false,
+      id: existing.rows[0]?.id ?? null,
+      status: existing.rows[0]?.status ?? null,
+    };
+  } finally {
+    await client.end();
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const event = readEventPayload();
+  const repoFullName = process.env.GITHUB_REPOSITORY || event.repository?.full_name;
+  const sha = process.env.GITHUB_SHA || event.after || runGit(["rev-parse", "HEAD"]);
+  const pullRequest = await fetchAssociatedPullRequest({
+    repoFullName,
+    sha,
+    token: process.env.GITHUB_TOKEN,
+  });
+  const job = buildAnnouncementJob({ event, pullRequest });
+
+  if (!job.eligiblePathCount) {
+    console.log(
+      JSON.stringify(
+        {
+          skipped: true,
+          reason: "no_eligible_paths",
+          summary: publicJobSummary(job),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  if (options.dryRun) {
+    console.log(
+      JSON.stringify(
+        {
+          dryRun: true,
+          summary: publicJobSummary(job),
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const result = await enqueueJob(job);
+  console.log(
+    JSON.stringify(
+      {
+        ...result,
+        summary: publicJobSummary(job),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/.github/workflows/discord-lab-updates.yml
+++ b/.github/workflows/discord-lab-updates.yml
@@ -1,6 +1,19 @@
 name: Discord Lab Updates
 
 on:
+  issues:
+    types:
+      - opened
+      - edited
+      - labeled
+      - reopened
+      - closed
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - closed
   push:
     branches:
       - main
@@ -34,7 +47,11 @@ jobs:
       - name: Enqueue lab update announcement
         env:
           ANNOUNCER_MAX_ATTEMPTS: "5"
+          DISCORD_CODE_REVIEW_CHANNEL_ID: ${{ vars.DISCORD_CODE_REVIEW_CHANNEL_ID }}
+          DISCORD_CONTRIBUTE_FORUM_CHANNEL_ID: ${{ vars.DISCORD_CONTRIBUTE_FORUM_CHANNEL_ID }}
+          DISCORD_GOOD_FIRST_ISSUES_CHANNEL_ID: ${{ vars.DISCORD_GOOD_FIRST_ISSUES_CHANNEL_ID }}
           DISCORD_LAB_UPDATES_CHANNEL_ID: ${{ vars.DISCORD_LAB_UPDATES_CHANNEL_ID || '1347671631295811595' }}
+          DISCORD_REPO_UPDATES_CHANNEL_ID: ${{ vars.DISCORD_REPO_UPDATES_CHANNEL_ID }}
           GITHUB_TOKEN: ${{ github.token }}
           NODE_PATH: ${{ runner.temp }}/discord-announcer-node/node_modules
           PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL: ${{ secrets.PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL }}

--- a/.github/workflows/discord-lab-updates.yml
+++ b/.github/workflows/discord-lab-updates.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: discord-lab-updates-${{ github.ref }}
@@ -39,7 +40,7 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Install Postgres client
+      - name: Install pg Node package
         run: |
           mkdir -p "$RUNNER_TEMP/discord-announcer-node"
           npm install --prefix "$RUNNER_TEMP/discord-announcer-node" --no-save pg@8

--- a/.github/workflows/discord-lab-updates.yml
+++ b/.github/workflows/discord-lab-updates.yml
@@ -1,0 +1,41 @@
+name: Discord Lab Updates
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: discord-lab-updates-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  enqueue-discord-announcement:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Postgres client
+        run: |
+          mkdir -p "$RUNNER_TEMP/discord-announcer-node"
+          npm install --prefix "$RUNNER_TEMP/discord-announcer-node" --no-save pg@8
+
+      - name: Enqueue lab update announcement
+        env:
+          ANNOUNCER_MAX_ATTEMPTS: "5"
+          DISCORD_LAB_UPDATES_CHANNEL_ID: ${{ vars.DISCORD_LAB_UPDATES_CHANNEL_ID || '1347671631295811595' }}
+          GITHUB_TOKEN: ${{ github.token }}
+          NODE_PATH: ${{ runner.temp }}/discord-announcer-node/node_modules
+          PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL: ${{ secrets.PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL }}
+        run: node .github/scripts/enqueue-discord-announcement.mjs


### PR DESCRIPTION
## Summary
- add a push-to-main workflow that enqueues Discord lab update jobs into Postgres
- add a Node enqueue script with path filtering, PR metadata lookup, and dedupe keys
- document the required GitHub secret and optional channel variable

## Verification
- node .github/scripts/enqueue-discord-announcement.mjs --dry-run
- real enqueue SQL test against Postgres, followed by deletion of the temporary test row
- GitHub Actions secret PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL configured
- GitHub Actions variable DISCORD_LAB_UPDATES_CHANNEL_ID configured