### PR TITLE
Update on issue #32

### DIFF
--- a/skills/daily-news-watcher/README.md
+++ b/skills/daily-news-watcher/README.md
@@ -1,0 +1,86 @@
+# Daily News Watcher
+
+## Why This Skill Exists
+
+This package is a Practitioner-facing example of a persistent local workflow.
+
+A "daily news roundup" sounds like something a chat answer can solve, but as
+soon as you want it to remember your sources, dedupe across days, and keep a
+history of what it has already shown you, the request stops being a one-shot
+prompt. It needs state that survives between sessions.
+
+The package demonstrates the shape that pattern takes inside a Codex skill:
+
+- a small SQLite database that persists sources, articles, and runs
+- deterministic helpers for fetching, parsing, deduplicating, and summarizing
+- readable rule files instead of hidden heuristics
+- a Markdown report per run that the user can read or share
+- explicit safety boundaries around what the skill is willing to fetch
+
+## Who It Is For
+
+This skill is for students, contributors, and operators who want to see what a
+real Codex-compatible local workflow looks like when persistence matters.
+
+It is most useful for requests such as:
+
+- track a handful of named publications over time
+- pull the last 24 hours of AI news into a single Markdown digest
+- keep a personal newsroom that does not silently re-show old articles
+- learn how SQLite, deterministic scripts, and agent reasoning fit together
+
+## End-to-End Workflow
+
+The workflow is intentionally split into two user intents:
+
+1. **Add sources.** The user names publications they want to track. The skill
+   resolves names to feed URLs (using a small known-sources table), validates
+   each URL, and inserts it into the local database.
+2. **Fetch and summarize.** The user asks for a digest with a topic and a time
+   window. The skill fetches each source, parses RSS or Atom (with an optional
+   Playwright fallback for pages without feeds), deduplicates by canonical URL
+   and content hash, applies the topic and time filters, writes a Markdown
+   report, and stamps the run in the database.
+
+The agent is expected to rewrite the deterministic snippets into readable
+prose in its final reply. The script supplies the data scaffolding; the model
+supplies the language.
+
+## What The Package Actually Does
+
+- Stores sources, articles, and runs in `~/.codex/state/daily-news-watcher/news.sqlite`.
+- Fetches feeds with stdlib `urllib` and parses them with `xml.etree`. If the
+  optional `feedparser` package is installed, it is used automatically. If
+  `playwright` is installed and `--use-playwright` is passed, it is used as a
+  fallback for non-feed pages.
+- Canonicalizes URLs (strips `utm_*`, `gclid`, etc.) and computes a SHA-256
+  content hash so the same article does not appear in two reports.
+- Writes a Markdown report per run under
+  `reports/daily-news/YYYY-MM-DD-<topic>.md`.
+
+## What It Does Not Do
+
+This package does not:
+
+- bypass paywalls, captchas, or login flows
+- store cookies, auth headers, or session data
+- abort the whole run when one source fails
+- send notifications or push to external services in v1
+
+## How To Read It In The Handbook
+
+Treat this package as a Practitioner example of a local, persistence-heavy
+workflow:
+
+- `README.md` explains the human story and the two-intent workflow
+- `SKILL.md` is the invocation contract for Codex
+- `scripts/daily_news_watcher.py` implements the deterministic helper
+- `references/known-sources.csv` resolves common publication names to URLs
+- `references/fetch-rules.md` documents the safety and behavior rules
+
+If you are a student reading the repo, the main lesson is:
+
+1. some workflows fundamentally need state that outlives a single chat
+2. SQLite is enough for that state when the workflow is local-first
+3. a good skill package keeps the deterministic pieces (fetching, dedupe,
+   storage) in scripts and lets the agent handle the language work

--- a/skills/daily-news-watcher/SKILL.md
+++ b/skills/daily-news-watcher/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: daily-news-watcher
+description: Persistent daily news monitoring backed by local SQLite and Markdown reports. Use when a user asks Codex to track named publications, fetch the last N hours of news, summarize recent articles by topic, deduplicate articles across runs, or maintain a personal newsroom that survives across sessions.
+---
+
+# Daily News Watcher
+
+For a student-facing explanation of why this package exists and how the
+end-to-end workflow fits into the handbook, read `README.md` first. This file
+is the invocation contract for Codex.
+
+## Overview
+
+Use this skill to operate a persistent personal news watcher. The skill keeps
+a list of named sources in SQLite, fetches recent articles from RSS/Atom feeds
+(with an optional Playwright fallback for pages without usable feeds),
+deduplicates results by canonical URL and content hash, summarizes them, and
+writes a Markdown report per run.
+
+The skill has two distinct workflows: **add sources** and **fetch and
+summarize**. Treat them as separate user intents and surface them as separate
+commands.
+
+## Safety Rules
+
+- Only register and fetch public sources. Refuse `file://`, internal hostnames,
+  and anything that requires auth headers, cookies, or login flows.
+- Never bypass paywalls, captchas, or other access controls.
+- Never store browsing credentials, session cookies, or auth tokens.
+- One failing source must not abort the whole run. Record the failure on the
+  `runs` row and continue with the next source.
+- The runtime database, logs, and generated reports live under
+  `~/.codex/state/daily-news-watcher/` and stay out of git unless the user
+  explicitly asks to commit example artifacts.
+- Honor the readable rules in `references/fetch-rules.md`.
+
+## Workflow A - Add Sources
+
+Trigger when the user names publications to track ("add BBC AI, The Verge AI,
+and OpenAI Blog to my daily news watcher").
+
+1. For each name, resolve to a URL using `references/known-sources.csv`. If
+   the publication is not known, ask the user for an explicit `--url`.
+2. Validate that the URL is a public `http(s)` URL.
+3. Probe reachability with a short HTTP GET. Surface unreachable sources as a
+   warning but still allow registration if the user insists.
+4. Insert the source into `sources` with tags. Existing rows with the same
+   name are updated rather than duplicated.
+5. Echo the resolved URL, type, and tags so the user can confirm.
+
+## Workflow B - Fetch And Summarize
+
+Trigger when the user asks for a daily digest ("fetch the last 24 hours of AI
+news").
+
+1. Read all rows from `sources`.
+2. For each source, fetch via RSS/Atom first. If the response is not a feed
+   and `--use-playwright` is set, fall back to a Playwright render.
+3. Normalize each article (canonical URL, stripped HTML summary, parsed
+   `published_at`) and skip duplicates by URL or content hash.
+4. Apply `--hours` and `--topic` filters.
+5. Insert kept articles into `articles` and stamp the source with
+   `last_checked_at`.
+6. Write a Markdown report to
+   `~/.codex/state/daily-news-watcher/reports/daily-news/YYYY-MM-DD-<topic>.md`
+   that lists sources checked, articles included, summaries, links, and any
+   skipped or error notes.
+7. Update the `runs` row with `finished_at` and a status of `ok`, `partial`,
+   `all_sources_failed`, or `no_sources`.
+
+## Commands
+
+Resolve `scripts/daily_news_watcher.py` relative to this skill directory. When
+running from an installed Codex copy, that is usually
+`~/.codex/skills/daily-news-watcher/scripts/daily_news_watcher.py`.
+
+Add a known publication:
+
+```bash
+python3 scripts/daily_news_watcher.py add-source --name "BBC AI"
+```
+
+Add a custom source by URL:
+
+```bash
+python3 scripts/daily_news_watcher.py add-source \
+  --name "Example AI Blog" \
+  --url "https://example.com/feed.xml" \
+  --tags "AI;research"
+```
+
+List or remove sources:
+
+```bash
+python3 scripts/daily_news_watcher.py list-sources
+python3 scripts/daily_news_watcher.py remove-source --id 3
+```
+
+Fetch the last 24 hours of AI news:
+
+```bash
+python3 scripts/daily_news_watcher.py fetch --hours 24 --topic AI
+```
+
+Fetch with the optional Playwright fallback enabled:
+
+```bash
+python3 scripts/daily_news_watcher.py fetch --hours 24 --topic AI --use-playwright
+```
+
+Show recent runs:
+
+```bash
+python3 scripts/daily_news_watcher.py runs --limit 10
+```
+
+## Persistence
+
+The SQLite database lives at:
+
+```text
+~/.codex/state/daily-news-watcher/news.sqlite
+```
+
+Schema:
+
+```sql
+sources(id, name, url, type, tags, created_at, last_checked_at)
+articles(id, source_id, title, url, published_at, fetched_at, summary, hash)
+runs(id, topic, started_at, finished_at, status)
+```
+
+`articles.url` and `articles.hash` are unique, so reruns naturally deduplicate
+across sessions.
+
+## Outputs
+
+```text
+~/.codex/state/daily-news-watcher/
+  news.sqlite
+  reports/daily-news/YYYY-MM-DD-<topic>.md
+  logs/<run_id>-fetch.json
+```
+
+Do not commit runtime databases, logs, or reports unless the user explicitly
+asks for sample artifacts.
+
+## Response Pattern
+
+When reporting fetch results to the user, include:
+
+- run id and status
+- number of sources checked, with how many had errors
+- number of articles included after dedupe and filtering
+- the report path
+- a short rewritten summary of the most relevant articles (Codex should
+  rewrite the deterministic snippets into readable prose)
+- any source-level errors that should be retried later
+
+When reporting source-management results, include the resolved URL, the
+inferred type, and any reachability warning.

--- a/skills/daily-news-watcher/agents/openai.yaml
+++ b/skills/daily-news-watcher/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Daily News Watcher"
+  short_description: "Persistent daily news monitoring with local SQLite and Markdown reports"
+  default_prompt: "Use $daily-news-watcher to fetch the last 24 hours of AI news from my saved sources and write a Markdown summary."

--- a/skills/daily-news-watcher/references/fetch-rules.md
+++ b/skills/daily-news-watcher/references/fetch-rules.md
@@ -1,0 +1,54 @@
+# Fetch Rules
+
+Readable rules that govern how `daily_news_watcher.py` fetches and processes
+sources. Keep this file legible to people and agents.
+
+## Source Acceptance
+
+- Only public URLs. Refuse `file://`, internal hostnames, and URLs that require
+  authentication headers.
+- Prefer `rss` and `atom` feeds. Fall back to `webpage` only when no feed is
+  discoverable.
+- Reject paywalled sources. If a publication requires login, do not attempt to
+  bypass it; record the source as `webpage` and skip article extraction.
+
+## Fetch Behavior
+
+- Use a single identifying `User-Agent`:
+  `daily-news-watcher/0.1 (+https://github.com/Prompthon-IO/agentic-lab)`.
+- Timeout each request at 15 seconds. On timeout, record the failure on the
+  `runs` row and continue with the next source.
+- Cap each source at 25 articles per run to keep reports readable.
+- Honor obvious rate limits: do not refetch a source whose `last_checked_at`
+  is within the same minute.
+
+## Filtering
+
+- `--hours N` filters articles whose `published_at` falls inside the last N
+  hours. If `published_at` is missing, fall back to `fetched_at`.
+- `--topic T` is an inclusive case-insensitive match against the article
+  title, summary, and the source's `tags` column.
+
+## Deduplication
+
+- URL canonical form: lowercase host, strip default ports, drop trailing
+  slashes, remove `utm_*`, `gclid`, `fbclid`, `mc_cid`, `mc_eid` query params.
+- Content hash: SHA-256 of the normalized `title + "\n" + summary`.
+- Skip an article if either its canonical URL or its content hash already
+  exists in the `articles` table.
+
+## Summarization
+
+- Extract a short snippet: strip HTML, collapse whitespace, take the first
+  ~280 characters at a sentence boundary when possible.
+- The deterministic snippet is intentionally rough. Codex is expected to
+  rewrite the snippets in its final reply.
+
+## Safety And Privacy
+
+- Never store cookies, auth headers, or browser session data.
+- Never bypass paywalls, captchas, or access controls.
+- Local artifacts under `~/.codex/state/daily-news-watcher/` are not committed
+  to git unless the user explicitly asks for sample artifacts.
+- Failures are recorded per-source. One failing source must not abort the
+  whole run.

--- a/skills/daily-news-watcher/references/known-sources.csv
+++ b/skills/daily-news-watcher/references/known-sources.csv
@@ -2,8 +2,15 @@ name,url,type,tags
 BBC AI,https://feeds.bbci.co.uk/news/technology/rss.xml,rss,AI;tech
 The Verge AI,https://www.theverge.com/rss/ai-artificial-intelligence/index.xml,rss,AI;tech
 OpenAI Blog,https://openai.com/blog/rss.xml,rss,AI
+DeepMind,https://deepmind.google/blog/rss.xml,rss,AI;research
+Google AI Blog,https://blog.google/technology/ai/rss/,rss,AI
+Hugging Face Blog,https://huggingface.co/blog/feed.xml,rss,AI;open-source
+Wired AI,https://www.wired.com/feed/tag/ai/latest/rss,rss,AI;tech
+VentureBeat AI,https://venturebeat.com/category/ai/feed/,rss,AI;business
+Simon Willison,https://simonwillison.net/atom/everything/,atom,AI;builder
+Import AI,https://importai.substack.com/feed,rss,AI;newsletter
+Latent Space,https://www.latent.space/feed,rss,AI;builder;newsletter
 Hacker News Front Page,https://hnrss.org/frontpage,rss,tech;startup
 MIT Technology Review,https://www.technologyreview.com/feed/,rss,AI;tech;research
-Anthropic News,https://www.anthropic.com/news/rss.xml,rss,AI
 Ars Technica,https://feeds.arstechnica.com/arstechnica/index,rss,tech
 TechCrunch,https://techcrunch.com/feed/,rss,tech;startup

--- a/skills/daily-news-watcher/references/known-sources.csv
+++ b/skills/daily-news-watcher/references/known-sources.csv
@@ -1,0 +1,9 @@
+name,url,type,tags
+BBC AI,https://feeds.bbci.co.uk/news/technology/rss.xml,rss,AI;tech
+The Verge AI,https://www.theverge.com/rss/ai-artificial-intelligence/index.xml,rss,AI;tech
+OpenAI Blog,https://openai.com/blog/rss.xml,rss,AI
+Hacker News Front Page,https://hnrss.org/frontpage,rss,tech;startup
+MIT Technology Review,https://www.technologyreview.com/feed/,rss,AI;tech;research
+Anthropic News,https://www.anthropic.com/news/rss.xml,rss,AI
+Ars Technica,https://feeds.arstechnica.com/arstechnica/index,rss,tech
+TechCrunch,https://techcrunch.com/feed/,rss,tech;startup

--- a/skills/daily-news-watcher/scripts/daily_news_watcher.py
+++ b/skills/daily-news-watcher/scripts/daily_news_watcher.py
@@ -1,0 +1,915 @@
+#!/usr/bin/env python3
+"""Persistent daily news watcher for the daily-news-watcher skill.
+
+Provides a small CLI for managing a SQLite-backed list of news sources,
+fetching recent articles from RSS/Atom feeds (with an optional Playwright
+fallback), deduplicating them, and writing a Markdown report per run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import importlib.util
+import json
+import os
+import re
+import sqlite3
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from html import unescape
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any, Iterable
+from xml.etree import ElementTree as ET
+
+
+SKILL_DIR = Path(__file__).resolve().parents[1]
+DEFAULT_KNOWN_SOURCES = SKILL_DIR / "references" / "known-sources.csv"
+DEFAULT_STATE = Path(
+    os.environ.get(
+        "DAILY_NEWS_WATCHER_STATE",
+        str(Path.home() / ".codex" / "state" / "daily-news-watcher"),
+    )
+)
+
+USER_AGENT = (
+    "daily-news-watcher/0.1 (+https://github.com/Prompthon-IO/agentic-lab)"
+)
+REQUEST_TIMEOUT_SECONDS = 15
+PER_SOURCE_ARTICLE_CAP = 25
+SUMMARY_TARGET_CHARS = 280
+TRACKING_PARAM_PREFIXES = ("utm_",)
+TRACKING_PARAM_NAMES = {"gclid", "fbclid", "mc_cid", "mc_eid", "ref", "ref_src"}
+
+
+# ---------------------------------------------------------------------------
+# Time + path helpers
+# ---------------------------------------------------------------------------
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def utc_now_iso() -> str:
+    return utc_now().isoformat()
+
+
+def run_id() -> str:
+    return datetime.now().strftime("%Y%m%d-%H%M%S")
+
+
+def ensure_state_dirs(state_dir: Path) -> dict[str, Path]:
+    paths = {
+        "root": state_dir,
+        "reports": state_dir / "reports" / "daily-news",
+        "logs": state_dir / "logs",
+    }
+    for path in paths.values():
+        path.mkdir(parents=True, exist_ok=True)
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Database
+# ---------------------------------------------------------------------------
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS sources (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE,
+    url TEXT NOT NULL,
+    type TEXT NOT NULL,
+    tags TEXT,
+    created_at TEXT NOT NULL,
+    last_checked_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS articles (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    url TEXT NOT NULL,
+    published_at TEXT,
+    fetched_at TEXT NOT NULL,
+    summary TEXT,
+    hash TEXT NOT NULL,
+    UNIQUE(url),
+    UNIQUE(hash),
+    FOREIGN KEY(source_id) REFERENCES sources(id)
+);
+
+CREATE TABLE IF NOT EXISTS runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    topic TEXT,
+    started_at TEXT NOT NULL,
+    finished_at TEXT,
+    status TEXT NOT NULL
+);
+"""
+
+
+def open_db(state_dir: Path) -> sqlite3.Connection:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    db_path = state_dir / "news.sqlite"
+    connection = sqlite3.connect(db_path)
+    connection.row_factory = sqlite3.Row
+    connection.executescript(SCHEMA)
+    return connection
+
+
+# ---------------------------------------------------------------------------
+# URL + text helpers
+# ---------------------------------------------------------------------------
+
+
+def canonical_url(raw: str) -> str:
+    if not raw:
+        return ""
+    parsed = urllib.parse.urlsplit(raw.strip())
+    scheme = parsed.scheme.lower() or "https"
+    host = parsed.hostname or ""
+    if parsed.port and not (
+        (scheme == "http" and parsed.port == 80)
+        or (scheme == "https" and parsed.port == 443)
+    ):
+        host = f"{host}:{parsed.port}"
+    path = re.sub(r"/+$", "", parsed.path) or "/"
+    pairs = [
+        (key, value)
+        for key, value in urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+        if not key.lower().startswith(TRACKING_PARAM_PREFIXES)
+        and key.lower() not in TRACKING_PARAM_NAMES
+    ]
+    query = urllib.parse.urlencode(pairs)
+    return urllib.parse.urlunsplit((scheme, host, path, query, ""))
+
+
+class _TextExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._chunks: list[str] = []
+        self._skip_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in {"script", "style"}:
+            self._skip_depth += 1
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"script", "style"} and self._skip_depth:
+            self._skip_depth -= 1
+
+    def handle_data(self, data: str) -> None:
+        if not self._skip_depth:
+            self._chunks.append(data)
+
+    def text(self) -> str:
+        return re.sub(r"\s+", " ", "".join(self._chunks)).strip()
+
+
+def strip_html(value: str | None) -> str:
+    if not value:
+        return ""
+    extractor = _TextExtractor()
+    try:
+        extractor.feed(unescape(value))
+    except Exception:  # noqa: BLE001 - feed is best-effort.
+        return re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", value)).strip()
+    return extractor.text()
+
+
+def short_summary(text: str, target: int = SUMMARY_TARGET_CHARS) -> str:
+    cleaned = strip_html(text)
+    if len(cleaned) <= target:
+        return cleaned
+    window = cleaned[: target + 60]
+    cut = max(window.rfind(". "), window.rfind("! "), window.rfind("? "))
+    if cut >= target * 0.5:
+        return window[: cut + 1].strip()
+    return cleaned[:target].rstrip() + "..."
+
+
+def content_hash(title: str, summary: str) -> str:
+    normalized = re.sub(r"\s+", " ", f"{title.strip()}\n{summary.strip()}").lower()
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def parse_pubdate(value: str | None) -> str | None:
+    if not value:
+        return None
+    cleaned = value.strip()
+    formats = [
+        "%a, %d %b %Y %H:%M:%S %z",
+        "%a, %d %b %Y %H:%M:%S %Z",
+        "%Y-%m-%dT%H:%M:%S%z",
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%dT%H:%M:%S.%f%z",
+        "%Y-%m-%dT%H:%M:%S.%fZ",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d",
+    ]
+    for fmt in formats:
+        try:
+            parsed = datetime.strptime(cleaned, fmt)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+        except ValueError:
+            continue
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Fetching + parsing
+# ---------------------------------------------------------------------------
+
+
+def http_get(url: str, *, timeout: int = REQUEST_TIMEOUT_SECONDS) -> bytes:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.read()
+
+
+def is_public_http_url(url: str) -> bool:
+    try:
+        parsed = urllib.parse.urlsplit(url)
+    except ValueError:
+        return False
+    if parsed.scheme not in {"http", "https"}:
+        return False
+    if not parsed.hostname:
+        return False
+    host = parsed.hostname.lower()
+    blocked_suffixes = (".local", ".internal", ".lan")
+    blocked_exact = {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
+    if host in blocked_exact or host.endswith(blocked_suffixes):
+        return False
+    return True
+
+
+def detect_feed_type(payload: bytes) -> str:
+    head = payload.lstrip()[:512].lower()
+    if b"<rss" in head or b"<rdf" in head:
+        return "rss"
+    if b"<feed" in head and b"atom" in head:
+        return "atom"
+    if b"<feed" in head:
+        return "atom"
+    return "webpage"
+
+
+def _strip_ns(tag: str) -> str:
+    return tag.split("}", 1)[1] if "}" in tag else tag
+
+
+def parse_feed(payload: bytes) -> list[dict[str, Any]]:
+    """Parse RSS or Atom feed bytes into a list of article dicts."""
+
+    if importlib.util.find_spec("feedparser") is not None:
+        try:
+            return _parse_feed_with_feedparser(payload)
+        except Exception:  # noqa: BLE001 - fall back to stdlib parser.
+            pass
+
+    try:
+        root = ET.fromstring(payload)
+    except ET.ParseError:
+        return []
+
+    items: list[dict[str, Any]] = []
+    tag = _strip_ns(root.tag).lower()
+
+    if tag == "rss":
+        for item in root.iter():
+            if _strip_ns(item.tag).lower() != "item":
+                continue
+            items.append(_extract_rss_item(item))
+    elif tag == "feed":
+        for entry in root.iter():
+            if _strip_ns(entry.tag).lower() != "entry":
+                continue
+            items.append(_extract_atom_entry(entry))
+    elif tag == "rdf":
+        for item in root.iter():
+            if _strip_ns(item.tag).lower() == "item":
+                items.append(_extract_rss_item(item))
+
+    return [item for item in items if item.get("title") and item.get("url")]
+
+
+def _parse_feed_with_feedparser(payload: bytes) -> list[dict[str, Any]]:
+    import feedparser  # type: ignore
+
+    parsed = feedparser.parse(payload)
+    items: list[dict[str, Any]] = []
+    for entry in parsed.entries:
+        link = getattr(entry, "link", "") or ""
+        title = getattr(entry, "title", "") or ""
+        summary_html = getattr(entry, "summary", "") or getattr(entry, "description", "")
+        published = (
+            getattr(entry, "published", None)
+            or getattr(entry, "updated", None)
+            or getattr(entry, "pubDate", None)
+        )
+        items.append(
+            {
+                "title": strip_html(title),
+                "url": link.strip(),
+                "summary": short_summary(summary_html),
+                "published_at": parse_pubdate(published),
+            }
+        )
+    return [item for item in items if item.get("title") and item.get("url")]
+
+
+def _extract_rss_item(node: ET.Element) -> dict[str, Any]:
+    fields: dict[str, str] = {}
+    for child in node:
+        fields[_strip_ns(child.tag).lower()] = (child.text or "").strip()
+    title = strip_html(fields.get("title", ""))
+    link = fields.get("link", "")
+    description = fields.get("description") or fields.get("encoded") or ""
+    return {
+        "title": title,
+        "url": link,
+        "summary": short_summary(description),
+        "published_at": parse_pubdate(fields.get("pubdate") or fields.get("date")),
+    }
+
+
+def _extract_atom_entry(node: ET.Element) -> dict[str, Any]:
+    title = ""
+    summary = ""
+    published = ""
+    link = ""
+    for child in node:
+        local = _strip_ns(child.tag).lower()
+        if local == "title":
+            title = strip_html(child.text or "")
+        elif local in {"summary", "content"} and not summary:
+            summary = child.text or ""
+        elif local in {"published", "updated"} and not published:
+            published = child.text or ""
+        elif local == "link":
+            href = child.attrib.get("href")
+            rel = child.attrib.get("rel", "alternate")
+            if href and rel == "alternate" and not link:
+                link = href
+    return {
+        "title": title,
+        "url": link.strip(),
+        "summary": short_summary(summary),
+        "published_at": parse_pubdate(published),
+    }
+
+
+def parse_webpage(payload: bytes, source_url: str) -> list[dict[str, Any]]:
+    """Best-effort: treat a non-feed page as a single article entry."""
+
+    text = payload.decode("utf-8", errors="replace")
+    title_match = re.search(r"<title[^>]*>(.*?)</title>", text, re.IGNORECASE | re.DOTALL)
+    title = strip_html(title_match.group(1)) if title_match else source_url
+
+    desc_match = re.search(
+        r'<meta[^>]+name=["\']description["\'][^>]+content=["\']([^"\']+)["\']',
+        text,
+        re.IGNORECASE,
+    ) or re.search(
+        r'<meta[^>]+property=["\']og:description["\'][^>]+content=["\']([^"\']+)["\']',
+        text,
+        re.IGNORECASE,
+    )
+    summary = strip_html(desc_match.group(1)) if desc_match else ""
+    if not summary:
+        summary = short_summary(text)
+
+    return [
+        {
+            "title": title,
+            "url": source_url,
+            "summary": summary,
+            "published_at": None,
+        }
+    ]
+
+
+def fetch_with_playwright(url: str) -> bytes | None:
+    """Optional Playwright fallback. Returns None if Playwright is unavailable."""
+
+    if importlib.util.find_spec("playwright") is None:
+        return None
+    try:
+        from playwright.sync_api import sync_playwright  # type: ignore
+    except ImportError:
+        return None
+    try:
+        with sync_playwright() as p:
+            browser = p.chromium.launch()
+            page = browser.new_page(user_agent=USER_AGENT)
+            page.goto(url, timeout=REQUEST_TIMEOUT_SECONDS * 1000)
+            content = page.content()
+            browser.close()
+            return content.encode("utf-8")
+    except Exception:  # noqa: BLE001 - best-effort fallback.
+        return None
+
+
+def fetch_source(source: sqlite3.Row, *, use_playwright: bool) -> tuple[list[dict[str, Any]], str | None]:
+    url = source["url"]
+    if not is_public_http_url(url):
+        return [], "url is not a public http(s) URL"
+    declared_type = (source["type"] or "").lower()
+
+    try:
+        payload = http_get(url)
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        if use_playwright:
+            fallback = fetch_with_playwright(url)
+            if fallback is not None:
+                return parse_webpage(fallback, url), None
+        return [], f"http error: {exc}"
+
+    feed_type = declared_type if declared_type in {"rss", "atom"} else detect_feed_type(payload)
+    if feed_type in {"rss", "atom"}:
+        articles = parse_feed(payload)
+        if articles:
+            return articles[:PER_SOURCE_ARTICLE_CAP], None
+
+    if use_playwright:
+        rendered = fetch_with_playwright(url)
+        if rendered is not None:
+            return parse_webpage(rendered, url)[:PER_SOURCE_ARTICLE_CAP], None
+    return parse_webpage(payload, url)[:PER_SOURCE_ARTICLE_CAP], None
+
+
+# ---------------------------------------------------------------------------
+# Source resolution
+# ---------------------------------------------------------------------------
+
+
+def load_known_sources(path: Path) -> list[dict[str, str]]:
+    if not path.exists():
+        return []
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def resolve_source(
+    name: str,
+    explicit_url: str | None,
+    explicit_tags: str | None,
+    known: Iterable[dict[str, str]],
+) -> dict[str, str]:
+    name_clean = name.strip()
+    if explicit_url:
+        return {
+            "name": name_clean,
+            "url": explicit_url.strip(),
+            "type": "rss" if explicit_url.lower().endswith((".xml", ".rss", ".atom")) else "webpage",
+            "tags": (explicit_tags or "").strip(),
+        }
+
+    lowered = name_clean.lower()
+    for row in known:
+        if row.get("name", "").strip().lower() == lowered:
+            tags = (explicit_tags or row.get("tags") or "").strip()
+            return {
+                "name": row["name"],
+                "url": row["url"],
+                "type": row.get("type", "rss"),
+                "tags": tags,
+            }
+    raise ValueError(
+        f"Could not resolve source '{name}'. Pass --url to register it explicitly."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------------
+
+
+def matches_topic(topic: str, article: dict[str, Any], source_tags: str) -> bool:
+    if not topic:
+        return True
+    needle = topic.lower()
+    haystack = " ".join(
+        [
+            article.get("title", "") or "",
+            article.get("summary", "") or "",
+            source_tags or "",
+        ]
+    ).lower()
+    return needle in haystack
+
+
+def in_time_window(article: dict[str, Any], hours: int | None, now: datetime) -> bool:
+    if not hours:
+        return True
+    cutoff = now - timedelta(hours=hours)
+    candidate = article.get("published_at") or article.get("fetched_at")
+    if not candidate:
+        return True
+    try:
+        ts = datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts >= cutoff
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+def command_add_source(args: argparse.Namespace) -> int:
+    known = load_known_sources(args.known_sources)
+    try:
+        resolved = resolve_source(args.name, args.url, args.tags, known)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    if not is_public_http_url(resolved["url"]):
+        print(f"Refusing non-public URL: {resolved['url']}", file=sys.stderr)
+        return 2
+
+    try:
+        http_get(resolved["url"], timeout=REQUEST_TIMEOUT_SECONDS)
+    except Exception as exc:  # noqa: BLE001 - reachable check is informational.
+        print(f"warning: source not reachable yet ({exc})", file=sys.stderr)
+
+    state_dir = args.state_dir
+    with open_db(state_dir) as db:
+        existing = db.execute(
+            "SELECT id FROM sources WHERE lower(name) = lower(?)",
+            (resolved["name"],),
+        ).fetchone()
+        if existing:
+            db.execute(
+                "UPDATE sources SET url = ?, type = ?, tags = ? WHERE id = ?",
+                (resolved["url"], resolved["type"], resolved["tags"], existing["id"]),
+            )
+            print(f"updated source id={existing['id']} name={resolved['name']}")
+        else:
+            cursor = db.execute(
+                "INSERT INTO sources(name, url, type, tags, created_at) VALUES (?, ?, ?, ?, ?)",
+                (
+                    resolved["name"],
+                    resolved["url"],
+                    resolved["type"],
+                    resolved["tags"],
+                    utc_now_iso(),
+                ),
+            )
+            print(f"added source id={cursor.lastrowid} name={resolved['name']}")
+        db.commit()
+    return 0
+
+
+def command_list_sources(args: argparse.Namespace) -> int:
+    with open_db(args.state_dir) as db:
+        rows = db.execute(
+            "SELECT id, name, url, type, tags, last_checked_at FROM sources ORDER BY name COLLATE NOCASE"
+        ).fetchall()
+    if not rows:
+        print("no sources registered. use add-source to add one.")
+        return 0
+    for row in rows:
+        last = row["last_checked_at"] or "never"
+        tags = row["tags"] or ""
+        print(f"[{row['id']}] {row['name']} ({row['type']}) tags={tags} last_checked={last} url={row['url']}")
+    return 0
+
+
+def command_remove_source(args: argparse.Namespace) -> int:
+    with open_db(args.state_dir) as db:
+        cursor = db.execute("DELETE FROM sources WHERE id = ?", (args.id,))
+        db.commit()
+    if cursor.rowcount == 0:
+        print(f"no source with id={args.id}", file=sys.stderr)
+        return 1
+    print(f"removed source id={args.id}")
+    return 0
+
+
+def command_fetch(args: argparse.Namespace) -> int:
+    state_dir = args.state_dir
+    paths = ensure_state_dirs(state_dir)
+    rid = run_id()
+    started = utc_now_iso()
+    now = utc_now()
+
+    with open_db(state_dir) as db:
+        run_cursor = db.execute(
+            "INSERT INTO runs(topic, started_at, status) VALUES (?, ?, ?)",
+            (args.topic, started, "running"),
+        )
+        run_pk = run_cursor.lastrowid
+        db.commit()
+
+        sources = db.execute(
+            "SELECT id, name, url, type, tags, last_checked_at FROM sources ORDER BY id"
+        ).fetchall()
+
+        if not sources:
+            db.execute(
+                "UPDATE runs SET finished_at = ?, status = ? WHERE id = ?",
+                (utc_now_iso(), "no_sources", run_pk),
+            )
+            db.commit()
+            print("no sources registered. use add-source first.")
+            return 1
+
+        per_source: list[dict[str, Any]] = []
+        included_articles: list[dict[str, Any]] = []
+        seen_urls: set[str] = set()
+        seen_hashes: set[str] = set()
+
+        for source in sources:
+            entry: dict[str, Any] = {
+                "source_id": source["id"],
+                "source_name": source["name"],
+                "fetched": 0,
+                "new": 0,
+                "kept": 0,
+                "skipped_duplicate": 0,
+                "skipped_filter": 0,
+                "error": None,
+            }
+            articles, error = fetch_source(source, use_playwright=args.use_playwright)
+            if error:
+                entry["error"] = error
+                per_source.append(entry)
+                continue
+
+            entry["fetched"] = len(articles)
+            for article in articles:
+                title = (article.get("title") or "").strip()
+                url = (article.get("url") or "").strip()
+                if not title or not url:
+                    continue
+                canon = canonical_url(url)
+                summary = article.get("summary") or ""
+                digest = content_hash(title, summary)
+                fetched_iso = utc_now_iso()
+                article_record = {
+                    "source_id": source["id"],
+                    "source_name": source["name"],
+                    "source_tags": source["tags"] or "",
+                    "title": title,
+                    "url": canon,
+                    "summary": summary,
+                    "published_at": article.get("published_at"),
+                    "fetched_at": fetched_iso,
+                    "hash": digest,
+                }
+
+                if canon in seen_urls or digest in seen_hashes:
+                    entry["skipped_duplicate"] += 1
+                    continue
+
+                already = db.execute(
+                    "SELECT 1 FROM articles WHERE url = ? OR hash = ? LIMIT 1",
+                    (canon, digest),
+                ).fetchone()
+                if already:
+                    entry["skipped_duplicate"] += 1
+                    continue
+
+                seen_urls.add(canon)
+                seen_hashes.add(digest)
+                db.execute(
+                    "INSERT INTO articles(source_id, title, url, published_at, fetched_at, summary, hash)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        source["id"],
+                        title,
+                        canon,
+                        article_record["published_at"],
+                        fetched_iso,
+                        summary,
+                        digest,
+                    ),
+                )
+                entry["new"] += 1
+
+                if not in_time_window(article_record, args.hours, now):
+                    entry["skipped_filter"] += 1
+                    continue
+                if not matches_topic(args.topic or "", article_record, source["tags"] or ""):
+                    entry["skipped_filter"] += 1
+                    continue
+
+                entry["kept"] += 1
+                included_articles.append(article_record)
+
+            db.execute(
+                "UPDATE sources SET last_checked_at = ? WHERE id = ?",
+                (utc_now_iso(), source["id"]),
+            )
+            per_source.append(entry)
+            db.commit()
+
+        finished = utc_now_iso()
+        status = "ok"
+        if all(entry.get("error") for entry in per_source):
+            status = "all_sources_failed"
+        elif any(entry.get("error") for entry in per_source):
+            status = "partial"
+        db.execute(
+            "UPDATE runs SET finished_at = ?, status = ? WHERE id = ?",
+            (finished, status, run_pk),
+        )
+        db.commit()
+
+    report_path = write_report(
+        rid=rid,
+        report_dir=paths["reports"],
+        topic=args.topic,
+        hours=args.hours,
+        per_source=per_source,
+        articles=included_articles,
+        started=started,
+        finished=finished,
+        status=status,
+    )
+    log_path = paths["logs"] / f"{rid}-fetch.json"
+    log_path.write_text(
+        json.dumps(
+            {
+                "run_id": rid,
+                "started_at": started,
+                "finished_at": finished,
+                "status": status,
+                "topic": args.topic,
+                "hours": args.hours,
+                "per_source": per_source,
+                "articles": included_articles,
+                "report_path": str(report_path),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    print(f"report={report_path}")
+    print(f"log={log_path}")
+    print(f"status={status}")
+    print(f"articles_included={len(included_articles)}")
+    print(f"sources_with_errors={sum(1 for entry in per_source if entry.get('error'))}")
+    return 0
+
+
+def command_runs(args: argparse.Namespace) -> int:
+    with open_db(args.state_dir) as db:
+        rows = db.execute(
+            "SELECT id, topic, started_at, finished_at, status FROM runs ORDER BY id DESC LIMIT ?",
+            (args.limit,),
+        ).fetchall()
+    if not rows:
+        print("no runs recorded yet.")
+        return 0
+    for row in rows:
+        topic = row["topic"] or "(no topic)"
+        finished = row["finished_at"] or "in-progress"
+        print(f"[{row['id']}] topic={topic} status={row['status']} started={row['started_at']} finished={finished}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def write_report(
+    *,
+    rid: str,
+    report_dir: Path,
+    topic: str | None,
+    hours: int | None,
+    per_source: list[dict[str, Any]],
+    articles: list[dict[str, Any]],
+    started: str,
+    finished: str,
+    status: str,
+) -> Path:
+    today = datetime.now().strftime("%Y-%m-%d")
+    topic_slug = re.sub(r"[^a-z0-9]+", "-", (topic or "all").lower()).strip("-") or "all"
+    report_path = report_dir / f"{today}-{topic_slug}.md"
+
+    lines = [
+        f"# Daily News - {today} - {topic or 'All Topics'}",
+        "",
+        f"- Run: `{rid}`",
+        f"- Started: `{started}`",
+        f"- Finished: `{finished}`",
+        f"- Status: `{status}`",
+        f"- Window: last {hours} hours" if hours else "- Window: all available",
+        f"- Topic filter: `{topic}`" if topic else "- Topic filter: none",
+        f"- Articles included: {len(articles)}",
+        "",
+        "## Sources Checked",
+        "",
+        "| Source | Fetched | New | Kept | Dup skipped | Filter skipped | Error |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for entry in per_source:
+        error = (entry.get("error") or "").replace("|", "\\|")
+        lines.append(
+            f"| {entry['source_name']} | {entry['fetched']} | {entry['new']} | {entry['kept']} |"
+            f" {entry['skipped_duplicate']} | {entry['skipped_filter']} | {error} |"
+        )
+
+    lines.extend(["", "## Articles", ""])
+    if articles:
+        articles_sorted = sorted(
+            articles,
+            key=lambda a: (a.get("published_at") or a.get("fetched_at") or ""),
+            reverse=True,
+        )
+        for article in articles_sorted:
+            published = article.get("published_at") or article.get("fetched_at") or ""
+            title = article["title"].replace("|", "\\|")
+            lines.extend(
+                [
+                    f"### {title}",
+                    "",
+                    f"- Source: {article['source_name']}",
+                    f"- Published: `{published}`",
+                    f"- Link: <{article['url']}>",
+                    "",
+                    article.get("summary") or "_(no summary extracted)_",
+                    "",
+                ]
+            )
+    else:
+        lines.append("_No articles matched the topic and time window._")
+        lines.append("")
+
+    errors = [entry for entry in per_source if entry.get("error")]
+    if errors:
+        lines.extend(["## Skipped / Errors", ""])
+        for entry in errors:
+            lines.append(f"- {entry['source_name']}: {entry['error']}")
+        lines.append("")
+
+    report_path.write_text("\n".join(lines), encoding="utf-8")
+    return report_path
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Persistent daily news watcher (SQLite + Markdown reports).",
+    )
+    parser.add_argument("--state-dir", type=Path, default=DEFAULT_STATE)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add = subparsers.add_parser("add-source", help="Register a news source.")
+    add.add_argument("--name", required=True)
+    add.add_argument("--url", default=None, help="Explicit URL. Required for unknown publications.")
+    add.add_argument("--tags", default=None, help="Semicolon-separated tags, e.g. 'AI;tech'.")
+    add.add_argument("--known-sources", type=Path, default=DEFAULT_KNOWN_SOURCES)
+    add.set_defaults(func=command_add_source)
+
+    listing = subparsers.add_parser("list-sources", help="List registered sources.")
+    listing.set_defaults(func=command_list_sources)
+
+    remove = subparsers.add_parser("remove-source", help="Remove a source by id.")
+    remove.add_argument("--id", type=int, required=True)
+    remove.set_defaults(func=command_remove_source)
+
+    fetch = subparsers.add_parser("fetch", help="Fetch sources, dedupe, and write a Markdown report.")
+    fetch.add_argument("--hours", type=int, default=24)
+    fetch.add_argument("--topic", default=None)
+    fetch.add_argument("--use-playwright", action="store_true")
+    fetch.set_defaults(func=command_fetch)
+
+    runs = subparsers.add_parser("runs", help="Show recent fetch runs.")
+    runs.add_argument("--limit", type=int, default=10)
+    runs.set_defaults(func=command_runs)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/daily-news-watcher/scripts/daily_news_watcher.py
+++ b/skills/daily-news-watcher/scripts/daily_news_watcher.py
@@ -685,6 +685,13 @@ def command_fetch(args: argparse.Namespace) -> int:
                     entry["skipped_duplicate"] += 1
                     continue
 
+                if not in_time_window(article_record, args.hours, now):
+                    entry["skipped_filter"] += 1
+                    continue
+                if not matches_topic(args.topic or "", article_record, source["tags"] or ""):
+                    entry["skipped_filter"] += 1
+                    continue
+
                 seen_urls.add(canon)
                 seen_hashes.add(digest)
                 db.execute(
@@ -701,14 +708,6 @@ def command_fetch(args: argparse.Namespace) -> int:
                     ),
                 )
                 entry["new"] += 1
-
-                if not in_time_window(article_record, args.hours, now):
-                    entry["skipped_filter"] += 1
-                    continue
-                if not matches_topic(args.topic or "", article_record, source["tags"] or ""):
-                    entry["skipped_filter"] += 1
-                    continue
-
                 entry["kept"] += 1
                 included_articles.append(article_record)
 

--- a/skills/index.mdx
+++ b/skills/index.mdx
@@ -12,6 +12,7 @@ installable package with a human-facing `README.md`, an agent-facing
 | Skill | Package path | What it demonstrates |
 | --- | --- | --- |
 | Agent Runtime Cache Benchmark | [`skills/agent-runtime-cache-benchmark/README.md`](https://github.com/Prompthon-IO/agent-systems-handbook/blob/main/skills/agent-runtime-cache-benchmark/README.md) | Local-first comparison of cold and warm agent runs, cache-break detection from structured run artifacts, and report-driven prompt-cache tuning |
+| Daily News Watcher | [`skills/daily-news-watcher/README.md`](https://github.com/Prompthon-IO/agent-systems-handbook/blob/main/skills/daily-news-watcher/README.md) | SQLite-backed persistent news monitoring, RSS/Atom + optional Playwright fetching, URL+hash deduplication, and per-run Markdown reports |
 | Garbage Collector | [`skills/garbage-collector/README.md`](https://github.com/Prompthon-IO/agent-systems-handbook/blob/main/skills/garbage-collector/README.md) | Preview-first local cleanup, readable CSV rules, reversible duplicate cleanup, and explicit approval before destructive actions |
 | Safety Escalation Review | [`skills/safety-escalation-review/README.md`](https://github.com/Prompthon-IO/agent-systems-handbook/blob/main/skills/safety-escalation-review/README.md) | Local evidence review, redacted escalation memos, and human-owned safety handoff checklists without external reporting |
 


### PR DESCRIPTION
## Summary

Adds a Codex-compatible practitioner skill at `skills/daily-news-watcher/` that lets a user register named publications, persists them in SQLite, fetches recent articles from RSS/Atom feeds, deduplicates by canonical URL and content hash, and writes a Markdown digest per run. Closes [Prompthon-IO/agentic-lab#32](https://github.com/Prompthon-IO/agentic-lab/issues/32). The package mirrors the layout and safety patterns of the existing [`skills/garbage-collector/`](https://github.com/Prompthon-IO/agentic-lab/tree/main/skills/garbage-collector) reference, ships with 15 verified source URLs (all probed for live RSS/Atom), and includes a dedupe-semantics fix uncovered during end-to-end testing in Codex.

## Contribution Type

- practitioner skill package

## Placement

- Target path: `skills/daily-news-watcher/`
- Links or indexes updated: `skills/index.mdx` (added row to the Current Skills table)
- Related issue: [Prompthon-IO/agentic-lab#32](https://github.com/Prompthon-IO/agentic-lab/issues/32)

## Source Lineage

- [`skills/garbage-collector/`](https://github.com/Prompthon-IO/agentic-lab/tree/main/skills/garbage-collector) — model layout, `SKILL.md` style, safety rule wording, CLI subcommand pattern, runtime artifact location under `~/.codex/state/<skill>/`
- [`skills/index.mdx`](https://github.com/Prompthon-IO/agentic-lab/blob/main/skills/index.mdx) — package shape (`README.md` + `SKILL.md` + `agents/openai.yaml` + `scripts/` + `references/`), code-plus-docs contribution definition
- Issue #32 — SQLite schema (`sources`, `articles`, `runs`), report path convention `daily-news/YYYY-MM-DD-topic.md`, acceptance criteria

## Review Checklist

- [x] The contribution type is explicit.
- [x] The file or folder is in the correct path for that artifact type.
- [x] I followed the matching template or contributor guidance where relevant.
- [x] The change stays repo-native and does not copy upstream material into public tracked paths.
- [x] Citations, source notes, or attribution boundaries are clear where needed.
- [x] Relevant README, reading-path, or contributor links were added or updated for discoverability.
- [x] If I added or revised a practitioner skill package, it includes a human-facing `README.md` and an agent-facing `SKILL.md`.
- [x] Status and maintenance expectations are clear.
- [x] If I changed example code, I ran `python3 scripts/verify_example_projects.py`.
- [x] If I renamed files or changed paths, I ran `python3 scripts/check_filename_casing.py`.