### PR TITLE
Finalize support CTA labels and icons

### DIFF
--- a/snippets/support-cta-zh-Hans.mdx
+++ b/snippets/support-cta-zh-Hans.mdx
@@ -1,7 +1,17 @@
-<div className="not-prose my-4 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700 dark:border-gray-800 dark:bg-gray-900/40 dark:text-gray-300">
-  <div className="flex flex-wrap gap-x-3 gap-y-1">
-    <a className="font-medium no-underline hover:underline" href="https://discord.gg/sDE2HhGTg4" target="_blank" rel="noreferrer">在 Discord 提问</a>
-    <a className="font-medium no-underline hover:underline" href="https://github.com/Prompthon-IO/agent-systems-handbook/issues/new/choose" target="_blank" rel="noreferrer">提交 GitHub Issue</a>
-    <a className="font-medium no-underline hover:underline" href="https://github.com/Prompthon-IO/agent-systems-handbook/blob/main/zh-Hans/SUPPORT.md" target="_blank" rel="noreferrer">阅读支持指南</a>
+<div className="not-prose my-4 rounded-md border border-gray-200 bg-gray-50 p-2 text-sm dark:border-gray-800 dark:bg-gray-900/40">
+  <div className="mb-2 px-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">需要帮助？</div>
+  <div className="flex flex-wrap gap-2">
+    <a className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 no-underline shadow-sm hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:bg-gray-900" href="https://discord.gg/sDE2HhGTg4" target="_blank" rel="noreferrer">
+      <Icon icon="discord" iconType="brands" size={14} color="#6b7280" />
+      <span>在 Discord 提问</span>
+    </a>
+    <a className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 no-underline shadow-sm hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:bg-gray-900" href="https://github.com/Prompthon-IO/agent-systems-handbook/issues/new/choose" target="_blank" rel="noreferrer">
+      <Icon icon="github" iconType="brands" size={14} color="#6b7280" />
+      <span>提交 GitHub Issue</span>
+    </a>
+    <a className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 no-underline shadow-sm hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:bg-gray-900" href="https://github.com/Prompthon-IO/agent-systems-handbook/blob/main/zh-Hans/SUPPORT.md" target="_blank" rel="noreferrer">
+      <Icon icon="life-ring" size={14} color="#6b7280" />
+      <span>支持指南</span>
+    </a>
   </div>
 </div>

--- a/snippets/support-cta-zh-Hans.mdx
+++ b/snippets/support-cta-zh-Hans.mdx
@@ -2,15 +2,15 @@
   <div className="mb-2 px-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">需要帮助？</div>
   <div className="flex flex-wrap gap-2">
     <a className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 no-underline shadow-sm hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:bg-gray-900" href="https://discord.gg/sDE2HhGTg4" target="_blank" rel="noreferrer">
-      <Icon icon="discord" iconType="brands" size={14} color="#6b7280" />
+      <Icon icon="discord" iconType="brands" size={14} />
       <span>在 Discord 提问</span>
     </a>
     <a className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 no-underline shadow-sm hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:bg-gray-900" href="https://github.com/Prompthon-IO/agent-systems-handbook/issues/new/choose" target="_blank" rel="noreferrer">
-      <Icon icon="github" iconType="brands" size={14} color="#6b7280" />
+      <Icon icon="github" iconType="brands" size={14} />
       <span>提交 GitHub Issue</span>
     </a>
     <a className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 no-underline shadow-sm hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:bg-gray-900" href="https://github.com/Prompthon-IO/agent-systems-handbook/blob/main/zh-Hans/SUPPORT.md" target="_blank" rel="noreferrer">
-      <Icon icon="life-ring" size={14} color="#6b7280" />
+      <Icon icon="life-ring" size={14} />
       <span>支持指南</span>
     </a>
   </div>

--- a/snippets/support-cta.mdx
+++ b/snippets/support-cta.mdx
@@ -1,7 +1,17 @@
-<div className="not-prose my-4 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700 dark:border-gray-800 dark:bg-gray-900/40 dark:text-gray-300">
-  <div className="flex flex-wrap gap-x-3 gap-y-1">
-    <a className="font-medium no-underline hover:underline" href="https://discord.gg/sDE2HhGTg4" target="_blank" rel="noreferrer">Ask in Discord</a>
-    <a className="font-medium no-underline hover:underline" href="https://github.com/Prompthon-IO/agent-systems-handbook/issues/new/choose" target="_blank" rel="noreferrer">Open a GitHub issue</a>
-    <a className="font-medium no-underline hover:underline" href="https://github.com/Prompthon-IO/agent-systems-handbook/blob/main/SUPPORT.md" target="_blank" rel="noreferrer">Read the support guide</a>
+<div className="not-prose my-4 rounded-md border border-gray-200 bg-gray-50 p-2 text-sm dark:border-gray-800 dark:bg-gray-900/40">
+  <div className="mb-2 px-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Need help?</div>
+  <div className="flex flex-wrap gap-2">
+    <a className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 no-underline shadow-sm hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:bg-gray-900" href="https://discord.gg/sDE2HhGTg4" target="_blank" rel="noreferrer">
+      <Icon icon="discord" iconType="brands" size={14} color="#6b7280" />
+      <span>Ask in Discord</span>
+    </a>
+    <a className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 no-underline shadow-sm hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:bg-gray-900" href="https://github.com/Prompthon-IO/agent-systems-handbook/issues/new/choose" target="_blank" rel="noreferrer">
+      <Icon icon="github" iconType="brands" size={14} color="#6b7280" />
+      <span>Open GitHub issue</span>
+    </a>
+    <a className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 no-underline shadow-sm hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:bg-gray-900" href="https://github.com/Prompthon-IO/agent-systems-handbook/blob/main/SUPPORT.md" target="_blank" rel="noreferrer">
+      <Icon icon="life-ring" size={14} color="#6b7280" />
+      <span>Support guide</span>
+    </a>
   </div>
 </div>

--- a/snippets/support-cta.mdx
+++ b/snippets/support-cta.mdx
@@ -7,7 +7,7 @@
     </a>
     <a className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 no-underline shadow-sm hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:bg-gray-900" href="https://github.com/Prompthon-IO/agent-systems-handbook/issues/new/choose" target="_blank" rel="noreferrer">
       <Icon icon="github" iconType="brands" size={14} color="#6b7280" />
-      <span>Open GitHub issue</span>
+      <span>Open a GitHub issue</span>
     </a>
     <a className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 no-underline shadow-sm hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:bg-gray-900" href="https://github.com/Prompthon-IO/agent-systems-handbook/blob/main/SUPPORT.md" target="_blank" rel="noreferrer">
       <Icon icon="life-ring" size={14} color="#6b7280" />

--- a/snippets/support-cta.mdx
+++ b/snippets/support-cta.mdx
@@ -2,15 +2,15 @@
   <div className="mb-2 px-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Need help?</div>
   <div className="flex flex-wrap gap-2">
     <a className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 no-underline shadow-sm hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:bg-gray-900" href="https://discord.gg/sDE2HhGTg4" target="_blank" rel="noreferrer">
-      <Icon icon="discord" iconType="brands" size={14} color="#6b7280" />
+      <Icon icon="discord" iconType="brands" size={14} />
       <span>Ask in Discord</span>
     </a>
     <a className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 no-underline shadow-sm hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:bg-gray-900" href="https://github.com/Prompthon-IO/agent-systems-handbook/issues/new/choose" target="_blank" rel="noreferrer">
-      <Icon icon="github" iconType="brands" size={14} color="#6b7280" />
+      <Icon icon="github" iconType="brands" size={14} />
       <span>Open a GitHub issue</span>
     </a>
     <a className="inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white px-3 py-1.5 font-medium text-gray-700 no-underline shadow-sm hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950/60 dark:text-gray-200 dark:hover:bg-gray-900" href="https://github.com/Prompthon-IO/agent-systems-handbook/blob/main/SUPPORT.md" target="_blank" rel="noreferrer">
-      <Icon icon="life-ring" size={14} color="#6b7280" />
+      <Icon icon="life-ring" size={14} />
       <span>Support guide</span>
     </a>
   </div>


### PR DESCRIPTION
## Summary
- Use a GitHub brand icon for the issue action
- Rename the final action to Support guide
- Apply the same wording and icon treatment to the Chinese support CTA

## Validation
- python3 -m json.tool docs.json >/dev/null
- git diff --check
- python3 scripts/verify_example_projects.py
- PATH=/Users/liqingpan/.nvm/versions/node/v20.17.0/bin:$PATH npx mint validate

Follow-up to #75, #77, and #78.