### PR TITLE
[codex] fix fork PR Discord announcements

### DIFF
--- a/.github/discord-lab-updates.md
+++ b/.github/discord-lab-updates.md
@@ -51,3 +51,8 @@ Postgres and does not post to Discord.
    `discord_announcement_jobs`.
 4. Nova P posts regular feed and PR coordination messages.
 5. CaraP handles channel setup and settings changes.
+
+For forked PRs, GitHub does not expose repository secrets to the
+`pull_request` run. Those untrusted PR runs skip the database write, and the
+trusted `main` push that follows a merge enqueues the same PR-merge announcement
+using the PR dedupe key.

--- a/.github/scripts/enqueue-discord-announcement.mjs
+++ b/.github/scripts/enqueue-discord-announcement.mjs
@@ -243,7 +243,30 @@ async function buildPushJobs(event) {
   });
 
   if (pullRequest) {
-    return [];
+    return [
+      makeJob({
+        authorLogin: pullRequest.user?.login || null,
+        branch,
+        changeSummary: truncate(firstParagraph(pullRequest.body), 700) || `Merged PR #${pullRequest.number}.`,
+        channelKey: "repo-updates",
+        commitSha: sha,
+        dedupeKey: `${repoFullName}:pr:${pullRequest.number}:merged:repo-updates`,
+        eventType: "github_pr_merged",
+        mergedByLogin: pullRequest.merged_by?.login ||
+          event.head_commit?.committer?.username ||
+          process.env.GITHUB_ACTOR ||
+          null,
+        payloadJson: {
+          pull_request: pullRequest,
+          sourceUrl: pullRequest.html_url,
+        },
+        prNumber: pullRequest.number,
+        prTitle: pullRequest.title,
+        prUrl: pullRequest.html_url,
+        repoFullName,
+        repoUrl,
+      }),
+    ];
   }
 
   const before = event.before || runGit(["rev-parse", `${sha}^`], "");
@@ -415,6 +438,17 @@ function publicJobSummary(job) {
   };
 }
 
+function isForkPullRequestJob(job) {
+  if (job.payloadJson?.eventName !== "pull_request") {
+    return false;
+  }
+
+  const headRepoFullName = normalizeGitHubRepoFullName(
+    job.payloadJson?.pull_request?.head?.repo?.full_name,
+  );
+  return Boolean(headRepoFullName && headRepoFullName !== job.repoFullName);
+}
+
 function wantsSsl(databaseUrl) {
   return /(?:[?&]ssl=true|[?&]sslmode=(?:require|prefer|verify-ca|verify-full))/i.test(
     databaseUrl,
@@ -424,6 +458,10 @@ function wantsSsl(databaseUrl) {
 async function enqueueJob(job) {
   const databaseUrl = process.env.PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL;
   if (!databaseUrl) {
+    if (process.env.GITHUB_ACTIONS === "true" && isForkPullRequestJob(job)) {
+      return { skipped: true, reason: "fork_pull_request_secrets_unavailable" };
+    }
+
     const message = "Missing required PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL secret; cannot enqueue Discord announcement job.";
     if (process.env.GITHUB_ACTIONS === "true") {
       console.error(`::error::${message}`);

--- a/.github/scripts/enqueue-discord-announcement.test.mjs
+++ b/.github/scripts/enqueue-discord-announcement.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const scriptPath = path.join(__dirname, "enqueue-discord-announcement.mjs");
+const repoRoot = path.resolve(__dirname, "../..");
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+test("trusted main push for an associated fork PR enqueues the PR merge announcement", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "discord-announcer-"));
+  const eventPath = path.join(tempDir, "event.json");
+  const fetchPreloadPath = path.join(tempDir, "mock-fetch.mjs");
+  const mergeSha = "9a91452002bd2f7db8e9b329cbddc4d6985f05dd";
+
+  writeJson(eventPath, {
+    after: mergeSha,
+    before: "3d7168117324528ca26fc25bb7ff51ab42b2a34e",
+    ref: "refs/heads/main",
+    repository: {
+      full_name: "Prompthon-IO/agent-systems-handbook",
+      html_url: "https://github.com/Prompthon-IO/agent-systems-handbook",
+    },
+  });
+
+  fs.writeFileSync(
+    fetchPreloadPath,
+    `
+globalThis.fetch = async () => new Response(JSON.stringify([
+  {
+    number: 71,
+    title: "feat: add personal-knowledge-capture skill package",
+    html_url: "https://github.com/Prompthon-IO/agent-systems-handbook/pull/71",
+    user: { login: "emptyshell424" }
+  }
+]));
+`,
+  );
+
+  const result = spawnSync(
+    process.execPath,
+    ["--import", fetchPreloadPath, scriptPath, "--dry-run"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        DISCORD_REPO_UPDATES_CHANNEL_ID: "1499430188105334996",
+        GITHUB_EVENT_NAME: "push",
+        GITHUB_EVENT_PATH: eventPath,
+        GITHUB_REF_NAME: "main",
+        GITHUB_REPOSITORY: "Prompthon-IO/agent-systems-handbook",
+        GITHUB_SHA: mergeSha,
+        GITHUB_TOKEN: "test-token",
+      },
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.dryRun, true);
+  assert.deepEqual(output.jobs, [
+    {
+      channelKey: "repo-updates",
+      commitSha: mergeSha,
+      dedupeKey: "Prompthon-IO/agent-systems-handbook:pr:71:merged:repo-updates",
+      discordChannelId: "1499430188105334996",
+      eventType: "github_pr_merged",
+      prNumber: 71,
+      prTitle: "feat: add personal-knowledge-capture skill package",
+      repoFullName: "Prompthon-IO/agent-systems-handbook",
+      sourceUrl: "https://github.com/Prompthon-IO/agent-systems-handbook/pull/71",
+    },
+  ]);
+});
+
+test("fork pull request events skip cleanly when Actions secrets are unavailable", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "discord-announcer-"));
+  const eventPath = path.join(tempDir, "event.json");
+  const mergeSha = "9a91452002bd2f7db8e9b329cbddc4d6985f05dd";
+
+  writeJson(eventPath, {
+    action: "closed",
+    repository: {
+      full_name: "Prompthon-IO/agent-systems-handbook",
+      html_url: "https://github.com/Prompthon-IO/agent-systems-handbook",
+    },
+    pull_request: {
+      base: {
+        ref: "main",
+      },
+      body: "",
+      head: {
+        repo: {
+          full_name: "emptyshell424/agent-systems-handbook",
+        },
+        sha: "46398001c783afc154329826b51c86b06b4a9b9e",
+      },
+      html_url: "https://github.com/Prompthon-IO/agent-systems-handbook/pull/71",
+      merge_commit_sha: mergeSha,
+      merged: true,
+      merged_by: {
+        login: "dprat0821",
+      },
+      number: 71,
+      title: "feat: add personal-knowledge-capture skill package",
+      user: {
+        login: "emptyshell424",
+      },
+    },
+    sender: {
+      login: "dprat0821",
+    },
+  });
+
+  const env = {
+    ...process.env,
+    ANNOUNCER_MAX_ATTEMPTS: "5",
+    DISCORD_REPO_UPDATES_CHANNEL_ID: "1499430188105334996",
+    GITHUB_ACTIONS: "true",
+    GITHUB_EVENT_NAME: "pull_request",
+    GITHUB_EVENT_PATH: eventPath,
+    GITHUB_REF_NAME: "feat/personal-knowledge-capture",
+    GITHUB_REPOSITORY: "Prompthon-IO/agent-systems-handbook",
+    GITHUB_SHA: "46398001c783afc154329826b51c86b06b4a9b9e",
+  };
+  delete env.PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL;
+
+  const result = spawnSync(process.execPath, [scriptPath], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env,
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.deepEqual(output.results, [
+    {
+      reason: "fork_pull_request_secrets_unavailable",
+      skipped: true,
+      summary: {
+        channelKey: "repo-updates",
+        commitSha: mergeSha,
+        dedupeKey: "Prompthon-IO/agent-systems-handbook:pr:71:merged:repo-updates",
+        discordChannelId: "1499430188105334996",
+        eventType: "github_pr_merged",
+        prNumber: 71,
+        prTitle: "feat: add personal-knowledge-capture skill package",
+        repoFullName: "Prompthon-IO/agent-systems-handbook",
+        sourceUrl: "https://github.com/Prompthon-IO/agent-systems-handbook/pull/71",
+      },
+    },
+  ]);
+});

--- a/.github/workflows/discord-lab-updates.yml
+++ b/.github/workflows/discord-lab-updates.yml
@@ -47,6 +47,9 @@ jobs:
           mkdir -p "$RUNNER_TEMP/discord-announcer-node"
           npm install --prefix "$RUNNER_TEMP/discord-announcer-node" --no-save pg@8
 
+      - name: Test enqueue script
+        run: node --test .github/scripts/enqueue-discord-announcement.test.mjs
+
       - name: Enqueue lab update announcement
         env:
           ANNOUNCER_MAX_ATTEMPTS: "5"


### PR DESCRIPTION
## Summary

- enqueue PR-merge Discord announcements from the trusted `main` push path when GitHub can associate the merge commit with a PR
- skip fork-origin `pull_request` enqueue attempts cleanly when GitHub Actions withholds repository secrets
- add Node regression coverage for the fork PR merge path and wire it into the Discord Lab Updates workflow

## Why

Fork PRs do not receive `PATHWAY_DISCORD_ANNOUNCER_DATABASE_URL` on the `pull_request` run, so PR #71 failed before it could create a `discord_announcement_jobs` row. The follow-up `push` run had secrets, but the script skipped PR-associated commits to avoid duplicates. That left outside contributors unrecognized in the wrap-up channel.

## Validation

- `node --test .github/scripts/enqueue-discord-announcement.test.mjs`
- `node --check .github/scripts/enqueue-discord-announcement.mjs`
- `node --check .github/scripts/enqueue-discord-announcement.test.mjs`
- `git diff --check`