### PR TITLE
[codex] add docs analytics setup

### DIFF
--- a/WEBSITE.mdx
+++ b/WEBSITE.mdx
@@ -52,7 +52,7 @@ Do not add that active `vercel.json` until the real Mintlify subdomain is known.
 
 ## Analytics and Search Console
 
-Mintlify analytics should be used for documentation-native usage signals such as most-read pages, internal searches, search result clicks, feedback, and assistant activity. Access those reports in the Mintlify dashboard or from an authenticated CLI session with `mint analytics`.
+Mintlify analytics should be used for documentation-native usage signals such as most-read pages, internal searches, search result clicks, feedback, and assistant activity. Access those reports in the Mintlify dashboard or from an authenticated CLI session with `npx mint analytics`.
 
 GA4 is configured through the Mintlify `docs.json` integration with measurement ID `G-K26DVPPVLY`. Use GA4 for external reporting, referral/source analysis, and click-path exploration.
 

--- a/WEBSITE.mdx
+++ b/WEBSITE.mdx
@@ -29,6 +29,8 @@ npx mint broken-links
 
 The primary Mintlify deployment should be connected through the Mintlify GitHub app. Mintlify reads `docs.json` and publishes the documentation site when changes are pushed.
 
+The production documentation site is published at `https://labs.prompthon.io`.
+
 If the handbook should appear under a Vercel-owned domain, configure Vercel as a reverse proxy after the Mintlify subdomain exists:
 
 ```json
@@ -47,6 +49,14 @@ If the handbook should appear under a Vercel-owned domain, configure Vercel as a
 ```
 
 Do not add that active `vercel.json` until the real Mintlify subdomain is known.
+
+## Analytics and Search Console
+
+Mintlify analytics should be used for documentation-native usage signals such as most-read pages, internal searches, search result clicks, feedback, and assistant activity. Access those reports in the Mintlify dashboard or from an authenticated CLI session with `mint analytics`.
+
+GA4 is configured through the Mintlify `docs.json` integration with measurement ID `G-K26DVPPVLY`. Use GA4 for external reporting, referral/source analysis, and click-path exploration.
+
+Google Search Console should use a URL-prefix property for `https://labs.prompthon.io/`. The verification token is committed in `docs.json` as the `google-site-verification` meta tag. After deployment, verify the property and submit `https://labs.prompthon.io/sitemap.xml`.
 
 ## Compatibility Policy
 

--- a/docs.json
+++ b/docs.json
@@ -2,6 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "maple",
   "name": "Agent Systems Handbook by Prompthon",
+  "description": "A practical AI agents handbook for students, practitioners, and builders exploring agent systems, agentic workflows, context engineering, MCP, A2A, evaluation, observability, and multi-agent architecture.",
   "logo": {
     "light": "https://github.com/Prompthon-IO.png?size=96",
     "dark": "https://github.com/Prompthon-IO.png?size=96",
@@ -476,6 +477,16 @@
         }
       }
     ]
+  },
+  "integrations": {
+    "ga4": {
+      "measurementId": "G-K26DVPPVLY"
+    }
+  },
+  "seo": {
+    "metatags": {
+      "google-site-verification": "LlDE8i_8_vKcs6sx68AgnM9ZOjjMQEJXrq7nDZMOdjg"
+    }
   },
   "contextual": {
     "options": [

--- a/zh-Hans/WEBSITE.mdx
+++ b/zh-Hans/WEBSITE.mdx
@@ -29,6 +29,8 @@ npx mint broken-links
 
 主 Mintlify 部署应通过 Mintlify GitHub 应用连接。Mintlify 会读取 `docs.json`，并在推送更改时发布文档站点。
 
+正式文档站点发布于 `https://labs.prompthon.io`。
+
 如果手册应显示在 Vercel 拥有的域名下，请在 Mintlify 子域名存在后，将 Vercel 配置为反向代理：
 
 ```json
@@ -47,6 +49,14 @@ npx mint broken-links
 ```
 
 在确认真实的 Mintlify 子域名前，不要添加那个已启用的 `vercel.json`。
+
+## 分析与 Search Console
+
+Mintlify 分析功能应用于文档原生使用信号，例如阅读量最高的页面、内部搜索、搜索结果点击、反馈和助手活动。可在 Mintlify 仪表盘或通过已认证的 CLI 会话 `npx mint analytics` 访问相关报告。
+
+GA4 通过 Mintlify `docs.json` 集成配置，测量 ID 为 `G-K26DVPPVLY`。GA4 用于外部报表、引流来源分析和点击路径探索。
+
+Google Search Console 应为 `https://labs.prompthon.io/` 设置 URL 前缀属性。验证 token 已以 `google-site-verification` meta 标签的形式提交到 `docs.json`。部署完成后，验证该属性并提交 `https://labs.prompthon.io/sitemap.xml`。
 
 ## 兼容性策略
 


### PR DESCRIPTION
## Summary
- Add GA4 integration for `labs.prompthon.io` through Mintlify `docs.json`.
- Add the Google Search Console verification meta tag and global site description.
- Document Mintlify analytics, GA4, Search Console, and sitemap follow-up steps in `WEBSITE.mdx`.

## Test Plan
- `python3 -m json.tool docs.json`
- `git diff --check`
- `PATH="/Users/liqingpan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npx mint validate`
- `PATH="/Users/liqingpan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npx mint broken-links`