### PR TITLE
[jiafenglu0623] Add coding agents case study with OpenAI Codex signal

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,12 @@
 
 Describe the change in 2-5 sentences. Keep the scope concrete.
 
+## Target Branch
+
+- Normal contributor work targets `develop`.
+- Release PRs target `main` only when opened by `dprat0821` from same-repository `develop`.
+- `main` is the production Mintlify branch and should not receive direct feature PRs.
+
 ## Contribution Type
 
 Select the best match and remove the rest.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Skill Packages
+      labels:
+        - skill package
+    - title: Enhancements
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/scripts/enqueue-discord-announcement.mjs
+++ b/.github/scripts/enqueue-discord-announcement.mjs
@@ -335,6 +335,9 @@ function buildPullRequestJobs(event) {
   if (!pullRequest) {
     return [];
   }
+  if (pullRequest.base?.ref !== "main") {
+    return [];
+  }
 
   const { repoFullName, repoUrl } = baseRepoInfo(event);
   if (["opened", "reopened", "ready_for_review"].includes(action)) {

--- a/.github/workflows/discord-lab-updates.yml
+++ b/.github/workflows/discord-lab-updates.yml
@@ -9,6 +9,8 @@ on:
       - reopened
       - closed
   pull_request:
+    branches:
+      - main
     types:
       - opened
       - reopened

--- a/.github/workflows/main-release-gate.yml
+++ b/.github/workflows/main-release-gate.yml
@@ -1,0 +1,51 @@
+name: Main Release Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - edited
+
+permissions:
+  contents: read
+
+jobs:
+  main-release-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require dprat0821 develop-to-main release PR
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_REPO: ${{ github.repository }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -euo pipefail
+
+          if [ "$BASE_REF" != "main" ]; then
+            echo "::error::Release PRs must target main."
+            exit 1
+          fi
+
+          if [ "$HEAD_REF" != "develop" ]; then
+            echo "::error::Main release PRs must come from develop, not ${HEAD_REF}."
+            exit 1
+          fi
+
+          if [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            echo "::error::Main release PRs must use the same repository develop branch."
+            exit 1
+          fi
+
+          if [ "$PR_AUTHOR" != "dprat0821" ]; then
+            echo "::error::Only dprat0821 may open release PRs into main."
+            exit 1
+          fi
+
+          echo "Release gate passed for ${HEAD_REPO}:${HEAD_REF} -> ${BASE_REPO}:${BASE_REF} by ${PR_AUTHOR}."

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -1,0 +1,64 @@
+name: Release Main
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-main-main
+  cancel-in-progress: false
+
+jobs:
+  release-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create date-based release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TZ: America/Toronto
+        run: |
+          set -euo pipefail
+
+          git fetch --tags --force origin
+
+          release_date="$(date +'%Y.%m.%d')"
+          prefix="release-${release_date}."
+          last_number="$(
+            git tag -l "${prefix}*" |
+              while read -r tag; do
+                suffix="${tag#"$prefix"}"
+                case "$suffix" in
+                  ""|*[!0-9]*)
+                    ;;
+                  *)
+                    echo "$suffix"
+                    ;;
+                esac
+              done |
+              sort -n |
+              tail -1
+          )"
+
+          if [ -z "$last_number" ]; then
+            next_number=1
+          else
+            next_number=$((last_number + 1))
+          fi
+
+          tag="${prefix}${next_number}"
+          echo "Creating ${tag} for ${GITHUB_SHA}"
+
+          gh release create "$tag" \
+            --target "$GITHUB_SHA" \
+            --generate-notes \
+            --fail-on-no-commits

--- a/.github/workflows/validate-mintlify.yml
+++ b/.github/workflows/validate-mintlify.yml
@@ -1,0 +1,34 @@
+name: Validate Mintlify
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  push:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-mintlify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Read Node.js version
+        id: node-version
+        run: echo "version=$(cat .node-version)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ steps.node-version.outputs.version }}
+
+      - name: Validate Mintlify docs
+        run: npx --yes mint validate

--- a/.github/workflows/verify-example-projects.yml
+++ b/.github/workflows/verify-example-projects.yml
@@ -3,10 +3,13 @@ name: Verify Example Projects
 on:
   pull_request:
     branches:
+      - develop
       - main
   push:
     branches:
+      - develop
       - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,11 +99,26 @@ for the routing sequence.
 3. Claim the issue with a visible comment and wait for maintainer
    acknowledgement or the `claimed` label.
 4. Fork the repository if you do not have write access, or create a focused
-   branch from the latest `main` if you do.
+   branch from the latest `develop` if you do.
 5. Place the work in the correct folder using the matching template.
 6. Add or update links from the relevant README or contributor surface.
-7. Open a PR with a short scope summary and the linked issue.
+7. Open a PR into `develop` with a short scope summary and the linked issue.
 8. Review the change against the shared checklist before requesting merge.
+
+## Branch and release flow
+
+`develop` is the shared integration branch for normal contributor work. Use it
+for lab articles, radar notes, source projects, practitioner skill packages,
+reference notes, and repository process changes.
+
+`main` is the production Mintlify branch. Merges into `main` are release events,
+and they trigger production publishing plus a GitHub release/tag. Do not open
+feature or content PRs directly into `main`.
+
+Release PRs into `main` are opened only by `dprat0821` from the same-repository
+`develop` branch. This keeps deployment authorization and release tagging under
+one maintainer account while still allowing contributors to collaborate through
+`develop`.
 
 ## Review standard
 

--- a/WEBSITE.mdx
+++ b/WEBSITE.mdx
@@ -29,6 +29,8 @@ npx mint broken-links
 
 The primary Mintlify deployment should be connected through the Mintlify GitHub app. Mintlify reads `docs.json` and publishes the documentation site when changes are pushed.
 
+The production documentation site is published at `https://labs.prompthon.io`.
+
 If the handbook should appear under a Vercel-owned domain, configure Vercel as a reverse proxy after the Mintlify subdomain exists:
 
 ```json
@@ -47,6 +49,14 @@ If the handbook should appear under a Vercel-owned domain, configure Vercel as a
 ```
 
 Do not add that active `vercel.json` until the real Mintlify subdomain is known.
+
+## Analytics and Search Console
+
+Mintlify analytics should be used for documentation-native usage signals such as most-read pages, internal searches, search result clicks, feedback, and assistant activity. Access those reports in the Mintlify dashboard or from an authenticated CLI session with `npx mint analytics`.
+
+GA4 is configured through the Mintlify `docs.json` integration with measurement ID `G-K26DVPPVLY`. Use GA4 for external reporting, referral/source analysis, and click-path exploration.
+
+Google Search Console should use a URL-prefix property for `https://labs.prompthon.io/`. The verification token is committed in `docs.json` as the `google-site-verification` meta tag. After deployment, verify the property and submit `https://labs.prompthon.io/sitemap.xml`.
 
 ## Compatibility Policy
 

--- a/case-studies/README.md
+++ b/case-studies/README.md
@@ -23,6 +23,8 @@ modes.
 
 - [Deep Research Agents](./deep-research-agents.mdx): a bounded look at
   planning, evidence collection, synthesis, and citation discipline.
+- [Coding Agents](./coding-agents.mdx): a repository-first case study for
+  scoped edits, verification, approvals, and human review.
 - [Customer Support Agents](./customer-support-agents.mdx): a local-first case
   study for email triage and policy-grounded reply drafting.
 

--- a/case-studies/coding-agents.mdx
+++ b/case-studies/coding-agents.mdx
@@ -1,0 +1,178 @@
+---
+title: Coding Agents
+owner: Prompthon IO
+updated: 2026-05-03
+depth: intermediate
+region_tags:
+  - global
+coding_required: optional
+external_readings:
+  - title: Introducing Codex
+    url: https://openai.com/index/introducing-codex/
+  - title: Codex CLI documentation
+    url: https://developers.openai.com/codex/cli
+  - title: openai/codex repository
+    url: https://github.com/openai/codex
+status: draft
+---
+
+import SupportCTA from "/snippets/support-cta.mdx";
+
+<SupportCTA />
+
+## Summary
+
+Coding agents help turn a software task into a bounded implementation loop:
+inspect the repository, propose a change, edit the right files, run checks, and
+hand back a diff with verification notes.
+
+The current product signal is strong enough to treat this as a real agent shape,
+not just autocomplete with a chat box. OpenAI's Codex positioning now spans a
+cloud software-engineering agent plus a local terminal coding agent, which
+makes the workflow legible for both teams and individual builders.
+
+## Why It Matters
+
+Coding work has the right mix of structure and uncertainty for agents.
+
+Useful, because the work is already artifact-heavy:
+
+- issue text or bug report
+- repository files
+- tests and linters
+- patch diffs
+- review comments
+
+Risky, because the agent can silently make the wrong edit, miss a failing test,
+or overreach into unrelated files while still sounding confident.
+
+That makes boundaries more important than raw generation quality. A useful
+coding agent is a repo-scoped worker with explicit verification, not a generic
+"write some code" assistant.
+
+## Mental Model
+
+A durable coding-agent workflow has five steps:
+
+- `inspect`: read the issue, repo structure, and nearby code before changing anything
+- `plan`: decide the smallest file set and validation path
+- `change`: edit the scoped files and preserve unrelated local work
+- `verify`: run tests, linters, or focused commands that check the claimed fix
+- `handoff`: summarize the diff, remaining risks, and next reviewer focus
+
+The key system boundary is not "can the model code?" It is whether the runtime
+keeps the agent inside the intended repository, tool, and approval limits while
+preserving a readable audit trail.
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+  Task["Issue or task prompt"] --> Inspect["Repo inspection"]
+  Inspect --> Plan["Scoped plan"]
+  Plan --> Edit["File edits"]
+  Edit --> Verify["Tests and checks"]
+  Verify --> Diff["Patch, logs, summary"]
+  Diff --> Review["Human review or merge queue"]
+```
+
+## Tool Landscape
+
+Coding agents usually combine:
+
+- repository read access for code, docs, and configuration
+- file-edit tools that can produce an inspectable patch
+- shell access for tests, formatters, builds, and git inspection
+- browser or web access when a task depends on current docs or a running UI
+- guardrails for approvals, network access, and destructive commands
+
+OpenAI's current Codex surfaces make this split clearer than many earlier
+coding assistants:
+
+- the cloud Codex product frames software tasks as isolated runs with their own
+  sandboxed environment and repository preload
+- the open-source Codex CLI frames the local path as a terminal coding agent
+  with approval modes, MCP access, web search, and cloud-task handoff
+
+That is why coding agents should be taught as an end-to-end system loop, not as
+just model output quality.
+
+## Guardrails
+
+Useful defaults for coding agents:
+
+- start from repository inspection, not instant editing
+- keep the write scope as small as possible
+- preserve unrelated working-tree changes
+- require explicit verification before claiming completion
+- keep command output, diffs, and test results visible to the reviewer
+- treat secrets, production credentials, and destructive git commands as separate approvals
+
+If the environment supports both local and cloud execution, keep the trust
+boundary explicit. Local execution can see the developer's real machine state.
+Cloud execution is easier to isolate, but it still needs clear repo, secret, and
+network policy.
+
+## Tradeoffs
+
+- More autonomy reduces copy-paste work, but it increases the risk of broad
+  unintended edits.
+- Local execution sees the real repository and environment, but it inherits more
+  secrets and workstation risk.
+- Cloud sandboxes isolate runs more cleanly, but they can drift from the exact
+  local setup if dependencies or secrets differ.
+- Fast patch generation feels productive, but a slower repo-inspect and verify
+  loop usually produces better changes.
+
+Practical default:
+
+- use a local or cloud coding agent to inspect, patch, and verify
+- keep a human in the review loop for merge decisions
+- optimize for traceable diffs and reproducible checks instead of one-shot code generation
+
+## Current Product Signal
+
+The current seven-day signal for this handbook run was `OpenAI Codex`, drawn
+from stored article coverage and then verified against current first-party docs
+and the public GitHub repository.
+
+The reusable lesson is broader than one vendor:
+
+- coding agents are becoming a distinct product category
+- the winning shape is repository-first, verification-heavy, and approval-aware
+- teams should evaluate them as agent systems with memory, tools, policies, and
+  review artifacts, not as pure prompt UX
+
+## Starter Direction
+
+For a practical on-ramp, start with the existing
+[Codex Desktop Agent Setup](/workshops/desktop-agents/codex) workshop. It is
+the shortest path in this repo from installation to real repository work.
+
+From there, connect this case study to:
+
+- [Evaluation And Observability](/systems/evaluation-and-observability) for the
+  verification and trace loop
+- [Context Engineering](/systems/context-engineering) for instruction, state,
+  and retrieval boundaries
+- [Case Studies Overview](/case-studies) for adjacent product shapes such as
+  deep research and customer support agents
+
+## Citations
+
+- Official source: [Introducing Codex](https://openai.com/index/introducing-codex/)
+- Official source: [Codex CLI documentation](https://developers.openai.com/codex/cli)
+- High-signal repository: [openai/codex](https://github.com/openai/codex)
+
+## Reading Extensions
+
+- [Codex Desktop Agent Setup](/workshops/desktop-agents/codex)
+- [Evaluation And Observability](/systems/evaluation-and-observability)
+- [Context Engineering](/systems/context-engineering)
+- [Case Studies Overview](/case-studies)
+
+## Update Log
+
+- 2026-05-03: Added a repo-native coding-agents case study anchored in the
+  current OpenAI Codex signal and linked it to the handbook's existing Codex
+  workshop.

--- a/case-studies/index.mdx
+++ b/case-studies/index.mdx
@@ -29,6 +29,8 @@ modes.
 
 - [Deep Research Agents](/case-studies/deep-research-agents): a bounded look at
   planning, evidence collection, synthesis, and citation discipline.
+- [Coding Agents](/case-studies/coding-agents): a repository-first case study
+  for scoped edits, verification, approvals, and human review.
 - [Customer Support Agents](/case-studies/customer-support-agents): a local-first case
   study for email triage and policy-grounded reply drafting.
 

--- a/contributor-kit/contribution-workflow.mdx
+++ b/contributor-kit/contribution-workflow.mdx
@@ -10,9 +10,10 @@ import SupportCTA from "/snippets/support-cta.mdx";
 Use this flow when you want to report a problem, suggest an improvement, or
 make a contribution to the Agent Systems Handbook.
 
-This is the handbook's practical GitHub flow, not the release-branch model
-sometimes called GitFlow. The sequence is: ask or open an issue, claim the work,
-make a small branch, open a pull request, and respond to review.
+This is the handbook's practical GitHub flow for normal contributor work, not
+the production release flow. The sequence is: ask or open an issue, claim the
+work, make a small branch from `develop`, open a pull request back to
+`develop`, and respond to review.
 
 ## Choose The Right Entry Point
 
@@ -85,7 +86,7 @@ If you do not have write access to the repository, fork it first.
 
 Then work from your fork:
 
-1. Create a branch from the latest `main`.
+1. Create a branch from the latest `develop`.
 2. Keep the branch focused on the claimed issue.
 3. Put the file in the correct contributor lane or template path.
 4. Add or update links so the work is discoverable.
@@ -96,7 +97,10 @@ the same rule applies: one branch should map to one clear issue or outcome.
 
 ## Open The Pull Request
 
-Open the pull request against `Prompthon-IO/agent-systems-handbook:main`.
+Open the pull request against `Prompthon-IO/agent-systems-handbook:develop`.
+
+`main` is reserved for maintainer-run release PRs and Mintlify production
+deployment.
 
 ![GitHub open pull request screen](/assets/contributor-workflow/github-open-pr.png)
 

--- a/docs.json
+++ b/docs.json
@@ -2,6 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "maple",
   "name": "Agent Systems Handbook by Prompthon",
+  "description": "A practical AI agents handbook for students, practitioners, and builders exploring agent systems, agentic workflows, context engineering, MCP, A2A, evaluation, observability, and multi-agent architecture.",
   "logo": {
     "light": "https://github.com/Prompthon-IO.png?size=96",
     "dark": "https://github.com/Prompthon-IO.png?size=96",
@@ -476,6 +477,16 @@
         }
       }
     ]
+  },
+  "integrations": {
+    "ga4": {
+      "measurementId": "G-K26DVPPVLY"
+    }
+  },
+  "seo": {
+    "metatags": {
+      "google-site-verification": "LlDE8i_8_vKcs6sx68AgnM9ZOjjMQEJXrq7nDZMOdjg"
+    }
   },
   "contextual": {
     "options": [

--- a/zh-Hans/CONTRIBUTING.md
+++ b/zh-Hans/CONTRIBUTING.md
@@ -67,11 +67,24 @@
 1. 选择贡献类型。
 2. 找到或打开定义该工作的 issue。
 3. 用可见评论认领 issue，并等待维护者确认或添加 `claimed` 标签。
-4. 如果没有写权限，请 fork 仓库；如果有写权限，请基于最新 `main` 创建聚焦分支。
+4. 如果没有写权限，请 fork 仓库；如果有写权限，请基于最新 `develop` 创建聚焦分支。
 5. 使用对应模板将工作放到正确的文件夹中。
 6. 从相关 README 或贡献入口添加或更新链接。
-7. 打开一个带有简短范围摘要并链接 issue 的 PR。
+7. 打开一个目标为 `develop`、带有简短范围摘要并链接 issue 的 PR。
 8. 在请求合并之前，根据共享检查清单审查变更。
+
+## 分支与发布流程
+
+`develop` 是普通贡献工作的共享集成分支。Lab 文章、radar 笔记、source
+projects、practitioner skill packages、reference notes，以及仓库流程变更都应先进入
+`develop`。
+
+`main` 是生产环境 Mintlify 分支。合并到 `main` 就是发布事件，会触发生产发布以及
+GitHub release/tag。不要把功能或内容 PR 直接开到 `main`。
+
+进入 `main` 的发布 PR 只能由 `dprat0821` 从同一仓库的 `develop` 分支打开。这样可以把
+部署授权和 release tagging 保持在一个维护者账号下，同时仍然允许贡献者通过
+`develop` 协作。
 
 ## 审核标准
 

--- a/zh-Hans/WEBSITE.mdx
+++ b/zh-Hans/WEBSITE.mdx
@@ -29,6 +29,8 @@ npx mint broken-links
 
 主 Mintlify 部署应通过 Mintlify GitHub 应用连接。Mintlify 会读取 `docs.json`，并在推送更改时发布文档站点。
 
+正式文档站点发布于 `https://labs.prompthon.io`。
+
 如果手册应显示在 Vercel 拥有的域名下，请在 Mintlify 子域名存在后，将 Vercel 配置为反向代理：
 
 ```json
@@ -47,6 +49,14 @@ npx mint broken-links
 ```
 
 在确认真实的 Mintlify 子域名前，不要添加那个已启用的 `vercel.json`。
+
+## 分析与 Search Console
+
+Mintlify 分析功能应用于文档原生使用信号，例如阅读量最高的页面、内部搜索、搜索结果点击、反馈和助手活动。可在 Mintlify 仪表盘或通过已认证的 CLI 会话 `npx mint analytics` 访问相关报告。
+
+GA4 通过 Mintlify `docs.json` 集成配置，测量 ID 为 `G-K26DVPPVLY`。GA4 用于外部报表、引流来源分析和点击路径探索。
+
+Google Search Console 应为 `https://labs.prompthon.io/` 设置 URL 前缀属性。验证 token 已以 `google-site-verification` meta 标签的形式提交到 `docs.json`。部署完成后，验证该属性并提交 `https://labs.prompthon.io/sitemap.xml`。
 
 ## 兼容性策略
 

--- a/zh-Hans/case-studies/README.md
+++ b/zh-Hans/case-studies/README.md
@@ -19,6 +19,7 @@
 ## 当前页面
 
 - [Deep Research Agents](./deep-research-agents.mdx)：对规划、证据收集、综合整理和引用规范的有边界审视。
+- [Coding Agents](./coding-agents.mdx)：一个以仓库为先的案例研究，聚焦范围化改动、验证、审批和人工评审。
 - [Customer Support Agents](./customer-support-agents.mdx)：一个面向本地优先的案例研究，用于电子邮件分流和基于政策的回复草拟。
 
 ## 示例入门项目

--- a/zh-Hans/case-studies/coding-agents.mdx
+++ b/zh-Hans/case-studies/coding-agents.mdx
@@ -1,0 +1,169 @@
+---
+title: 编码智能体
+owner: Prompthon IO
+updated: 2026-05-03
+depth: intermediate
+region_tags:
+  - global
+coding_required: optional
+external_readings:
+  - title: Introducing Codex
+    url: https://openai.com/index/introducing-codex/
+  - title: Codex CLI documentation
+    url: https://developers.openai.com/codex/cli
+  - title: openai/codex repository
+    url: https://github.com/openai/codex
+status: draft
+---
+
+import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
+
+<SupportCTA />
+
+## 概述
+
+编码智能体把一个软件任务变成有边界的实现循环：检查仓库、提出改动、
+编辑正确文件、运行检查，并交付带验证说明的 diff。
+
+当前的产品信号已经足够强，不应再把它视为“带聊天框的补全”。OpenAI 对
+Codex 的当前定位同时覆盖云端软件工程智能体和本地终端编码智能体，这让
+团队和个人构建者都能更清楚地理解这类工作流。
+
+## 为什么这很重要
+
+编码工作同时具备结构性和不确定性，因此很适合智能体，也很容易出错。
+
+之所以有用，是因为它天然围绕产物展开：
+
+- issue 文本或 bug 描述
+- 仓库文件
+- 测试与 linter
+- patch diff
+- review 评论
+
+之所以有风险，是因为智能体可能在语气很自信的情况下仍然改错文件、漏掉
+失败测试，或者越界修改不相关内容。
+
+因此，比起“模型会不会写代码”，更关键的是边界是否明确。一个有用的编码
+智能体应当是仓库范围内的 worker，并且带有显式验证，而不是一个泛化的
+“帮我写点代码”的助手。
+
+## 心智模型
+
+一个耐用的编码智能体工作流通常有五步：
+
+- `inspect`：先读 issue、仓库结构和附近代码，再决定是否改动
+- `plan`：确定最小文件集合和验证路径
+- `change`：在保留无关本地改动的前提下编辑目标文件
+- `verify`：运行测试、linter 或聚焦命令来验证声称的修复
+- `handoff`：总结 diff、剩余风险以及 reviewer 接下来该关注什么
+
+关键的系统边界不是“模型是否会写代码”，而是运行时是否能让智能体停留在
+目标仓库、工具和审批范围内，同时保留可读的审计轨迹。
+
+## 架构图
+
+```mermaid
+flowchart LR
+  Task["Issue 或任务提示"] --> Inspect["仓库检查"]
+  Inspect --> Plan["范围化计划"]
+  Plan --> Edit["文件编辑"]
+  Edit --> Verify["测试与检查"]
+  Verify --> Diff["补丁、日志、总结"]
+  Diff --> Review["人工评审或合并队列"]
+```
+
+## 工具版图
+
+编码智能体通常需要组合这些能力：
+
+- 用于读取代码、文档和配置的仓库访问
+- 能产出可审查补丁的文件编辑工具
+- 用于测试、格式化、构建和 git 检查的 shell 能力
+- 当任务依赖当前文档或运行中的 UI 时的浏览器或网页访问
+- 面向审批、网络访问和破坏性命令的 guardrails
+
+OpenAI 当前的 Codex 表面比很多早期编码助手更清楚地暴露了这条分工线：
+
+- 云端 Codex 将软件任务描述为各自独立的运行，每次运行都在 sandbox 环境
+  中并预装仓库
+- 开源的 Codex CLI 则把本地路径描述为一个终端编码智能体，具备 approval
+  modes、MCP 访问、web search 和 cloud-task handoff
+
+因此，编码智能体更适合被教授为一条端到端系统循环，而不只是模型输出质
+量问题。
+
+## Guardrails
+
+对编码智能体来说，有用的默认做法包括：
+
+- 从仓库检查开始，而不是立刻编辑
+- 尽量缩小写入范围
+- 保留无关的 working-tree 改动
+- 在宣称完成前要求显式验证
+- 让命令输出、diff 和测试结果对 reviewer 可见
+- 将 secrets、生产凭据和破坏性 git 命令视为单独审批边界
+
+如果环境同时支持本地执行和云端执行，就要把信任边界讲清楚。本地执行能看
+到开发者真实机器状态，但也会继承更多 secrets 与工作站风险。云端 sandbox
+更容易隔离，但仍然需要明确的仓库、密钥和网络策略。
+
+## 权衡
+
+- 更高自治度能减少复制粘贴工作，但也会增加广泛误改的风险。
+- 本地执行能看到真实仓库和环境，但会继承更多 secrets 与工作站风险。
+- 云端 sandbox 更容易隔离，但如果依赖和 secrets 不一致，也可能偏离真实
+  本地设置。
+- 快速生成 patch 看起来很高效，但更慢一点的 inspect 加 verify 循环通常会
+  产生更好的改动。
+
+实用默认做法：
+
+- 用本地或云端编码智能体来检查、修改并验证
+- 让人类保留 merge 决策权
+- 优先追求可追踪的 diff 和可复现的检查，而不是一次性代码生成
+
+## 当前产品信号
+
+本次手册运行的当前七日信号是 `OpenAI Codex`。这个词先来自已存储的文章覆
+盖，然后再用当前的一手文档和公开 GitHub 仓库完成核实。
+
+可复用的经验比某一家供应商更广：
+
+- 编码智能体正在变成一个独立产品类别
+- 最有效的形态是 repository-first、verification-heavy、approval-aware
+- 团队应把它们作为带有 memory、tools、policies 和 review artifacts 的
+  智能体系统来评估，而不是把它们当作纯 prompt UX
+
+## 入门方向
+
+如果你要一个最快的实践入口，可以先看现有的
+[Codex 桌面智能体设置](/zh-Hans/workshops/desktop-agents/codex) 工作坊。它
+是这个仓库里从安装走到真实仓库工作的最短路径。
+
+然后再把本页连接到：
+
+- [评估与可观测性](/zh-Hans/systems/evaluation-and-observability)，理解验
+  证和轨迹循环
+- [上下文工程](/zh-Hans/systems/context-engineering)，理解 instruction、
+  state 和 retrieval 边界
+- [案例研究总览](/zh-Hans/case-studies)，对照 deep research 与客户支持
+  等其他产品形态
+
+## 引用
+
+- 官方来源：[Introducing Codex](https://openai.com/index/introducing-codex/)
+- 官方来源：[Codex CLI documentation](https://developers.openai.com/codex/cli)
+- 高信号仓库：[openai/codex](https://github.com/openai/codex)
+
+## 延伸阅读
+
+- [Codex 桌面智能体设置](/zh-Hans/workshops/desktop-agents/codex)
+- [评估与可观测性](/zh-Hans/systems/evaluation-and-observability)
+- [上下文工程](/zh-Hans/systems/context-engineering)
+- [案例研究总览](/zh-Hans/case-studies)
+
+## 更新日志
+
+- 2026-05-03：新增一个 repo 原生的编码智能体案例研究，用当前 OpenAI
+  Codex 信号锚定，并与仓库现有的 Codex 工作坊互相链接。

--- a/zh-Hans/case-studies/index.mdx
+++ b/zh-Hans/case-studies/index.mdx
@@ -25,6 +25,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 ## 当前页面
 
 - [Deep Research Agents](/zh-Hans/case-studies/deep-research-agents)：对规划、证据收集、综合整理和引用规范的有边界审视。
+- [Coding Agents](/zh-Hans/case-studies/coding-agents)：一个以仓库为先的案例研究，聚焦范围化改动、验证、审批和人工评审。
 - [Customer Support Agents](/zh-Hans/case-studies/customer-support-agents)：一个面向本地优先的案例研究，用于电子邮件分流和基于政策的回复草拟。
 
 ## 示例入门项目

--- a/zh-Hans/contributor-kit/contribution-workflow.mdx
+++ b/zh-Hans/contributor-kit/contribution-workflow.mdx
@@ -9,9 +9,9 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 当你想报告问题、提出改进建议，或为 Agent Systems Handbook 做贡献时，请使用这条流程。
 
-这里说的是本手册实际采用的 GitHub 协作流程，不是有 release branch 的正式
-GitFlow 模型。顺序是：提问或创建 issue、认领工作、创建小分支、打开 pull
-request，并回应 review。
+这里说的是本手册普通贡献工作实际采用的 GitHub 协作流程，不是生产发布流程。
+顺序是：提问或创建 issue、认领工作、基于 `develop` 创建小分支、把 pull request
+打回 `develop`，并回应 review。
 
 ## 选择正确入口
 
@@ -72,7 +72,7 @@ Claim request:
 
 然后从你的 fork 工作：
 
-1. 基于最新 `main` 创建分支。
+1. 基于最新 `develop` 创建分支。
 2. 让分支聚焦在已认领的 issue 上。
 3. 把文件放到正确的贡献 lane 或模板路径。
 4. 添加或更新链接，让工作可被发现。
@@ -82,7 +82,9 @@ Claim request:
 
 ## 打开 Pull Request
 
-将 pull request 打到 `Prompthon-IO/agent-systems-handbook:main`。
+将 pull request 打到 `Prompthon-IO/agent-systems-handbook:develop`。
+
+`main` 只保留给维护者执行的发布 PR 和 Mintlify 生产环境部署。
 
 ![GitHub 打开 pull request 的页面](/assets/contributor-workflow/github-open-pr.png)
 


### PR DESCRIPTION
## Summary
- add a new `Coding Agents` case study page in English and Chinese
- connect the new page from the case-studies overview and README surfaces
- anchor the page in the current `OpenAI Codex` signal and link back to the existing Codex workshop

## Why this run
The seven-day stored article window surfaced a coding-agent / Codex signal, but the deterministic selector's top generic terms were too broad to make a useful PR. This branch keeps the handbook change narrow by filling the missing `Coding agents` destination that already existed in the repo taxonomy.

## Sources used
- https://openai.com/index/introducing-codex/
- https://developers.openai.com/codex/cli
- https://github.com/openai/codex

## Verification
- `python3 scripts/verify_example_projects.py`
- `git diff --check`