### PR TITLE
chore: add branch release management

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,12 @@
 
 Describe the change in 2-5 sentences. Keep the scope concrete.
 
+## Target Branch
+
+- Normal contributor work targets `develop`.
+- Release PRs target `main` only when opened by `dprat0821` from same-repository `develop`.
+- `main` is the production Mintlify branch and should not receive direct feature PRs.
+
 ## Contribution Type
 
 Select the best match and remove the rest.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Skill Packages
+      labels:
+        - skill package
+    - title: Enhancements
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/scripts/enqueue-discord-announcement.mjs
+++ b/.github/scripts/enqueue-discord-announcement.mjs
@@ -335,6 +335,9 @@ function buildPullRequestJobs(event) {
   if (!pullRequest) {
     return [];
   }
+  if (pullRequest.base?.ref !== "main") {
+    return [];
+  }
 
   const { repoFullName, repoUrl } = baseRepoInfo(event);
   if (["opened", "reopened", "ready_for_review"].includes(action)) {

--- a/.github/workflows/discord-lab-updates.yml
+++ b/.github/workflows/discord-lab-updates.yml
@@ -9,6 +9,8 @@ on:
       - reopened
       - closed
   pull_request:
+    branches:
+      - main
     types:
       - opened
       - reopened

--- a/.github/workflows/main-release-gate.yml
+++ b/.github/workflows/main-release-gate.yml
@@ -1,0 +1,51 @@
+name: Main Release Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - edited
+
+permissions:
+  contents: read
+
+jobs:
+  main-release-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require dprat0821 develop-to-main release PR
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+
+          if [ "$BASE_REF" != "main" ]; then
+            echo "::error::Release PRs must target main."
+            exit 1
+          fi
+
+          if [ "$HEAD_REF" != "develop" ]; then
+            echo "::error::Main release PRs must come from develop, not ${HEAD_REF}."
+            exit 1
+          fi
+
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error::Main release PRs must use the same repository develop branch."
+            exit 1
+          fi
+
+          if [ "$PR_AUTHOR" != "dprat0821" ]; then
+            echo "::error::Only dprat0821 may open release PRs into main."
+            exit 1
+          fi
+
+          echo "Release gate passed for ${HEAD_REPO}:${HEAD_REF} -> ${BASE_REPO}:${BASE_REF} by ${PR_AUTHOR}."

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-main-main
+  cancel-in-progress: false
+
 jobs:
   release-main:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -1,0 +1,60 @@
+name: Release Main
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create date-based release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TZ: America/Toronto
+        run: |
+          set -euo pipefail
+
+          git fetch --tags --force origin
+
+          release_date="$(date +'%Y.%m.%d')"
+          prefix="release-${release_date}."
+          last_number="$(
+            git tag -l "${prefix}*" |
+              while read -r tag; do
+                suffix="${tag#"$prefix"}"
+                case "$suffix" in
+                  ""|*[!0-9]*)
+                    ;;
+                  *)
+                    echo "$suffix"
+                    ;;
+                esac
+              done |
+              sort -n |
+              tail -1
+          )"
+
+          if [ -z "$last_number" ]; then
+            next_number=1
+          else
+            next_number=$((last_number + 1))
+          fi
+
+          tag="${prefix}${next_number}"
+          echo "Creating ${tag} for ${GITHUB_SHA}"
+
+          gh release create "$tag" \
+            --target "$GITHUB_SHA" \
+            --generate-notes \
+            --fail-on-no-commits

--- a/.github/workflows/validate-mintlify.yml
+++ b/.github/workflows/validate-mintlify.yml
@@ -1,0 +1,34 @@
+name: Validate Mintlify
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  push:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-mintlify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Read Node.js version
+        id: node-version
+        run: echo "version=$(cat .node-version)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.node-version.outputs.version }}
+
+      - name: Validate Mintlify docs
+        run: npx --yes mint validate

--- a/.github/workflows/verify-example-projects.yml
+++ b/.github/workflows/verify-example-projects.yml
@@ -3,10 +3,13 @@ name: Verify Example Projects
 on:
   pull_request:
     branches:
+      - develop
       - main
   push:
     branches:
+      - develop
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,11 +99,26 @@ for the routing sequence.
 3. Claim the issue with a visible comment and wait for maintainer
    acknowledgement or the `claimed` label.
 4. Fork the repository if you do not have write access, or create a focused
-   branch from the latest `main` if you do.
+   branch from the latest `develop` if you do.
 5. Place the work in the correct folder using the matching template.
 6. Add or update links from the relevant README or contributor surface.
-7. Open a PR with a short scope summary and the linked issue.
+7. Open a PR into `develop` with a short scope summary and the linked issue.
 8. Review the change against the shared checklist before requesting merge.
+
+## Branch and release flow
+
+`develop` is the shared integration branch for normal contributor work. Use it
+for lab articles, radar notes, source projects, practitioner skill packages,
+reference notes, and repository process changes.
+
+`main` is the production Mintlify branch. Merges into `main` are release events,
+and they trigger production publishing plus a GitHub release/tag. Do not open
+feature or content PRs directly into `main`.
+
+Release PRs into `main` are opened only by `dprat0821` from the same-repository
+`develop` branch. This keeps deployment authorization and release tagging under
+one maintainer account while still allowing contributors to collaborate through
+`develop`.
 
 ## Review standard
 

--- a/contributor-kit/contribution-workflow.mdx
+++ b/contributor-kit/contribution-workflow.mdx
@@ -10,9 +10,10 @@ import SupportCTA from "/snippets/support-cta.mdx";
 Use this flow when you want to report a problem, suggest an improvement, or
 make a contribution to the Agent Systems Handbook.
 
-This is the handbook's practical GitHub flow, not the release-branch model
-sometimes called GitFlow. The sequence is: ask or open an issue, claim the work,
-make a small branch, open a pull request, and respond to review.
+This is the handbook's practical GitHub flow for normal contributor work, not
+the production release flow. The sequence is: ask or open an issue, claim the
+work, make a small branch from `develop`, open a pull request back to
+`develop`, and respond to review.
 
 ## Choose The Right Entry Point
 
@@ -85,7 +86,7 @@ If you do not have write access to the repository, fork it first.
 
 Then work from your fork:
 
-1. Create a branch from the latest `main`.
+1. Create a branch from the latest `develop`.
 2. Keep the branch focused on the claimed issue.
 3. Put the file in the correct contributor lane or template path.
 4. Add or update links so the work is discoverable.
@@ -96,7 +97,10 @@ the same rule applies: one branch should map to one clear issue or outcome.
 
 ## Open The Pull Request
 
-Open the pull request against `Prompthon-IO/agent-systems-handbook:main`.
+Open the pull request against `Prompthon-IO/agent-systems-handbook:develop`.
+
+`main` is reserved for maintainer-run release PRs and Mintlify production
+deployment.
 
 ![GitHub open pull request screen](/assets/contributor-workflow/github-open-pr.png)
 

--- a/zh-Hans/CONTRIBUTING.md
+++ b/zh-Hans/CONTRIBUTING.md
@@ -67,11 +67,24 @@
 1. 选择贡献类型。
 2. 找到或打开定义该工作的 issue。
 3. 用可见评论认领 issue，并等待维护者确认或添加 `claimed` 标签。
-4. 如果没有写权限，请 fork 仓库；如果有写权限，请基于最新 `main` 创建聚焦分支。
+4. 如果没有写权限，请 fork 仓库；如果有写权限，请基于最新 `develop` 创建聚焦分支。
 5. 使用对应模板将工作放到正确的文件夹中。
 6. 从相关 README 或贡献入口添加或更新链接。
-7. 打开一个带有简短范围摘要并链接 issue 的 PR。
+7. 打开一个目标为 `develop`、带有简短范围摘要并链接 issue 的 PR。
 8. 在请求合并之前，根据共享检查清单审查变更。
+
+## 分支与发布流程
+
+`develop` 是普通贡献工作的共享集成分支。Lab 文章、radar 笔记、source
+projects、practitioner skill packages、reference notes，以及仓库流程变更都应先进入
+`develop`。
+
+`main` 是生产环境 Mintlify 分支。合并到 `main` 就是发布事件，会触发生产发布以及
+GitHub release/tag。不要把功能或内容 PR 直接开到 `main`。
+
+进入 `main` 的发布 PR 只能由 `dprat0821` 从同一仓库的 `develop` 分支打开。这样可以把
+部署授权和 release tagging 保持在一个维护者账号下，同时仍然允许贡献者通过
+`develop` 协作。
 
 ## 审核标准
 

--- a/zh-Hans/contributor-kit/contribution-workflow.mdx
+++ b/zh-Hans/contributor-kit/contribution-workflow.mdx
@@ -9,9 +9,9 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 当你想报告问题、提出改进建议，或为 Agent Systems Handbook 做贡献时，请使用这条流程。
 
-这里说的是本手册实际采用的 GitHub 协作流程，不是有 release branch 的正式
-GitFlow 模型。顺序是：提问或创建 issue、认领工作、创建小分支、打开 pull
-request，并回应 review。
+这里说的是本手册普通贡献工作实际采用的 GitHub 协作流程，不是生产发布流程。
+顺序是：提问或创建 issue、认领工作、基于 `develop` 创建小分支、把 pull request
+打回 `develop`，并回应 review。
 
 ## 选择正确入口
 
@@ -72,7 +72,7 @@ Claim request:
 
 然后从你的 fork 工作：
 
-1. 基于最新 `main` 创建分支。
+1. 基于最新 `develop` 创建分支。
 2. 让分支聚焦在已认领的 issue 上。
 3. 把文件放到正确的贡献 lane 或模板路径。
 4. 添加或更新链接，让工作可被发现。
@@ -82,7 +82,9 @@ Claim request:
 
 ## 打开 Pull Request
 
-将 pull request 打到 `Prompthon-IO/agent-systems-handbook:main`。
+将 pull request 打到 `Prompthon-IO/agent-systems-handbook:develop`。
+
+`main` 只保留给维护者执行的发布 PR 和 Mintlify 生产环境部署。
 
 ![GitHub 打开 pull request 的页面](/assets/contributor-workflow/github-open-pr.png)
 


### PR DESCRIPTION
## Summary
- Adds the `develop` integration branch workflow shape and release PR gate for `main`.
- Adds Mintlify validation, date-based main release creation, and GitHub generated release-note categories.
- Updates contributor guidance and filters Discord PR announcements to production-facing `main` PRs.

## Test Plan
- [x] python3 scripts/verify_example_projects.py
- [x] node --check .github/scripts/enqueue-discord-announcement.mjs
- [x] ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path) }' .github/workflows/*.yml .github/release.yml
- [x] PATH="/Users/liqingpan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npx --yes mint validate