### PR TITLE
fix: address release PR review feedback

### DIFF
--- a/.github/discord-lab-updates.md
+++ b/.github/discord-lab-updates.md
@@ -1,8 +1,8 @@
 # Discord Lab Updates Automation
 
 This repository enqueues Discord announcement jobs for Agentic Labs GitHub
-events: issue `good-first-issue` labels, PR coordination, PR merges, and direct
-pushes to `main`.
+events: issue `good-first-issue` labels, PR coordination for `develop` and
+`main`, PR merges, and direct pushes to `main`.
 A separate local announcer worker drains those jobs from Postgres and posts
 them to the Agentic Labs Discord channels.
 
@@ -44,7 +44,8 @@ Postgres and does not post to Discord.
 
 ## Runtime Flow
 
-1. A matching issue, PR, or direct `main` push event lands in GitHub.
+1. A matching issue, `develop` or `main` PR, or direct `main` push event lands
+   in GitHub.
 2. `.github/workflows/discord-lab-updates.yml` checks out the repo and runs the
    enqueue script.
 3. The script inserts one or more deduped rows into

--- a/.github/scripts/enqueue-discord-announcement.mjs
+++ b/.github/scripts/enqueue-discord-announcement.mjs
@@ -358,7 +358,8 @@ function buildPullRequestJobs(event) {
   if (!pullRequest) {
     return [];
   }
-  if (pullRequest.base?.ref !== "main") {
+  const baseRef = pullRequest.base?.ref;
+  if (!["develop", "main"].includes(baseRef)) {
     return [];
   }
 
@@ -383,6 +384,10 @@ function buildPullRequestJobs(event) {
         repoUrl,
       }),
     ];
+  }
+
+  if (baseRef !== "main") {
+    return [];
   }
 
   if (action === "closed" && pullRequest.merged) {

--- a/.github/scripts/enqueue-discord-announcement.test.mjs
+++ b/.github/scripts/enqueue-discord-announcement.test.mjs
@@ -159,3 +159,68 @@ test("fork pull request events skip cleanly when Actions secrets are unavailable
     },
   ]);
 });
+
+test("develop pull request events enqueue code review coordination", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "discord-announcer-"));
+  const eventPath = path.join(tempDir, "event.json");
+
+  writeJson(eventPath, {
+    action: "opened",
+    repository: {
+      full_name: "Prompthon-IO/agent-systems-handbook",
+      html_url: "https://github.com/Prompthon-IO/agent-systems-handbook",
+    },
+    pull_request: {
+      base: {
+        ref: "develop",
+      },
+      body: "Adds a focused contributor guide.",
+      head: {
+        repo: {
+          full_name: "Prompthon-IO/agent-systems-handbook",
+        },
+        sha: "abc123",
+      },
+      html_url: "https://github.com/Prompthon-IO/agent-systems-handbook/pull/99",
+      number: 99,
+      title: "docs: add contributor guide",
+      user: {
+        login: "contributor",
+      },
+    },
+    sender: {
+      login: "contributor",
+    },
+  });
+
+  const result = spawnSync(process.execPath, [scriptPath, "--dry-run"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      DISCORD_CODE_REVIEW_CHANNEL_ID: "1499430188105334997",
+      GITHUB_EVENT_NAME: "pull_request",
+      GITHUB_EVENT_PATH: eventPath,
+      GITHUB_REF_NAME: "feature/contributor-guide",
+      GITHUB_REPOSITORY: "Prompthon-IO/agent-systems-handbook",
+      GITHUB_SHA: "abc123",
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.dryRun, true);
+  assert.deepEqual(output.jobs, [
+    {
+      channelKey: "code-review",
+      commitSha: "abc123",
+      dedupeKey: "Prompthon-IO/agent-systems-handbook:pr:99:opened:code-review",
+      discordChannelId: "1499430188105334997",
+      eventType: "github_pull_request_opened",
+      prNumber: 99,
+      prTitle: "docs: add contributor guide",
+      repoFullName: "Prompthon-IO/agent-systems-handbook",
+      sourceUrl: "https://github.com/Prompthon-IO/agent-systems-handbook/pull/99",
+    },
+  ]);
+});

--- a/.github/workflows/discord-lab-updates.yml
+++ b/.github/workflows/discord-lab-updates.yml
@@ -10,6 +10,7 @@ on:
       - closed
   pull_request:
     branches:
+      - develop
       - main
     types:
       - opened

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -22,6 +22,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Require main ref
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "::error::release-main must run from main, not ${GITHUB_REF_NAME}."
+            exit 1
+          fi
+
       - name: Create date-based release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/docs.json
+++ b/docs.json
@@ -119,6 +119,7 @@
                 "pages": [
                   "case-studies/index",
                   "case-studies/deep-research-agents",
+                  "case-studies/coding-agents",
                   "case-studies/customer-support-agents"
                 ]
               },
@@ -174,7 +175,9 @@
                 "group": "Contribution types",
                 "pages": [
                   "contributor-kit/article-guidelines",
+                  "contributor-kit/radar-note-guidelines",
                   "contributor-kit/source-project-guidelines",
+                  "contributor-kit/reference-note-guidelines",
                   "contributor-kit/skill-package-guidelines",
                   "contributor-kit/discord-activity-record"
                 ]
@@ -340,6 +343,7 @@
                 "pages": [
                   "zh-Hans/case-studies/index",
                   "zh-Hans/case-studies/deep-research-agents",
+                  "zh-Hans/case-studies/coding-agents",
                   "zh-Hans/case-studies/customer-support-agents"
                 ]
               },
@@ -392,7 +396,9 @@
                 "group": "贡献类型",
                 "pages": [
                   "zh-Hans/contributor-kit/article-guidelines",
+                  "zh-Hans/contributor-kit/radar-note-guidelines",
                   "zh-Hans/contributor-kit/source-project-guidelines",
+                  "zh-Hans/contributor-kit/reference-note-guidelines",
                   "zh-Hans/contributor-kit/skill-package-guidelines",
                   "zh-Hans/contributor-kit/discord-activity-record"
                 ]


### PR DESCRIPTION
## Summary
- register the new Coding Agents case-study pages in English and Chinese Mintlify navigation
- restore radar-note and reference-note guideline pages in English and Chinese navigation
- run Discord PR coordination for `develop` PRs and keep merge announcements scoped to `main`
- guard manual `release-main` runs so production releases can only be minted from `main`

## Validation
- `node --test .github/scripts/enqueue-discord-announcement.test.mjs`
- `node --check .github/scripts/enqueue-discord-announcement.mjs`
- `node --check .github/scripts/enqueue-discord-announcement.test.mjs`
- `python3 -m json.tool docs.json`
- `ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path) }' .github/workflows/discord-lab-updates.yml .github/workflows/release-main.yml`\n- `python3 scripts/verify_example_projects.py`\n- `npx --yes mint@latest validate`\n- `npx --yes mint@latest broken-links`\n- `git diff --check`