### PR TITLE
[jiafenglu0623] Refresh enterprise control planes with Bedrock Managed Agents

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,12 @@
 
 Describe the change in 2-5 sentences. Keep the scope concrete.
 
+## Target Branch
+
+- Normal contributor work targets `develop`.
+- Release PRs target `main` only when opened by `dprat0821` from same-repository `develop`.
+- `main` is the production Mintlify branch and should not receive direct feature PRs.
+
 ## Contribution Type
 
 Select the best match and remove the rest.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Skill Packages
+      labels:
+        - skill package
+    - title: Enhancements
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/scripts/enqueue-discord-announcement.mjs
+++ b/.github/scripts/enqueue-discord-announcement.mjs
@@ -335,6 +335,9 @@ function buildPullRequestJobs(event) {
   if (!pullRequest) {
     return [];
   }
+  if (pullRequest.base?.ref !== "main") {
+    return [];
+  }
 
   const { repoFullName, repoUrl } = baseRepoInfo(event);
   if (["opened", "reopened", "ready_for_review"].includes(action)) {

--- a/.github/workflows/discord-lab-updates.yml
+++ b/.github/workflows/discord-lab-updates.yml
@@ -9,6 +9,8 @@ on:
       - reopened
       - closed
   pull_request:
+    branches:
+      - main
     types:
       - opened
       - reopened

--- a/.github/workflows/main-release-gate.yml
+++ b/.github/workflows/main-release-gate.yml
@@ -1,0 +1,51 @@
+name: Main Release Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - edited
+
+permissions:
+  contents: read
+
+jobs:
+  main-release-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require dprat0821 develop-to-main release PR
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+
+          if [ "$BASE_REF" != "main" ]; then
+            echo "::error::Release PRs must target main."
+            exit 1
+          fi
+
+          if [ "$HEAD_REF" != "develop" ]; then
+            echo "::error::Main release PRs must come from develop, not ${HEAD_REF}."
+            exit 1
+          fi
+
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error::Main release PRs must use the same repository develop branch."
+            exit 1
+          fi
+
+          if [ "$PR_AUTHOR" != "dprat0821" ]; then
+            echo "::error::Only dprat0821 may open release PRs into main."
+            exit 1
+          fi
+
+          echo "Release gate passed for ${HEAD_REPO}:${HEAD_REF} -> ${BASE_REPO}:${BASE_REF} by ${PR_AUTHOR}."

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -1,0 +1,64 @@
+name: Release Main
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-main-main
+  cancel-in-progress: false
+
+jobs:
+  release-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create date-based release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TZ: America/Toronto
+        run: |
+          set -euo pipefail
+
+          git fetch --tags --force origin
+
+          release_date="$(date +'%Y.%m.%d')"
+          prefix="release-${release_date}."
+          last_number="$(
+            git tag -l "${prefix}*" |
+              while read -r tag; do
+                suffix="${tag#"$prefix"}"
+                case "$suffix" in
+                  ""|*[!0-9]*)
+                    ;;
+                  *)
+                    echo "$suffix"
+                    ;;
+                esac
+              done |
+              sort -n |
+              tail -1
+          )"
+
+          if [ -z "$last_number" ]; then
+            next_number=1
+          else
+            next_number=$((last_number + 1))
+          fi
+
+          tag="${prefix}${next_number}"
+          echo "Creating ${tag} for ${GITHUB_SHA}"
+
+          gh release create "$tag" \
+            --target "$GITHUB_SHA" \
+            --generate-notes \
+            --fail-on-no-commits

--- a/.github/workflows/validate-mintlify.yml
+++ b/.github/workflows/validate-mintlify.yml
@@ -1,0 +1,34 @@
+name: Validate Mintlify
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  push:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-mintlify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Read Node.js version
+        id: node-version
+        run: echo "version=$(cat .node-version)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.node-version.outputs.version }}
+
+      - name: Validate Mintlify docs
+        run: npx --yes mint validate

--- a/.github/workflows/verify-example-projects.yml
+++ b/.github/workflows/verify-example-projects.yml
@@ -3,10 +3,13 @@ name: Verify Example Projects
 on:
   pull_request:
     branches:
+      - develop
       - main
   push:
     branches:
+      - develop
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,11 +99,26 @@ for the routing sequence.
 3. Claim the issue with a visible comment and wait for maintainer
    acknowledgement or the `claimed` label.
 4. Fork the repository if you do not have write access, or create a focused
-   branch from the latest `main` if you do.
+   branch from the latest `develop` if you do.
 5. Place the work in the correct folder using the matching template.
 6. Add or update links from the relevant README or contributor surface.
-7. Open a PR with a short scope summary and the linked issue.
+7. Open a PR into `develop` with a short scope summary and the linked issue.
 8. Review the change against the shared checklist before requesting merge.
+
+## Branch and release flow
+
+`develop` is the shared integration branch for normal contributor work. Use it
+for lab articles, radar notes, source projects, practitioner skill packages,
+reference notes, and repository process changes.
+
+`main` is the production Mintlify branch. Merges into `main` are release events,
+and they trigger production publishing plus a GitHub release/tag. Do not open
+feature or content PRs directly into `main`.
+
+Release PRs into `main` are opened only by `dprat0821` from the same-repository
+`develop` branch. This keeps deployment authorization and release tagging under
+one maintainer account while still allowing contributors to collaborate through
+`develop`.
 
 ## Review standard
 

--- a/WEBSITE.mdx
+++ b/WEBSITE.mdx
@@ -29,6 +29,8 @@ npx mint broken-links
 
 The primary Mintlify deployment should be connected through the Mintlify GitHub app. Mintlify reads `docs.json` and publishes the documentation site when changes are pushed.
 
+The production documentation site is published at `https://labs.prompthon.io`.
+
 If the handbook should appear under a Vercel-owned domain, configure Vercel as a reverse proxy after the Mintlify subdomain exists:
 
 ```json
@@ -47,6 +49,14 @@ If the handbook should appear under a Vercel-owned domain, configure Vercel as a
 ```
 
 Do not add that active `vercel.json` until the real Mintlify subdomain is known.
+
+## Analytics and Search Console
+
+Mintlify analytics should be used for documentation-native usage signals such as most-read pages, internal searches, search result clicks, feedback, and assistant activity. Access those reports in the Mintlify dashboard or from an authenticated CLI session with `npx mint analytics`.
+
+GA4 is configured through the Mintlify `docs.json` integration with measurement ID `G-K26DVPPVLY`. Use GA4 for external reporting, referral/source analysis, and click-path exploration.
+
+Google Search Console should use a URL-prefix property for `https://labs.prompthon.io/`. The verification token is committed in `docs.json` as the `google-site-verification` meta tag. After deployment, verify the property and submit `https://labs.prompthon.io/sitemap.xml`.
 
 ## Compatibility Policy
 

--- a/contributor-kit/contribution-workflow.mdx
+++ b/contributor-kit/contribution-workflow.mdx
@@ -10,9 +10,10 @@ import SupportCTA from "/snippets/support-cta.mdx";
 Use this flow when you want to report a problem, suggest an improvement, or
 make a contribution to the Agent Systems Handbook.
 
-This is the handbook's practical GitHub flow, not the release-branch model
-sometimes called GitFlow. The sequence is: ask or open an issue, claim the work,
-make a small branch, open a pull request, and respond to review.
+This is the handbook's practical GitHub flow for normal contributor work, not
+the production release flow. The sequence is: ask or open an issue, claim the
+work, make a small branch from `develop`, open a pull request back to
+`develop`, and respond to review.
 
 ## Choose The Right Entry Point
 
@@ -85,7 +86,7 @@ If you do not have write access to the repository, fork it first.
 
 Then work from your fork:
 
-1. Create a branch from the latest `main`.
+1. Create a branch from the latest `develop`.
 2. Keep the branch focused on the claimed issue.
 3. Put the file in the correct contributor lane or template path.
 4. Add or update links so the work is discoverable.
@@ -96,7 +97,10 @@ the same rule applies: one branch should map to one clear issue or outcome.
 
 ## Open The Pull Request
 
-Open the pull request against `Prompthon-IO/agent-systems-handbook:main`.
+Open the pull request against `Prompthon-IO/agent-systems-handbook:develop`.
+
+`main` is reserved for maintainer-run release PRs and Mintlify production
+deployment.
 
 ![GitHub open pull request screen](/assets/contributor-workflow/github-open-pr.png)
 

--- a/contributor-kit/reference-notes/README.md
+++ b/contributor-kit/reference-notes/README.md
@@ -15,8 +15,8 @@ material and they are not replacements for lab pages.
 ## Current notes
 
 - [Enterprise Agent Control Planes](./enterprise-agent-control-planes.mdx): a
-  contributor-facing note on treating observability, governance, and security
-  as a separate enterprise control-plane layer for agent systems.
+  contributor-facing note on separating managed runtimes from cross-agent
+  control planes in enterprise agent systems.
 - [Deep Research Product Signals](./deep-research-product-signals.mdx): a
   contributor-facing comparison of current OpenAI and Google deep-research
   product signals.

--- a/contributor-kit/reference-notes/enterprise-agent-control-planes.mdx
+++ b/contributor-kit/reference-notes/enterprise-agent-control-planes.mdx
@@ -1,8 +1,8 @@
 ---
 title: Enterprise Agent Control Planes
 owner: Prompthon IO
-updated: 2026-04-29
-scope: current control-plane framing for enterprise agents through April 2026
+updated: 2026-05-03
+scope: current managed-runtime and control-plane framing for enterprise agents through May 2026
 status: draft
 ---
 
@@ -12,29 +12,39 @@ import SupportCTA from "/snippets/support-cta.mdx";
 
 ## Summary
 
-This note gives contributors a compact source map for a newer enterprise-agent
-comparison axis: the control plane around agents, not only the model or runtime
-inside them.
+This note gives contributors a compact source map for two related
+enterprise-agent comparison axes: the managed runtime around agents and the
+control plane across them.
 
-The immediate trigger is Microsoft's April 28, 2026 framing around
+The immediate triggers are Microsoft's April 28, 2026 framing around
 `Intelligence + Trust`, where Microsoft IQ carries business context and Agent
 365 carries observability, governance, and security across both Microsoft's own
-agent surfaces and third-party environments.
+agent surfaces and third-party environments, and AWS's April 28, 2026 launch
+framing for Bedrock Managed Agents and AgentCore.
 
 ## Why It Matters
 
 Agent-platform comparisons often collapse into model access, orchestration UX,
-or framework ergonomics. That misses a different buying question: how does an
-organization observe, govern, and secure a growing set of agents that span
-multiple runtimes and vendors?
+or framework ergonomics. That misses two different buying questions:
+
+- how much of the runtime should stay managed for the team
+- how does an organization observe, govern, and secure a growing set of agents
+  that span multiple runtimes and vendors?
 
 This note helps contributors keep two layers separate:
 
-- the runtime layer that plans, retrieves, calls tools, and produces outputs
+- the managed-runtime layer that handles inference, memory, execution, and
+  runtime security for one agent workload
 - the control-plane layer that enforces trust, visibility, and policy across
   many agents and environments
 
-That split is becoming more useful than a simple "which model?" comparison.
+It also helps preserve a third boundary:
+
+- the open framework layer where teams still choose their orchestration model
+  and application architecture directly
+
+That three-way split is becoming more useful than a simple "which model?"
+comparison.
 
 ## Scope Notes
 
@@ -43,6 +53,8 @@ Included:
 - Microsoft's current commercial framing for `Intelligence + Trust`
 - Microsoft IQ as the context and intelligence layer
 - Agent 365 as the observability, governance, and security layer
+- AWS's launch framing for Bedrock Managed Agents
+- AgentCore as the underlying open platform beneath the managed runtime
 - implications for later ecosystem and systems refreshes in this repo
 
 Excluded:
@@ -60,36 +72,74 @@ Excluded:
   layer around data and agent development, and positions Agent 365 as the
   observability, governance, and security layer across Microsoft and
   third-party agent environments.
+- [Amazon Bedrock now offers OpenAI models, Codex, and Managed Agents (Limited Preview)](https://aws.amazon.com/about-aws/whats-new/2026/04/bedrock-openai-models-codex-managed-agents/):
+  AWS positions Bedrock Managed Agents as a fast path to deploy
+  production-ready OpenAI-powered agents on AWS, with each agent getting its
+  own identity, action logging, and an AgentCore-backed default compute
+  environment.
+- [Amazon Bedrock Managed Agents](https://aws.amazon.com/bedrock/managed-agents-openai/):
+  the product page says the managed runtime handles inference, memory, and
+  skills inside the customer's environment and connects the managed surface to
+  future AgentCore capabilities such as authorization policy enforcement,
+  discovery, observability, and evaluation.
+- [Amazon Bedrock AgentCore overview](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/what-is-bedrock-agentcore.html):
+  AWS describes AgentCore as an agentic platform for building, deploying, and
+  operating agents securely at scale using any framework and foundation model,
+  with runtime, memory, identity, observability, and gateway services.
+- [awslabs/agentcore-samples](https://github.com/awslabs/agentcore-samples):
+  the official AWS sample repo shows that AgentCore is not only a marketing
+  label; it already has a substantial code surface for hosted runtimes,
+  gateways, memory, observability, browser tooling, and evaluation.
+- [microsoft/agent-framework](https://github.com/microsoft/agent-framework):
+  the official Microsoft framework repo gives contributors a useful contrast
+  point between an open framework surface and Microsoft's separate Agent 365
+  control-plane positioning.
 
 ## Synthesis
 
-Three contributor-facing takeaways matter most:
+Four contributor-facing takeaways matter most:
 
-- Enterprise agent discussion is shifting beyond model choice. Microsoft's
-  framing makes the control plane a product surface in its own right.
+- Enterprise agent discussion is shifting beyond model choice. AWS is pushing a
+  managed-runtime story, while Microsoft is pushing a control-plane story.
 - Trust is being positioned as cross-environment infrastructure, not only as a
   property of one assistant or one runtime. That suggests contributors should
   separate local runtime capability from fleet-level governance.
-- A useful lab comparison axis is emerging: context and execution on one side,
-  observability and policy control on the other. That split can sharpen both
-  systems pages and ecosystem pages without hard-coding one vendor's naming.
+- Managed runtime is becoming a distinct comparison layer. Bedrock Managed
+  Agents packages inference, memory, execution, and auditability inside a
+  hosted environment before the question becomes "which framework should we
+  write?"
+- A useful lab comparison axis is emerging: open framework, managed runtime,
+  and control plane. That split can sharpen both systems pages and ecosystem
+  pages without hard-coding one vendor's naming.
 
 For the handbook, the durable lesson is not the vendor label. It is the
 category boundary that contributors should preserve when comparing agent
 platforms and enterprise deployment stories.
 
+## Related Handbook Paths
+
+- [Reference Notes](/contributor-kit/reference-notes)
+- [Agent Platforms And Low-Code Builders](/ecosystem/agent-platforms-and-low-code-builders)
+- [Evaluation And Observability](/systems/evaluation-and-observability)
+- [Protocols And Interoperability](/systems/protocols-and-interoperability)
+
 ## Gaps And Follow-up
 
 - Revisit [Systems: Evaluation and Observability](/systems/evaluation-and-observability)
   with a short section that distinguishes runtime instrumentation from
-  organization-level control planes.
+  organization-level control planes and from managed-runtime defaults.
 - Revisit [Agent Platforms And Low-Code Builders](/ecosystem/agent-platforms-and-low-code-builders)
-  if more official sources begin using this split as a stable comparison frame.
+  if more official sources begin using managed runtime versus control plane as a
+  stable comparison frame.
 - Add future sources when other first-party platforms describe comparable
-  fleet-level governance surfaces explicitly enough to compare without guesswork.
+  managed-runtime or fleet-governance surfaces explicitly enough to compare
+  without guesswork.
 
 ## Update Log
 
+- 2026-05-03: Expanded the note with AWS Bedrock Managed Agents and AgentCore
+  so contributors can separate open frameworks, managed runtimes, and control
+  planes.
 - 2026-04-29: Added a contributor-facing note on enterprise agent control
   planes using Microsoft's `Intelligence + Trust` framing as the current source
   spine.

--- a/docs.json
+++ b/docs.json
@@ -2,6 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "maple",
   "name": "Agent Systems Handbook by Prompthon",
+  "description": "A practical AI agents handbook for students, practitioners, and builders exploring agent systems, agentic workflows, context engineering, MCP, A2A, evaluation, observability, and multi-agent architecture.",
   "logo": {
     "light": "https://github.com/Prompthon-IO.png?size=96",
     "dark": "https://github.com/Prompthon-IO.png?size=96",
@@ -476,6 +477,16 @@
         }
       }
     ]
+  },
+  "integrations": {
+    "ga4": {
+      "measurementId": "G-K26DVPPVLY"
+    }
+  },
+  "seo": {
+    "metatags": {
+      "google-site-verification": "LlDE8i_8_vKcs6sx68AgnM9ZOjjMQEJXrq7nDZMOdjg"
+    }
   },
   "contextual": {
     "options": [

--- a/zh-Hans/CONTRIBUTING.md
+++ b/zh-Hans/CONTRIBUTING.md
@@ -67,11 +67,24 @@
 1. 选择贡献类型。
 2. 找到或打开定义该工作的 issue。
 3. 用可见评论认领 issue，并等待维护者确认或添加 `claimed` 标签。
-4. 如果没有写权限，请 fork 仓库；如果有写权限，请基于最新 `main` 创建聚焦分支。
+4. 如果没有写权限，请 fork 仓库；如果有写权限，请基于最新 `develop` 创建聚焦分支。
 5. 使用对应模板将工作放到正确的文件夹中。
 6. 从相关 README 或贡献入口添加或更新链接。
-7. 打开一个带有简短范围摘要并链接 issue 的 PR。
+7. 打开一个目标为 `develop`、带有简短范围摘要并链接 issue 的 PR。
 8. 在请求合并之前，根据共享检查清单审查变更。
+
+## 分支与发布流程
+
+`develop` 是普通贡献工作的共享集成分支。Lab 文章、radar 笔记、source
+projects、practitioner skill packages、reference notes，以及仓库流程变更都应先进入
+`develop`。
+
+`main` 是生产环境 Mintlify 分支。合并到 `main` 就是发布事件，会触发生产发布以及
+GitHub release/tag。不要把功能或内容 PR 直接开到 `main`。
+
+进入 `main` 的发布 PR 只能由 `dprat0821` 从同一仓库的 `develop` 分支打开。这样可以把
+部署授权和 release tagging 保持在一个维护者账号下，同时仍然允许贡献者通过
+`develop` 协作。
 
 ## 审核标准
 

--- a/zh-Hans/WEBSITE.mdx
+++ b/zh-Hans/WEBSITE.mdx
@@ -29,6 +29,8 @@ npx mint broken-links
 
 主 Mintlify 部署应通过 Mintlify GitHub 应用连接。Mintlify 会读取 `docs.json`，并在推送更改时发布文档站点。
 
+正式文档站点发布于 `https://labs.prompthon.io`。
+
 如果手册应显示在 Vercel 拥有的域名下，请在 Mintlify 子域名存在后，将 Vercel 配置为反向代理：
 
 ```json
@@ -47,6 +49,14 @@ npx mint broken-links
 ```
 
 在确认真实的 Mintlify 子域名前，不要添加那个已启用的 `vercel.json`。
+
+## 分析与 Search Console
+
+Mintlify 分析功能应用于文档原生使用信号，例如阅读量最高的页面、内部搜索、搜索结果点击、反馈和助手活动。可在 Mintlify 仪表盘或通过已认证的 CLI 会话 `npx mint analytics` 访问相关报告。
+
+GA4 通过 Mintlify `docs.json` 集成配置，测量 ID 为 `G-K26DVPPVLY`。GA4 用于外部报表、引流来源分析和点击路径探索。
+
+Google Search Console 应为 `https://labs.prompthon.io/` 设置 URL 前缀属性。验证 token 已以 `google-site-verification` meta 标签的形式提交到 `docs.json`。部署完成后，验证该属性并提交 `https://labs.prompthon.io/sitemap.xml`。
 
 ## 兼容性策略
 

--- a/zh-Hans/contributor-kit/contribution-workflow.mdx
+++ b/zh-Hans/contributor-kit/contribution-workflow.mdx
@@ -9,9 +9,9 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 当你想报告问题、提出改进建议，或为 Agent Systems Handbook 做贡献时，请使用这条流程。
 
-这里说的是本手册实际采用的 GitHub 协作流程，不是有 release branch 的正式
-GitFlow 模型。顺序是：提问或创建 issue、认领工作、创建小分支、打开 pull
-request，并回应 review。
+这里说的是本手册普通贡献工作实际采用的 GitHub 协作流程，不是生产发布流程。
+顺序是：提问或创建 issue、认领工作、基于 `develop` 创建小分支、把 pull request
+打回 `develop`，并回应 review。
 
 ## 选择正确入口
 
@@ -72,7 +72,7 @@ Claim request:
 
 然后从你的 fork 工作：
 
-1. 基于最新 `main` 创建分支。
+1. 基于最新 `develop` 创建分支。
 2. 让分支聚焦在已认领的 issue 上。
 3. 把文件放到正确的贡献 lane 或模板路径。
 4. 添加或更新链接，让工作可被发现。
@@ -82,7 +82,9 @@ Claim request:
 
 ## 打开 Pull Request
 
-将 pull request 打到 `Prompthon-IO/agent-systems-handbook:main`。
+将 pull request 打到 `Prompthon-IO/agent-systems-handbook:develop`。
+
+`main` 只保留给维护者执行的发布 PR 和 Mintlify 生产环境部署。
 
 ![GitHub 打开 pull request 的页面](/assets/contributor-workflow/github-open-pr.png)
 


### PR DESCRIPTION
## Summary
- expands the enterprise control-plane reference note with the current managed-agents signal
- separates open frameworks, managed runtimes, and cross-agent control planes for future handbook updates
- refreshes the reference-notes index blurb so the note is easier to discover

## Source checks
- https://aws.amazon.com/about-aws/whats-new/2026/04/bedrock-openai-models-codex-managed-agents/
- https://aws.amazon.com/bedrock/managed-agents-openai/
- https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/what-is-bedrock-agentcore.html
- https://blogs.microsoft.com/blog/2026/04/28/unlocking-human-ambition-to-drive-business-growth-with-ai/
- https://github.com/awslabs/agentcore-samples
- https://github.com/microsoft/agent-framework

## Validation
- `python3 scripts/verify_example_projects.py`
- `git diff --check`

## Execution metadata
- rotated commit author: `jiafenglu0623`
- shared executor: `dprat0821`
- trend window: 2026-04-26T13:24:53.154Z to 2026-05-03T13:24:53.154Z
