### PR TITLE
chore: address release management review

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: release-main-main
+  cancel-in-progress: false
+
 jobs:
   release-main:
     runs-on: ubuntu-latest

--- a/contributor-kit/contribution-workflow.mdx
+++ b/contributor-kit/contribution-workflow.mdx
@@ -10,9 +10,10 @@ import SupportCTA from "/snippets/support-cta.mdx";
 Use this flow when you want to report a problem, suggest an improvement, or
 make a contribution to the Agent Systems Handbook.
 
-This is the handbook's practical GitHub flow, not the release-branch model
-sometimes called GitFlow. The sequence is: ask or open an issue, claim the work,
-make a small branch, open a pull request, and respond to review.
+This is the handbook's practical GitHub flow for normal contributor work, not
+the production release flow. The sequence is: ask or open an issue, claim the
+work, make a small branch from `develop`, open a pull request back to
+`develop`, and respond to review.
 
 ## Choose The Right Entry Point
 
@@ -85,7 +86,7 @@ If you do not have write access to the repository, fork it first.
 
 Then work from your fork:
 
-1. Create a branch from the latest `main`.
+1. Create a branch from the latest `develop`.
 2. Keep the branch focused on the claimed issue.
 3. Put the file in the correct contributor lane or template path.
 4. Add or update links so the work is discoverable.
@@ -96,7 +97,10 @@ the same rule applies: one branch should map to one clear issue or outcome.
 
 ## Open The Pull Request
 
-Open the pull request against `Prompthon-IO/agent-systems-handbook:main`.
+Open the pull request against `Prompthon-IO/agent-systems-handbook:develop`.
+
+`main` is reserved for maintainer-run release PRs and Mintlify production
+deployment.
 
 ![GitHub open pull request screen](/assets/contributor-workflow/github-open-pr.png)
 

--- a/zh-Hans/contributor-kit/contribution-workflow.mdx
+++ b/zh-Hans/contributor-kit/contribution-workflow.mdx
@@ -9,9 +9,9 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 当你想报告问题、提出改进建议，或为 Agent Systems Handbook 做贡献时，请使用这条流程。
 
-这里说的是本手册实际采用的 GitHub 协作流程，不是有 release branch 的正式
-GitFlow 模型。顺序是：提问或创建 issue、认领工作、创建小分支、打开 pull
-request，并回应 review。
+这里说的是本手册普通贡献工作实际采用的 GitHub 协作流程，不是生产发布流程。
+顺序是：提问或创建 issue、认领工作、基于 `develop` 创建小分支、把 pull request
+打回 `develop`，并回应 review。
 
 ## 选择正确入口
 
@@ -72,7 +72,7 @@ Claim request:
 
 然后从你的 fork 工作：
 
-1. 基于最新 `main` 创建分支。
+1. 基于最新 `develop` 创建分支。
 2. 让分支聚焦在已认领的 issue 上。
 3. 把文件放到正确的贡献 lane 或模板路径。
 4. 添加或更新链接，让工作可被发现。
@@ -82,7 +82,9 @@ Claim request:
 
 ## 打开 Pull Request
 
-将 pull request 打到 `Prompthon-IO/agent-systems-handbook:main`。
+将 pull request 打到 `Prompthon-IO/agent-systems-handbook:develop`。
+
+`main` 只保留给维护者执行的发布 PR 和 Mintlify 生产环境部署。
 
 ![GitHub 打开 pull request 的页面](/assets/contributor-workflow/github-open-pr.png)
 


### PR DESCRIPTION
## Summary
- Serializes the `release-main` workflow so rapid main pushes do not race while selecting the next date-based release tag.
- Updates the English contributor workflow guide to use `develop` as the normal PR target.
- Mirrors the same contributor workflow change in the Simplified Chinese guide.

## Review Notes
Addresses the reasonable Copilot review comments on PR #83 about release workflow concurrency and stale contributor workflow guidance.

## Test Plan
- [x] ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path) }' .github/workflows/release-main.yml
- [x] rg -n 'latest `main`|:main|against .*main|打到 `Prompthon-IO/agent-systems-handbook:main`|基于最新 `main`' contributor-kit/contribution-workflow.mdx zh-Hans/contributor-kit/contribution-workflow.mdx || true
- [x] PATH="/Users/liqingpan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npx --yes mint validate
- [x] python3 scripts/verify_example_projects.py
- [x] git diff --check