### PR TITLE
Rename workshops tab to events

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -44,36 +44,6 @@
             ]
           },
           {
-            "tab": "Workshops",
-            "icon": "graduation-cap",
-            "groups": [
-              {
-                "group": "Workshop tracks",
-                "pages": [
-                  "workshops/index",
-                  "workshops/openclaw/index"
-                ]
-              },
-              {
-                "group": "OpenClaw",
-                "pages": [
-                  "workshops/openclaw/install-windows",
-                  "workshops/openclaw/install-mac",
-                  "workshops/openclaw/accounts-and-onboarding",
-                  "workshops/openclaw/commands"
-                ]
-              },
-              {
-                "group": "Desktop agents and skills",
-                "pages": [
-                  "workshops/desktop-agents/codex",
-                  "workshops/desktop-agents/claude-code",
-                  "workshops/skills-introduction"
-                ]
-              }
-            ]
-          },
-          {
             "tab": "Handbook",
             "icon": "book-open",
             "groups": [
@@ -133,6 +103,31 @@
                   "radar/2026-04-local-agent-watch",
                   "radar/2026-04-interoperability-watch",
                   "radar/2026-04-protocol-watch"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Events",
+            "icon": "calendar-days",
+            "groups": [
+              {
+                "group": "Events",
+                "pages": [
+                  "workshops/index"
+                ]
+              },
+              {
+                "group": "Workshop materials",
+                "pages": [
+                  "workshops/openclaw/index",
+                  "workshops/openclaw/install-windows",
+                  "workshops/openclaw/install-mac",
+                  "workshops/openclaw/accounts-and-onboarding",
+                  "workshops/openclaw/commands",
+                  "workshops/desktop-agents/codex",
+                  "workshops/desktop-agents/claude-code",
+                  "workshops/skills-introduction"
                 ]
               }
             ]
@@ -268,36 +263,6 @@
             ]
           },
           {
-            "tab": "工作坊",
-            "icon": "graduation-cap",
-            "groups": [
-              {
-                "group": "工作坊路线",
-                "pages": [
-                  "zh-Hans/workshops/index",
-                  "zh-Hans/workshops/openclaw/index"
-                ]
-              },
-              {
-                "group": "OpenClaw",
-                "pages": [
-                  "zh-Hans/workshops/openclaw/install-windows",
-                  "zh-Hans/workshops/openclaw/install-mac",
-                  "zh-Hans/workshops/openclaw/accounts-and-onboarding",
-                  "zh-Hans/workshops/openclaw/commands"
-                ]
-              },
-              {
-                "group": "桌面智能体与 Skills",
-                "pages": [
-                  "zh-Hans/workshops/desktop-agents/codex",
-                  "zh-Hans/workshops/desktop-agents/claude-code",
-                  "zh-Hans/workshops/skills-introduction"
-                ]
-              }
-            ]
-          },
-          {
             "tab": "手册",
             "icon": "book-open",
             "groups": [
@@ -354,6 +319,31 @@
                   "zh-Hans/radar/2026-04-local-agent-watch",
                   "zh-Hans/radar/2026-04-interoperability-watch",
                   "zh-Hans/radar/2026-04-protocol-watch"
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "活动",
+            "icon": "calendar-days",
+            "groups": [
+              {
+                "group": "活动",
+                "pages": [
+                  "zh-Hans/workshops/index"
+                ]
+              },
+              {
+                "group": "工作坊材料",
+                "pages": [
+                  "zh-Hans/workshops/openclaw/index",
+                  "zh-Hans/workshops/openclaw/install-windows",
+                  "zh-Hans/workshops/openclaw/install-mac",
+                  "zh-Hans/workshops/openclaw/accounts-and-onboarding",
+                  "zh-Hans/workshops/openclaw/commands",
+                  "zh-Hans/workshops/desktop-agents/codex",
+                  "zh-Hans/workshops/desktop-agents/claude-code",
+                  "zh-Hans/workshops/skills-introduction"
                 ]
               }
             ]

--- a/workshops/index.mdx
+++ b/workshops/index.mdx
@@ -1,18 +1,32 @@
 ---
-title: "Workshops"
-description: "Guided setup tracks for local agents, workshop tools, and repeatable skill-based workflows."
+title: "Events"
+description: "Upcoming and past Prompthon events, plus the workshop materials used during hands-on sessions."
 ---
 
 import SupportCTA from "/snippets/support-cta.mdx";
 
 <SupportCTA />
 
-Workshops are practical, step-by-step tracks for getting local agent tools ready
-for real use. They sit between the high-level practitioner path and the deeper
-builder examples: enough structure to follow in a session, but still grounded in
-the repo's public terminology and contribution rules.
+Events are the public record for Prompthon workshop sessions and community
+learning activities. This page keeps upcoming sessions, past event history, and
+the hands-on materials used during workshops in one place.
 
-## Current Workshops
+## Upcoming Events
+
+| Time | Address | Topic | Language |
+| --- | --- | --- | --- |
+
+No upcoming events are listed yet.
+
+## Past Events
+
+| Time | Address | Topic | Language |
+| --- | --- | --- | --- |
+| TBD | TBD | Past event placeholder 1 | TBD |
+| TBD | TBD | Past event placeholder 2 | TBD |
+| TBD | TBD | Past event placeholder 3 | TBD |
+
+## Workshop Materials
 
 <CardGroup cols={2}>
   <Card title="OpenClaw Workshop" icon="graduation-cap" href="/workshops/openclaw">
@@ -33,10 +47,10 @@ the repo's public terminology and contribution rules.
   </Card>
 </CardGroup>
 
-## How To Use This Track
+## How To Use The Materials
 
-Start with the tool you need for the workshop you are joining. If you are not
-sure, use this order:
+Start with the tool you need for the event you are joining. If you are not sure,
+use this order:
 
 1. Install a local agent surface: [Codex](/workshops/desktop-agents/codex) or
    [Claude Code](/workshops/desktop-agents/claude-code).
@@ -45,6 +59,6 @@ sure, use this order:
    to make repeated workflows easier to invoke.
 
 <Note>
-  Workshop pages are public learning material. Do not publish private tokens,
-  personal account details, or screenshots that expose credentials.
+  Event and workshop pages are public learning material. Do not publish private
+  tokens, personal account details, or screenshots that expose credentials.
 </Note>

--- a/workshops/index.mdx
+++ b/workshops/index.mdx
@@ -13,18 +13,16 @@ the hands-on materials used during workshops in one place.
 
 ## Upcoming Events
 
-| Event | Time | Address / access | Language | Brief |
-| --- | --- | --- | --- | --- |
-
-No upcoming events are listed yet.
+No upcoming events are listed yet. Join
+[Discord](https://discord.gg/sDE2HhGTg4) to get the latest updates.
 
 ## Past Events
 
 | Event | Time | Address / access | Language | Brief |
 | --- | --- | --- | --- | --- |
-| Career Development Conference & Job Fair | March 15, 2026, Sunday, 12:00 PM-4:00 PM | 900 York Mills Rd, North York; Crowne Plaza Toronto, Prince Ballroom | English / likely bilingual support | Free career development conference and job fair. Dress code: business formal or business casual. |
+| Career Development Conference & Job Fair | March 15, 2026, Sunday, 12:00 PM-4:00 PM | 900 York Mills Rd, North York; Crowne Plaza Toronto, Prince Ballroom | English | Free career development conference and job fair. Dress code: business formal or business casual. |
 | How to Enter the AI Industry Within Six Months | March 16, 2026, Monday, 8:00 PM Toronto time | Zoom online meeting | Chinese / Mandarin | Online AI career webinar by Victoria Training Center covering generative AI internship projects, enterprise mentors, AI skill training, internship opportunities, resume and interview coaching, and reference support. |
-| York University Tech Career Webinar / Workshop | April 23, 2026, 6:30 PM | York University First Student Centre, 3rd Floor, Room 307; 4700 Keele St #335, North York, ON M3J 1P3 | Not specified / likely English | Tech career-focused session at York University, likely for students or early-career participants interested in technology career paths. |
+| York University Tech Career Webinar / Workshop | April 23, 2026, 6:30 PM | York University First Student Centre, 3rd Floor, Room 307; 4700 Keele St #335, North York, ON M3J 1P3 | English | Tech career-focused session at York University, likely for students or early-career participants interested in technology career paths. |
 | OpenClaw Workshop: Set Up Your Own AI Agent | April 25, 2026, Saturday, 1:00 PM Toronto time | 7050 Woodbine Ave., #300, Markham | Chinese / Mandarin | Free in-person OpenClaw workshop and installation support session, limited to 20 spots, first come first served. |
 
 ## Workshop Materials

--- a/workshops/index.mdx
+++ b/workshops/index.mdx
@@ -13,18 +13,19 @@ the hands-on materials used during workshops in one place.
 
 ## Upcoming Events
 
-| Time | Address | Topic | Language |
-| --- | --- | --- | --- |
+| Event | Time | Address / access | Language | Brief |
+| --- | --- | --- | --- | --- |
 
 No upcoming events are listed yet.
 
 ## Past Events
 
-| Time | Address | Topic | Language |
-| --- | --- | --- | --- |
-| TBD | TBD | Past event placeholder 1 | TBD |
-| TBD | TBD | Past event placeholder 2 | TBD |
-| TBD | TBD | Past event placeholder 3 | TBD |
+| Event | Time | Address / access | Language | Brief |
+| --- | --- | --- | --- | --- |
+| Career Development Conference & Job Fair | March 15, 2026, Sunday, 12:00 PM-4:00 PM | 900 York Mills Rd, North York; Crowne Plaza Toronto, Prince Ballroom | English / likely bilingual support | Free career development conference and job fair. Dress code: business formal or business casual. |
+| How to Enter the AI Industry Within Six Months | March 16, 2026, Monday, 8:00 PM Toronto time | Zoom online meeting | Chinese / Mandarin | Online AI career webinar by Victoria Training Center covering generative AI internship projects, enterprise mentors, AI skill training, internship opportunities, resume and interview coaching, and reference support. |
+| York University Tech Career Webinar / Workshop | April 23, 2026, 6:30 PM | York University First Student Centre, 3rd Floor, Room 307; 4700 Keele St #335, North York, ON M3J 1P3 | Not specified / likely English | Tech career-focused session at York University, likely for students or early-career participants interested in technology career paths. |
+| OpenClaw Workshop: Set Up Your Own AI Agent | April 25, 2026, Saturday, 1:00 PM Toronto time | 7050 Woodbine Ave., #300, Markham | Chinese / Mandarin | Free in-person OpenClaw workshop and installation support session, limited to 20 spots, first come first served. |
 
 ## Workshop Materials
 

--- a/zh-Hans/workshops/index.mdx
+++ b/zh-Hans/workshops/index.mdx
@@ -11,18 +11,16 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 ## 即将举行的活动
 
-| 活动 | 时间 | 地址 / 参与方式 | 语言 | 简介 |
-| --- | --- | --- | --- | --- |
-
-目前还没有列出即将举行的活动。
+目前还没有列出即将举行的活动。加入
+[Discord](https://discord.gg/sDE2HhGTg4) 获取最新更新。
 
 ## 过往活动
 
 | 活动 | 时间 | 地址 / 参与方式 | 语言 | 简介 |
 | --- | --- | --- | --- | --- |
-| Career Development Conference & Job Fair | 2026 年 3 月 15 日，星期日，12:00 PM-4:00 PM | 900 York Mills Rd, North York；Crowne Plaza Toronto, Prince Ballroom | 英文 / 可能提供双语支持 | 免费职业发展会议和招聘会。着装建议为商务正装或商务休闲。 |
+| Career Development Conference & Job Fair | 2026 年 3 月 15 日，星期日，12:00 PM-4:00 PM | 900 York Mills Rd, North York；Crowne Plaza Toronto, Prince Ballroom | 英文 | 免费职业发展会议和招聘会。着装建议为商务正装或商务休闲。 |
 | How to Enter the AI Industry Within Six Months | 2026 年 3 月 16 日，星期一，多伦多时间 8:00 PM | Zoom 线上会议 | 中文 / 普通话 | Victoria Training Center 举办的线上 AI 职业讲座，内容包括生成式 AI 实习项目、企业导师、AI 技能训练、实习机会、简历和面试辅导，以及推荐支持。 |
-| York University Tech Career Webinar / Workshop | 2026 年 4 月 23 日，6:30 PM | York University First Student Centre, 3rd Floor, Room 307；4700 Keele St #335, North York, ON M3J 1P3 | 未注明 / 可能为英文 | 约克大学技术职业主题活动，可能面向对技术职业路径感兴趣的学生和早期职业参与者。 |
+| York University Tech Career Webinar / Workshop | 2026 年 4 月 23 日，6:30 PM | York University First Student Centre, 3rd Floor, Room 307；4700 Keele St #335, North York, ON M3J 1P3 | 英文 | 约克大学技术职业主题活动，可能面向对技术职业路径感兴趣的学生和早期职业参与者。 |
 | OpenClaw Workshop: Set Up Your Own AI Agent | 2026 年 4 月 25 日，星期六，多伦多时间 1:00 PM | 7050 Woodbine Ave., #300, Markham | 中文 / 普通话 | 免费线下 OpenClaw 工作坊和安装支持活动，限 20 个名额，先到先得。 |
 
 ## 工作坊材料

--- a/zh-Hans/workshops/index.mdx
+++ b/zh-Hans/workshops/index.mdx
@@ -1,15 +1,30 @@
 ---
-title: "工作坊"
-description: "面向本地智能体、工作坊工具和可重复技能工作流的上手路线。"
+title: "活动"
+description: "Prompthon 活动预告、历史活动记录，以及实操工作坊使用的材料。"
 ---
 
 import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 <SupportCTA />
 
-工作坊是更偏实践的分步路线，用来帮助读者把本地智能体工具真正准备好。它位于高层实践者路径和更深入的构建者示例之间：足够具体，适合跟着一次活动完成；同时仍然使用 Prompthon Agentic Labs 的公开术语和贡献边界。
+活动页用来记录 Prompthon 工作坊和社区学习活动。这里集中放置即将举行的活动、过往活动记录，以及工作坊中会用到的实操材料。
 
-## 当前工作坊
+## 即将举行的活动
+
+| 时间 | 地址 | 主题 | 语言 |
+| --- | --- | --- | --- |
+
+目前还没有列出即将举行的活动。
+
+## 过往活动
+
+| 时间 | 地址 | 主题 | 语言 |
+| --- | --- | --- | --- |
+| 待补充 | 待补充 | 过往活动占位 1 | 待补充 |
+| 待补充 | 待补充 | 过往活动占位 2 | 待补充 |
+| 待补充 | 待补充 | 过往活动占位 3 | 待补充 |
+
+## 工作坊材料
 
 <CardGroup cols={2}>
   <Card title="OpenClaw 工作坊" icon="graduation-cap" href="/zh-Hans/workshops/openclaw">
@@ -26,7 +41,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
   </Card>
 </CardGroup>
 
-## 如何使用这条路线
+## 如何使用这些材料
 
 如果不确定从哪里开始，按这个顺序走：
 
@@ -35,5 +50,5 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 3. 当你准备把重复流程变得更容易调用时，再阅读 [Skills 入门](/zh-Hans/workshops/skills-introduction)。
 
 <Note>
-  工作坊页面是公开学习材料。不要发布私人 token、个人账号细节，或暴露凭据的截图。
+  活动和工作坊页面是公开学习材料。不要发布私人 token、个人账号细节，或暴露凭据的截图。
 </Note>

--- a/zh-Hans/workshops/index.mdx
+++ b/zh-Hans/workshops/index.mdx
@@ -11,18 +11,19 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 ## 即将举行的活动
 
-| 时间 | 地址 | 主题 | 语言 |
-| --- | --- | --- | --- |
+| 活动 | 时间 | 地址 / 参与方式 | 语言 | 简介 |
+| --- | --- | --- | --- | --- |
 
 目前还没有列出即将举行的活动。
 
 ## 过往活动
 
-| 时间 | 地址 | 主题 | 语言 |
-| --- | --- | --- | --- |
-| 待补充 | 待补充 | 过往活动占位 1 | 待补充 |
-| 待补充 | 待补充 | 过往活动占位 2 | 待补充 |
-| 待补充 | 待补充 | 过往活动占位 3 | 待补充 |
+| 活动 | 时间 | 地址 / 参与方式 | 语言 | 简介 |
+| --- | --- | --- | --- | --- |
+| Career Development Conference & Job Fair | 2026 年 3 月 15 日，星期日，12:00 PM-4:00 PM | 900 York Mills Rd, North York；Crowne Plaza Toronto, Prince Ballroom | 英文 / 可能提供双语支持 | 免费职业发展会议和招聘会。着装建议为商务正装或商务休闲。 |
+| How to Enter the AI Industry Within Six Months | 2026 年 3 月 16 日，星期一，多伦多时间 8:00 PM | Zoom 线上会议 | 中文 / 普通话 | Victoria Training Center 举办的线上 AI 职业讲座，内容包括生成式 AI 实习项目、企业导师、AI 技能训练、实习机会、简历和面试辅导，以及推荐支持。 |
+| York University Tech Career Webinar / Workshop | 2026 年 4 月 23 日，6:30 PM | York University First Student Centre, 3rd Floor, Room 307；4700 Keele St #335, North York, ON M3J 1P3 | 未注明 / 可能为英文 | 约克大学技术职业主题活动，可能面向对技术职业路径感兴趣的学生和早期职业参与者。 |
+| OpenClaw Workshop: Set Up Your Own AI Agent | 2026 年 4 月 25 日，星期六，多伦多时间 1:00 PM | 7050 Woodbine Ave., #300, Markham | 中文 / 普通话 | 免费线下 OpenClaw 工作坊和安装支持活动，限 20 个名额，先到先得。 |
 
 ## 工作坊材料
 


### PR DESCRIPTION
## Summary
- Rename the Workshops tab to Events and move it after Handbook in English and Chinese navigation.
- Convert the workshops landing page into an events hub with upcoming and past event tables.
- Keep existing OpenClaw, desktop agent, and skills pages grouped as workshop materials.

## Verification
- jq empty docs.json
- PATH=/usr/local/Cellar/node/23.9.0/bin:$PATH npm_config_cache=/tmp/mint-npx-cache-events-tab-node23 npx --yes mint@latest validate

## Account
- Commit authored with saved contributor profile gongxiaojing0825.
- Pushed/opened using existing shared executor gh auth dprat0821 because the contributor profile has no push token or SSH key.