### PR TITLE
feat: price-watcher initial commit (#35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ __pycache__/
 
 # Local runtime state
 .local-state/
-price-watcher-live-run/

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 
 # Local runtime state
 .local-state/
+price-watcher-live-run/

--- a/skills/price-watcher/README.md
+++ b/skills/price-watcher/README.md
@@ -1,4 +1,4 @@
-﻿# Price Watcher
+# Price Watcher
 
 ## Why This Skill Exists
 

--- a/skills/price-watcher/README.md
+++ b/skills/price-watcher/README.md
@@ -1,5 +1,9 @@
 # Price Watcher
 
+## Demo Video
+
+Watch a short walkthrough of this skill: [Price Watcher demo](https://youtu.be/i9qOsDBVg70).
+
 ## Why This Skill Exists
 
 This package is a Practitioner-facing workflow example for persistent product

--- a/skills/price-watcher/README.md
+++ b/skills/price-watcher/README.md
@@ -1,0 +1,103 @@
+﻿# Price Watcher
+
+## Why This Skill Exists
+
+This package is a Practitioner-facing workflow example for persistent product
+price tracking.
+
+It exists because "watch this product and tell me when it drops below my price"
+sounds like a simple prompt, but it needs durable local state, repeated source
+checks, product matching, price history, and report generation across sessions.
+A one-off chat answer cannot reliably remember watched items or compare today
+against previous checks.
+
+The package demonstrates a better pattern:
+
+- accept natural-language product requests
+- discover product sources instead of requiring pasted URLs
+- normalize likely product matches across retailers
+- store watched items and source URLs in SQLite
+- append price observations over time
+- generate lowest-price-first Markdown reports
+
+## Who It Is For
+
+This skill is for students, contributors, and operators who want to understand
+what a real Codex-compatible local workflow looks like when persistent state,
+browser-assisted lookup, and user-facing reports matter.
+
+It is most useful for requests such as:
+
+- watch a laptop, appliance, or other product until it drops below a target price
+- check all active watched items and summarize the best current prices
+- compare observed prices against the last recorded check
+- produce a local Markdown report that can be reviewed before any notification
+  workflow is added
+
+## End-to-End Workflow
+
+The workflow is intentionally local-first and source-aware:
+
+1. Parse the user's natural-language product request and target price.
+2. Store the original watched query in SQLite.
+3. Discover matching product pages across multiple sources.
+4. Normalize product identity so likely same-product matches can be deduplicated.
+5. Save source URLs for the watched item.
+6. Check known sources on demand, using browser automation where normal page
+   rendering is needed.
+7. Extract and normalize visible prices and currencies.
+8. Append price observations to history.
+9. Compare current prices against the previous check and target threshold.
+10. Write a Markdown report to `price-reports/YYYY-MM-DD.md`.
+
+That is the main teaching point of the package. The skill is not just "scrape a
+URL." It is a persistent watch-list workflow with product discovery, historical
+comparison, and reportable state.
+
+## What The Package Actually Does
+
+The package currently focuses on the v1 price-watching loop from issue #35:
+
+- natural-language watched-item setup
+- SQLite persistence using `items`, `sources`, and `price_checks`
+- multiple source URLs per watched product
+- helper commands for adding items, adding sources, recording prices, and
+  writing reports
+- reference guidance for source discovery, product normalization, and price
+  parsing
+- Markdown reports sorted by the lowest currently observed price
+
+The deterministic helper script is `scripts/price_watcher.py`. It manages local
+state and report generation. Live product discovery and Playwright/browser use
+are described in `SKILL.md` so Codex can apply the right runtime tools in the
+execution environment.
+
+## What It Does Not Do
+
+This package does not:
+
+- require users to manually provide product URLs
+- buy products, add items to cart, reserve inventory, or initiate checkout
+- bypass account gates, CAPTCHAs, paywalls, bot checks, or other access controls
+- treat Amazon pages as available unless they are normally browser-accessible
+- send notifications in v1
+- commit runtime SQLite databases or generated reports by default
+
+## How To Read It In The Handbook
+
+Treat this package as a Practitioner example of a persistent, browser-adjacent
+local workflow:
+
+- `README.md` explains the human story and end-to-end process
+- `SKILL.md` explains when Codex should invoke the package
+- `scripts/price_watcher.py` implements deterministic SQLite and report helpers
+- `references/schema.md` documents the local database shape
+- `references/source-discovery.md` describes product matching and deduplication
+- `references/price-parsing.md` describes conservative price extraction rules
+
+If you are a student reading the repo, the main lesson is:
+
+1. durable agent workflows need explicit local state
+2. product matching should start from user intent, not fixed URLs
+3. recurring checks should append history and produce reviewable reports
+4. commerce-adjacent automation needs clear safety and access boundaries

--- a/skills/price-watcher/SKILL.md
+++ b/skills/price-watcher/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: price-watcher
+description: Persistent product price tracking for natural-language product requests. Use when a user asks to watch, track, monitor, compare, or report prices for a product, especially with a target price or threshold such as "Watch MacBook Pro M3 14-inch and tell me if it drops below $1200." Supports source discovery, Playwright/browser product checks, SQLite history, threshold comparison, and Markdown price reports.
+---
+
+# Price Watcher
+
+Track product prices from natural-language product descriptions. Do not require the user to provide product URLs. Store the watch query, discover and refresh multiple source URLs, save price history in SQLite, and write reports to `price-reports/YYYY-MM-DD.md`.
+
+## Quick Start
+
+Use `scripts/price_watcher.py` for deterministic local state operations:
+
+```bash
+python skills/price-watcher/scripts/price_watcher.py init
+python skills/price-watcher/scripts/price_watcher.py add "Watch MacBook Pro M3 14-inch and notify me if it drops below $1200"
+python skills/price-watcher/scripts/price_watcher.py sources add --item-id 1 --site "Best Buy" --url "https://..."
+python skills/price-watcher/scripts/price_watcher.py record --item-id 1 --source-id 1 --price 1199.99 --currency USD
+python skills/price-watcher/scripts/price_watcher.py report
+```
+
+Default runtime paths:
+
+- Database: `price-watcher.sqlite3`
+- Reports: `price-reports/YYYY-MM-DD.md`
+
+Keep runtime databases and generated reports out of git unless the user explicitly asks to commit examples.
+
+## Workflow A: Add Watched Item
+
+1. Parse the user's request into:
+   - `query`: the product description to keep watching.
+   - `target_price`: the numeric threshold if present.
+   - `currency`: infer from symbols or wording; default to the user's locale when unclear.
+2. Store the original product query, not a single fixed URL.
+3. Search across multiple sources using web search, retailer search pages, or shopping/search APIs available in the current environment.
+4. Normalize likely product matches:
+   - canonical product name
+   - brand/model/generation/size/storage/color or other important attributes
+   - marketplace or retailer site
+   - product URL
+5. Deduplicate likely same-product matches by comparing normalized names and attributes. Prefer exact model/generation matches over merely similar products.
+6. Add multiple source URLs for the item. Do not ask the user to manually provide URLs unless source discovery fails and the user wants to help.
+
+Use `python skills/price-watcher/scripts/price_watcher.py add "<request>"` after parsing to create the SQLite item, then add discovered source URLs with `sources add`.
+
+## Workflow B: Check Prices
+
+For each active item:
+
+1. Load active items and known sources from SQLite.
+2. Refresh source discovery when:
+   - no sources exist,
+   - known sources fail repeatedly,
+   - the user asks for broader coverage,
+   - a product appears discontinued or out of stock everywhere.
+3. Query all known sources. Use direct HTTP only when normal access works. Use Playwright/browser automation for pages that need client-side rendering.
+4. Respect access controls:
+   - Amazon scraping is allowed only through normal browser-accessible pages.
+   - Do not bypass login, bot challenges, paywalls, CAPTCHAs, or account gates.
+   - Do not purchase items, add to cart, reserve inventory, or initiate checkout.
+5. Extract price, currency, availability when visible, and failure/skipped notes.
+6. Normalize price and currency before storage. If conversion rates are needed and unavailable, keep the observed currency and do not compare across currencies as exact values.
+7. Save each successful observation to `price_checks`.
+8. Compare against the previous check for the same item/source and the item target price.
+9. Generate a Markdown report with `report`.
+
+## Report Requirements
+
+Write reports to `price-reports/YYYY-MM-DD.md`. Sort items lowest-price-first by the best current observed price. Include:
+
+- item query and normalized name
+- target price and whether the best price meets it
+- source links
+- observed prices and currencies
+- lowest price across sources
+- changes since the previous check
+- failed or skipped source notes
+
+Treat notifications as out of scope for v1. For a request like "notify me," store the threshold and write report status; do not send messages unless a later version adds a notification channel.
+
+## SQLite Schema
+
+Use this schema exactly unless the user asks for an extension:
+
+```sql
+items(id, query, normalized_name, target_price, created_at, active)
+sources(id, item_id, site, url, last_checked_at)
+price_checks(id, item_id, source_id, price, currency, checked_at)
+```
+
+See `references/schema.md` for column meanings and operational notes.
+
+## Price Extraction
+
+Prefer structured data in this order:
+
+1. JSON-LD product offers
+2. Open Graph/product meta tags
+3. retailer page state JSON
+4. visible DOM text near product title or buy box
+
+Use `references/source-discovery.md` for source discovery and normalization heuristics. Use `references/price-parsing.md` for price parsing rules.
+
+## Failure Handling
+
+Record failed or skipped sources in the report even when no price can be stored. Common notes:
+
+- `blocked: login required`
+- `skipped: CAPTCHA or bot challenge`
+- `skipped: checkout/cart-only price`
+- `failed: price not visible`
+- `failed: page unavailable`
+
+Do not invent prices. If a page shows a range, store the lowest visible purchasable price only when the report clearly states it was a range.

--- a/skills/price-watcher/SKILL.md
+++ b/skills/price-watcher/SKILL.md
@@ -5,24 +5,26 @@ description: Persistent product price tracking for natural-language product requ
 
 # Price Watcher
 
-Track product prices from natural-language product descriptions. Do not require the user to provide product URLs. Store the watch query, discover and refresh multiple source URLs, save price history in SQLite, and write reports to `price-reports/YYYY-MM-DD.md`.
+Track product prices from natural-language product descriptions. Do not require the user to provide product URLs. Store the watch query, discover and refresh multiple source URLs, save price history in SQLite, and write reports to the configured report directory.
 
 ## Quick Start
 
-Use `scripts/price_watcher.py` for deterministic local state operations:
+Resolve paths relative to this skill directory. Use `scripts/price_watcher.py` for deterministic local state operations:
 
 ```bash
-python skills/price-watcher/scripts/price_watcher.py init
-python skills/price-watcher/scripts/price_watcher.py add "Watch MacBook Pro M3 14-inch and notify me if it drops below $1200"
-python skills/price-watcher/scripts/price_watcher.py sources add --item-id 1 --site "Best Buy" --url "https://..."
-python skills/price-watcher/scripts/price_watcher.py record --item-id 1 --source-id 1 --price 1199.99 --currency USD
-python skills/price-watcher/scripts/price_watcher.py report
+cd skills/price-watcher
+python3 scripts/price_watcher.py init
+python3 scripts/price_watcher.py add "Watch MacBook Pro M3 14-inch and notify me if it drops below $1200"
+python3 scripts/price_watcher.py sources add --item-id 1 --site "Best Buy" --url "https://..."
+python3 scripts/price_watcher.py record --item-id 1 --source-id 1 --price 1199.99 --currency USD
+python3 scripts/price_watcher.py report
 ```
 
 Default runtime paths:
 
-- Database: `price-watcher.sqlite3`
-- Reports: `price-reports/YYYY-MM-DD.md`
+- State root: `~/.codex/state/price-watcher/`, override with `PRICE_WATCHER_STATE`
+- Database: `~/.codex/state/price-watcher/price-watcher.sqlite3`
+- Reports: `~/.codex/state/price-watcher/price-reports/YYYY-MM-DD.md`
 
 Keep runtime databases and generated reports out of git unless the user explicitly asks to commit examples.
 
@@ -42,7 +44,7 @@ Keep runtime databases and generated reports out of git unless the user explicit
 5. Deduplicate likely same-product matches by comparing normalized names and attributes. Prefer exact model/generation matches over merely similar products.
 6. Add multiple source URLs for the item. Do not ask the user to manually provide URLs unless source discovery fails and the user wants to help.
 
-Use `python skills/price-watcher/scripts/price_watcher.py add "<request>"` after parsing to create the SQLite item, then add discovered source URLs with `sources add`.
+Use `python3 scripts/price_watcher.py add "<request>"` after parsing to create the SQLite item, then add discovered source URLs with `sources add`.
 
 ## Workflow B: Check Prices
 
@@ -62,12 +64,12 @@ For each active item:
 5. Extract price, currency, availability when visible, and failure/skipped notes.
 6. Normalize price and currency before storage. If conversion rates are needed and unavailable, keep the observed currency and do not compare across currencies as exact values.
 7. Save each successful observation to `price_checks`.
-8. Compare against the previous check for the same item/source and the item target price.
+8. Compare against the previous check for the same item/source and the item target price only when currencies are comparable.
 9. Generate a Markdown report with `report`.
 
 ## Report Requirements
 
-Write reports to `price-reports/YYYY-MM-DD.md`. Sort items lowest-price-first by the best current observed price. Include:
+Write reports to the configured `price-reports/YYYY-MM-DD.md` directory. Sort items lowest-price-first by the best current observed price. Include:
 
 - item query and normalized name
 - target price and whether the best price meets it

--- a/skills/price-watcher/agents/openai.yaml
+++ b/skills/price-watcher/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Price Watcher"
+  short_description: "Track product prices with reports"
+  default_prompt: "Use $price-watcher to watch a product by natural-language description, discover sources, save price history, and write a Markdown report."
+policy:
+  allow_implicit_invocation: true

--- a/skills/price-watcher/references/price-parsing.md
+++ b/skills/price-watcher/references/price-parsing.md
@@ -1,0 +1,31 @@
+# Price Parsing
+
+Extract prices conservatively. Do not record a price unless it is visible or present in structured product offer data.
+
+## Currency
+
+Recognize common symbols:
+
+- `$` -> infer USD/CAD/AUD from site or user locale
+- `US$` -> USD
+- `CA$` -> CAD
+- `£` -> GBP
+- `€` -> EUR
+
+Store ISO-style currency codes when possible.
+
+## Parsing Rules
+
+- Remove thousands separators.
+- Preserve cents.
+- Ignore crossed-out list prices when a current sale price is visible.
+- Ignore monthly financing prices unless the product is normally sold as a subscription.
+- Ignore cart, checkout, or member-only prices if they require an account, cart action, or bypassing access controls.
+- If a page shows a range, report the range in Markdown and store the lowest visible price only when it is a valid purchasable price.
+
+## Preferred Extraction Order
+
+1. JSON-LD `Product.offers.price` and `priceCurrency`
+2. meta tags such as `product:price:amount`
+3. embedded page state JSON with offer data
+4. visible DOM text near the product title, price block, or buy box

--- a/skills/price-watcher/references/schema.md
+++ b/skills/price-watcher/references/schema.md
@@ -1,6 +1,6 @@
 # SQLite Schema
 
-Use a local SQLite database for persistent state. The default path is `price-watcher.sqlite3` in the current workspace unless the user supplies another path.
+Use a local SQLite database for persistent state. The helper defaults to `~/.codex/state/price-watcher/price-watcher.sqlite3` unless the user supplies `--db` or sets `PRICE_WATCHER_STATE`.
 
 ## Tables
 
@@ -39,5 +39,5 @@ CREATE TABLE IF NOT EXISTS price_checks (
 - Store a concise canonical product name in `items.normalized_name` once a confident match exists.
 - Keep `items.target_price` numeric and currency-neutral in the v1 schema. Report the inferred currency in prose when it matters.
 - Allow multiple source rows per item.
-- Update `sources.last_checked_at` every time a source is attempted, even if extraction fails and the failure only appears in the Markdown report.
+- Update `sources.last_checked_at` every time a source is attempted, even if extraction fails and the failure only appears in the Markdown report. Use `sources mark-checked --source-id <id>` when a source was attempted but no price row should be inserted.
 - Append to `price_checks`; do not overwrite history.

--- a/skills/price-watcher/references/schema.md
+++ b/skills/price-watcher/references/schema.md
@@ -1,0 +1,43 @@
+# SQLite Schema
+
+Use a local SQLite database for persistent state. The default path is `price-watcher.sqlite3` in the current workspace unless the user supplies another path.
+
+## Tables
+
+```sql
+CREATE TABLE IF NOT EXISTS items (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  query TEXT NOT NULL,
+  normalized_name TEXT,
+  target_price REAL,
+  created_at TEXT NOT NULL,
+  active INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS sources (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  item_id INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  site TEXT NOT NULL,
+  url TEXT NOT NULL,
+  last_checked_at TEXT,
+  UNIQUE(item_id, url)
+);
+
+CREATE TABLE IF NOT EXISTS price_checks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  item_id INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  source_id INTEGER NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+  price REAL NOT NULL,
+  currency TEXT NOT NULL,
+  checked_at TEXT NOT NULL
+);
+```
+
+## Notes
+
+- Store the user's natural-language product query in `items.query`.
+- Store a concise canonical product name in `items.normalized_name` once a confident match exists.
+- Keep `items.target_price` numeric and currency-neutral in the v1 schema. Report the inferred currency in prose when it matters.
+- Allow multiple source rows per item.
+- Update `sources.last_checked_at` every time a source is attempted, even if extraction fails and the failure only appears in the Markdown report.
+- Append to `price_checks`; do not overwrite history.

--- a/skills/price-watcher/references/source-discovery.md
+++ b/skills/price-watcher/references/source-discovery.md
@@ -1,0 +1,37 @@
+# Source Discovery And Product Normalization
+
+Discover sources from the product query instead of asking for a URL.
+
+## Search Pattern
+
+Run several searches, mixing broad and retailer-specific queries:
+
+- `"<query>" price`
+- `"<query>" buy`
+- `"<query>" site:bestbuy.com`
+- `"<query>" site:walmart.com`
+- `"<query>" site:target.com`
+- `"<query>" site:bhphotovideo.com`
+- `"<query>" site:amazon.com`
+
+Choose retailers or marketplaces appropriate to the product category and the user's country.
+
+## Normalization
+
+Normalize names before deduplication:
+
+- lowercase
+- strip punctuation and marketing suffixes
+- normalize units, generations, and sizes
+- preserve important attributes such as model, year, processor, storage, dimensions, color, pack size, and condition
+
+Treat these as likely different products unless the page proves equivalence:
+
+- different generation or release year
+- different storage or memory
+- refurbished vs new
+- used/open-box vs new
+- bundle vs standalone item
+- subscription price vs one-time price
+
+Prefer source URLs that lead to a stable product detail page over search result pages.

--- a/skills/price-watcher/scripts/price_watcher.py
+++ b/skills/price-watcher/scripts/price_watcher.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import os
 import re
 import sqlite3
 from pathlib import Path
@@ -47,9 +48,23 @@ CREATE TABLE IF NOT EXISTS price_checks (
 
 PRICE_RE = re.compile(
     r"(?:below|under|less than|drops? below|at or below|<=|<)\s*"
-    r"(?P<symbol>US\$|CA\$|[$£€])?\s*(?P<amount>\d[\d,]*(?:\.\d{1,2})?)",
+    r"(?P<symbol>US\$|CA\$|[$\u00a3\u20ac])?\s*(?P<amount>\d[\d,]*(?:\.\d{1,2})?)",
     re.IGNORECASE,
 )
+NOTIFICATION_CLAUSE_RE = re.compile(
+    r"\s+and\s+(?:notify|tell|alert)\s+me\s+if\s+it\s+"
+    r"(?:drops?\s+)?(?:below|under|less than|at or below|<=|<)\s*"
+    r"(?:US\$|CA\$|[$\u00a3\u20ac])?\s*\d[\d,]*(?:\.\d{1,2})?\s*\.?\s*$",
+    re.IGNORECASE,
+)
+DEFAULT_STATE = Path(
+    os.environ.get(
+        "PRICE_WATCHER_STATE",
+        str(Path.home() / ".codex" / "state" / "price-watcher"),
+    )
+)
+DEFAULT_DB = DEFAULT_STATE / "price-watcher.sqlite3"
+DEFAULT_REPORT_DIR = DEFAULT_STATE / "price-reports"
 
 
 def utc_now() -> str:
@@ -57,6 +72,7 @@ def utc_now() -> str:
 
 
 def connect(db_path: Path) -> sqlite3.Connection:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA foreign_keys = ON")
@@ -73,8 +89,8 @@ def infer_currency(symbol: str | None) -> str:
         "US$": "USD",
         "CA$": "CAD",
         "$": "USD",
-        "£": "GBP",
-        "€": "EUR",
+        "\u00a3": "GBP",
+        "\u20ac": "EUR",
     }.get(symbol or "$", "USD")
 
 
@@ -88,7 +104,13 @@ def parse_watch_request(text: str) -> tuple[str, float | None, str]:
         currency = infer_currency(match.group("symbol"))
         query = text[: match.start()].strip()
     query = re.sub(r"^(watch|track|monitor)\s+", "", query, flags=re.IGNORECASE).strip()
-    query = re.sub(r"\s+and\s+(notify|tell|alert)\s+me\s+if\s+it\s*$", "", query, flags=re.IGNORECASE).strip()
+    query = NOTIFICATION_CLAUSE_RE.sub("", query).strip()
+    query = re.sub(
+        r"\s+and\s+(notify|tell|alert)\s+me\s+if\s+it\s*$",
+        "",
+        query,
+        flags=re.IGNORECASE,
+    ).strip()
     return query or text.strip(), target, currency
 
 
@@ -134,6 +156,12 @@ def record_price(
     checked_at: str | None = None,
 ) -> sqlite3.Row:
     checked_at = checked_at or utc_now()
+    source = conn.execute("SELECT item_id FROM sources WHERE id = ?", (source_id,)).fetchone()
+    if source is None:
+        raise ValueError(f"source_id {source_id} does not exist")
+    if int(source["item_id"]) != item_id:
+        raise ValueError(f"source_id {source_id} does not belong to item_id {item_id}")
+
     cur = conn.execute(
         """
         INSERT INTO price_checks(item_id, source_id, price, currency, checked_at)
@@ -146,7 +174,21 @@ def record_price(
     return conn.execute("SELECT * FROM price_checks WHERE id = ?", (cur.lastrowid,)).fetchone()
 
 
-def latest_prices(conn: sqlite3.Connection) -> Iterable[sqlite3.Row]:
+def mark_source_checked(
+    conn: sqlite3.Connection,
+    source_id: int,
+    checked_at: str | None = None,
+) -> sqlite3.Row:
+    checked_at = checked_at or utc_now()
+    conn.execute("UPDATE sources SET last_checked_at = ? WHERE id = ?", (checked_at, source_id))
+    conn.commit()
+    row = conn.execute("SELECT * FROM sources WHERE id = ?", (source_id,)).fetchone()
+    if row is None:
+        raise ValueError(f"source_id {source_id} does not exist")
+    return row
+
+
+def latest_source_prices(conn: sqlite3.Connection) -> Iterable[sqlite3.Row]:
     return conn.execute(
         """
         WITH ranked AS (
@@ -168,7 +210,7 @@ def latest_prices(conn: sqlite3.Connection) -> Iterable[sqlite3.Row]:
         )
         SELECT * FROM ranked
         WHERE rn = 1
-        ORDER BY price ASC, checked_at DESC
+        ORDER BY item_id ASC, price ASC, checked_at DESC
         """
     ).fetchall()
 
@@ -189,10 +231,18 @@ def money(price: float, currency: str) -> str:
     return f"{currency} {price:,.2f}"
 
 
+def target_status(price: float, currency: str, target_price: float | None) -> str:
+    if target_price is None:
+        return "No target"
+    if currency.upper() != "USD":
+        return "Currency mismatch"
+    return "Met" if price <= target_price else "Above target"
+
+
 def write_report(conn: sqlite3.Connection, report_dir: Path) -> Path:
     report_dir.mkdir(parents=True, exist_ok=True)
     path = report_dir / f"{dt.date.today().isoformat()}.md"
-    rows = list(latest_prices(conn))
+    rows = list(latest_source_prices(conn))
 
     lines = [
         f"# Price Watch Report - {dt.date.today().isoformat()}",
@@ -203,46 +253,60 @@ def write_report(conn: sqlite3.Connection, report_dir: Path) -> Path:
 
     if not rows:
         lines.extend(["No price observations recorded yet.", ""])
-    current_item = None
+
+    grouped: dict[int, list[sqlite3.Row]] = {}
     for row in rows:
-        if row["item_id"] != current_item:
-            current_item = row["item_id"]
-            target = row["target_price"]
-            target_text = f"target {target:,.2f}" if target is not None else "no target price"
-            lines.extend(
-                [
-                    f"## {row['normalized_name'] or row['query']}",
-                    "",
-                    f"- Query: {row['query']}",
-                    f"- Threshold: {target_text}",
-                    "",
-                    "| Source | Observed price | Target status | Change | Checked |",
-                    "| --- | ---: | --- | ---: | --- |",
-                ]
-            )
-        prev = previous_price(conn, int(row["source_id"]), int(row["id"]))
-        change = ""
-        if prev:
-            delta = float(row["price"]) - float(prev["price"])
-            change = f"{delta:+,.2f}"
-        target_status = "No target"
-        if row["target_price"] is not None:
-            target_status = "Met" if float(row["price"]) <= float(row["target_price"]) else "Above target"
-        source = f"[{row['site']}]({row['url']})"
-        lines.append(
-            f"| {source} | {money(float(row['price']), row['currency'])} | "
-            f"{target_status} | {change or 'n/a'} | {row['checked_at']} |"
+        grouped.setdefault(int(row["item_id"]), []).append(row)
+
+    def best_item_key(item_rows: list[sqlite3.Row]) -> tuple[float, int]:
+        best_usd = [
+            float(row["price"])
+            for row in item_rows
+            if str(row["currency"]).upper() == "USD"
+        ]
+        best_any = [float(row["price"]) for row in item_rows]
+        return (min(best_usd or best_any), int(item_rows[0]["item_id"]))
+
+    for item_rows in sorted(grouped.values(), key=best_item_key):
+        first = item_rows[0]
+        target = first["target_price"]
+        target_text = f"target USD {target:,.2f}" if target is not None else "no target price"
+        lines.extend(
+            [
+                f"## {first['normalized_name'] or first['query']}",
+                "",
+                f"- Query: {first['query']}",
+                f"- Threshold: {target_text}",
+                "",
+                "| Source | Observed price | Target status | Change | Checked |",
+                "| --- | ---: | --- | ---: | --- |",
+            ]
         )
-    lines.append("")
-    lines.append("Failed or skipped source notes: add source-specific notes here when a check could not store a price.")
-    lines.append("")
+        item_rows_sorted = sorted(
+            item_rows,
+            key=lambda row: (str(row["currency"]).upper() != "USD", float(row["price"])),
+        )
+        for row in item_rows_sorted:
+            prev = previous_price(conn, int(row["source_id"]), int(row["id"]))
+            change = ""
+            if prev:
+                delta = float(row["price"]) - float(prev["price"])
+                change = f"{delta:+,.2f}"
+            source = f"[{row['site']}]({row['url']})"
+            lines.append(
+                f"| {source} | {money(float(row['price']), row['currency'])} | "
+                f"{target_status(float(row['price']), row['currency'], row['target_price'])} | "
+                f"{change or 'n/a'} | {row['checked_at']} |"
+            )
+        lines.append("")
+
     path.write_text("\n".join(lines), encoding="utf-8")
     return path
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Manage price-watcher SQLite state and reports.")
-    parser.add_argument("--db", default="price-watcher.sqlite3", help="SQLite database path.")
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB, help="SQLite database path.")
     sub = parser.add_subparsers(dest="command", required=True)
 
     sub.add_parser("init", help="Create SQLite tables.")
@@ -256,6 +320,11 @@ def build_parser() -> argparse.ArgumentParser:
     sources_add.add_argument("--item-id", type=int, required=True)
     sources_add.add_argument("--site", required=True)
     sources_add.add_argument("--url", required=True)
+    sources_checked = sources_sub.add_parser(
+        "mark-checked",
+        help="Mark a source checked without recording a price.",
+    )
+    sources_checked.add_argument("--source-id", type=int, required=True)
 
     record = sub.add_parser("record", help="Record an observed price.")
     record.add_argument("--item-id", type=int, required=True)
@@ -264,14 +333,14 @@ def build_parser() -> argparse.ArgumentParser:
     record.add_argument("--currency", default="USD")
 
     report = sub.add_parser("report", help="Write a Markdown report.")
-    report.add_argument("--report-dir", default="price-reports")
+    report.add_argument("--report-dir", type=Path, default=DEFAULT_REPORT_DIR)
 
     return parser
 
 
 def main() -> None:
     args = build_parser().parse_args()
-    db_path = Path(args.db)
+    db_path = args.db
     with connect(db_path) as conn:
         init_db(conn)
         if args.command == "init":
@@ -282,11 +351,20 @@ def main() -> None:
         elif args.command == "sources" and args.sources_command == "add":
             row = add_source(conn, args.item_id, args.site, args.url)
             print(f"Source {row['id']}: {row['site']} {row['url']}")
+        elif args.command == "sources" and args.sources_command == "mark-checked":
+            try:
+                row = mark_source_checked(conn, args.source_id)
+            except ValueError as exc:
+                raise SystemExit(str(exc)) from exc
+            print(f"Marked source {row['id']} checked at {row['last_checked_at']}")
         elif args.command == "record":
-            row = record_price(conn, args.item_id, args.source_id, args.price, args.currency)
+            try:
+                row = record_price(conn, args.item_id, args.source_id, args.price, args.currency)
+            except ValueError as exc:
+                raise SystemExit(str(exc)) from exc
             print(f"Recorded check {row['id']}: {money(float(row['price']), row['currency'])}")
         elif args.command == "report":
-            path = write_report(conn, Path(args.report_dir))
+            path = write_report(conn, args.report_dir)
             print(path)
 
 

--- a/skills/price-watcher/scripts/price_watcher.py
+++ b/skills/price-watcher/scripts/price_watcher.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Local helper for the price-watcher Codex skill.
+
+This script manages SQLite state and Markdown reporting. It intentionally does
+not bypass retailer access controls or perform checkout actions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS items (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  query TEXT NOT NULL,
+  normalized_name TEXT,
+  target_price REAL,
+  created_at TEXT NOT NULL,
+  active INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS sources (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  item_id INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  site TEXT NOT NULL,
+  url TEXT NOT NULL,
+  last_checked_at TEXT,
+  UNIQUE(item_id, url)
+);
+
+CREATE TABLE IF NOT EXISTS price_checks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  item_id INTEGER NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+  source_id INTEGER NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+  price REAL NOT NULL,
+  currency TEXT NOT NULL,
+  checked_at TEXT NOT NULL
+);
+"""
+
+
+PRICE_RE = re.compile(
+    r"(?:below|under|less than|drops? below|at or below|<=|<)\s*"
+    r"(?P<symbol>US\$|CA\$|[$£€])?\s*(?P<amount>\d[\d,]*(?:\.\d{1,2})?)",
+    re.IGNORECASE,
+)
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+
+
+def connect(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    conn.executescript(SCHEMA)
+    conn.commit()
+
+
+def infer_currency(symbol: str | None) -> str:
+    return {
+        "US$": "USD",
+        "CA$": "CAD",
+        "$": "USD",
+        "£": "GBP",
+        "€": "EUR",
+    }.get(symbol or "$", "USD")
+
+
+def parse_watch_request(text: str) -> tuple[str, float | None, str]:
+    match = PRICE_RE.search(text)
+    target = None
+    currency = "USD"
+    query = text.strip()
+    if match:
+        target = float(match.group("amount").replace(",", ""))
+        currency = infer_currency(match.group("symbol"))
+        query = text[: match.start()].strip()
+    query = re.sub(r"^(watch|track|monitor)\s+", "", query, flags=re.IGNORECASE).strip()
+    query = re.sub(r"\s+and\s+(notify|tell|alert)\s+me\s+if\s+it\s*$", "", query, flags=re.IGNORECASE).strip()
+    return query or text.strip(), target, currency
+
+
+def normalize_name(query: str) -> str:
+    cleaned = re.sub(r"\s+", " ", query).strip()
+    return cleaned[:1].upper() + cleaned[1:] if cleaned else cleaned
+
+
+def add_item(conn: sqlite3.Connection, request: str) -> sqlite3.Row:
+    query, target, _currency = parse_watch_request(request)
+    cur = conn.execute(
+        """
+        INSERT INTO items(query, normalized_name, target_price, created_at, active)
+        VALUES (?, ?, ?, ?, 1)
+        """,
+        (query, normalize_name(query), target, utc_now()),
+    )
+    conn.commit()
+    return conn.execute("SELECT * FROM items WHERE id = ?", (cur.lastrowid,)).fetchone()
+
+
+def add_source(conn: sqlite3.Connection, item_id: int, site: str, url: str) -> sqlite3.Row:
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO sources(item_id, site, url)
+        VALUES (?, ?, ?)
+        """,
+        (item_id, site, url),
+    )
+    conn.commit()
+    return conn.execute(
+        "SELECT * FROM sources WHERE item_id = ? AND url = ?",
+        (item_id, url),
+    ).fetchone()
+
+
+def record_price(
+    conn: sqlite3.Connection,
+    item_id: int,
+    source_id: int,
+    price: float,
+    currency: str,
+    checked_at: str | None = None,
+) -> sqlite3.Row:
+    checked_at = checked_at or utc_now()
+    cur = conn.execute(
+        """
+        INSERT INTO price_checks(item_id, source_id, price, currency, checked_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (item_id, source_id, price, currency.upper(), checked_at),
+    )
+    conn.execute("UPDATE sources SET last_checked_at = ? WHERE id = ?", (checked_at, source_id))
+    conn.commit()
+    return conn.execute("SELECT * FROM price_checks WHERE id = ?", (cur.lastrowid,)).fetchone()
+
+
+def latest_prices(conn: sqlite3.Connection) -> Iterable[sqlite3.Row]:
+    return conn.execute(
+        """
+        WITH ranked AS (
+          SELECT
+            pc.*,
+            s.site,
+            s.url,
+            i.query,
+            i.normalized_name,
+            i.target_price,
+            ROW_NUMBER() OVER (
+              PARTITION BY pc.source_id
+              ORDER BY pc.checked_at DESC, pc.id DESC
+            ) AS rn
+          FROM price_checks pc
+          JOIN sources s ON s.id = pc.source_id
+          JOIN items i ON i.id = pc.item_id
+          WHERE i.active = 1
+        )
+        SELECT * FROM ranked
+        WHERE rn = 1
+        ORDER BY price ASC, checked_at DESC
+        """
+    ).fetchall()
+
+
+def previous_price(conn: sqlite3.Connection, source_id: int, latest_id: int) -> sqlite3.Row | None:
+    return conn.execute(
+        """
+        SELECT * FROM price_checks
+        WHERE source_id = ? AND id <> ?
+        ORDER BY checked_at DESC, id DESC
+        LIMIT 1
+        """,
+        (source_id, latest_id),
+    ).fetchone()
+
+
+def money(price: float, currency: str) -> str:
+    return f"{currency} {price:,.2f}"
+
+
+def write_report(conn: sqlite3.Connection, report_dir: Path) -> Path:
+    report_dir.mkdir(parents=True, exist_ok=True)
+    path = report_dir / f"{dt.date.today().isoformat()}.md"
+    rows = list(latest_prices(conn))
+
+    lines = [
+        f"# Price Watch Report - {dt.date.today().isoformat()}",
+        "",
+        "Sorted by lowest currently observed price.",
+        "",
+    ]
+
+    if not rows:
+        lines.extend(["No price observations recorded yet.", ""])
+    current_item = None
+    for row in rows:
+        if row["item_id"] != current_item:
+            current_item = row["item_id"]
+            target = row["target_price"]
+            target_text = f"target {target:,.2f}" if target is not None else "no target price"
+            lines.extend(
+                [
+                    f"## {row['normalized_name'] or row['query']}",
+                    "",
+                    f"- Query: {row['query']}",
+                    f"- Threshold: {target_text}",
+                    "",
+                    "| Source | Observed price | Target status | Change | Checked |",
+                    "| --- | ---: | --- | ---: | --- |",
+                ]
+            )
+        prev = previous_price(conn, int(row["source_id"]), int(row["id"]))
+        change = ""
+        if prev:
+            delta = float(row["price"]) - float(prev["price"])
+            change = f"{delta:+,.2f}"
+        target_status = "No target"
+        if row["target_price"] is not None:
+            target_status = "Met" if float(row["price"]) <= float(row["target_price"]) else "Above target"
+        source = f"[{row['site']}]({row['url']})"
+        lines.append(
+            f"| {source} | {money(float(row['price']), row['currency'])} | "
+            f"{target_status} | {change or 'n/a'} | {row['checked_at']} |"
+        )
+    lines.append("")
+    lines.append("Failed or skipped source notes: add source-specific notes here when a check could not store a price.")
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Manage price-watcher SQLite state and reports.")
+    parser.add_argument("--db", default="price-watcher.sqlite3", help="SQLite database path.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("init", help="Create SQLite tables.")
+
+    add = sub.add_parser("add", help="Add a natural-language watched item.")
+    add.add_argument("request")
+
+    sources = sub.add_parser("sources", help="Manage source URLs.")
+    sources_sub = sources.add_subparsers(dest="sources_command", required=True)
+    sources_add = sources_sub.add_parser("add", help="Add a source URL for an item.")
+    sources_add.add_argument("--item-id", type=int, required=True)
+    sources_add.add_argument("--site", required=True)
+    sources_add.add_argument("--url", required=True)
+
+    record = sub.add_parser("record", help="Record an observed price.")
+    record.add_argument("--item-id", type=int, required=True)
+    record.add_argument("--source-id", type=int, required=True)
+    record.add_argument("--price", type=float, required=True)
+    record.add_argument("--currency", default="USD")
+
+    report = sub.add_parser("report", help="Write a Markdown report.")
+    report.add_argument("--report-dir", default="price-reports")
+
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    db_path = Path(args.db)
+    with connect(db_path) as conn:
+        init_db(conn)
+        if args.command == "init":
+            print(f"Initialized {db_path}")
+        elif args.command == "add":
+            row = add_item(conn, args.request)
+            print(f"Added item {row['id']}: {row['query']} target={row['target_price']}")
+        elif args.command == "sources" and args.sources_command == "add":
+            row = add_source(conn, args.item_id, args.site, args.url)
+            print(f"Source {row['id']}: {row['site']} {row['url']}")
+        elif args.command == "record":
+            row = record_price(conn, args.item_id, args.source_id, args.price, args.currency)
+            print(f"Recorded check {row['id']}: {money(float(row['price']), row['currency'])}")
+        elif args.command == "report":
+            path = write_report(conn, Path(args.report_dir))
+            print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/price-watcher/scripts/price_watcher.py
+++ b/skills/price-watcher/scripts/price_watcher.py
@@ -57,6 +57,10 @@ NOTIFICATION_CLAUSE_RE = re.compile(
     r"(?:US\$|CA\$|[$\u00a3\u20ac])?\s*\d[\d,]*(?:\.\d{1,2})?\s*\.?\s*$",
     re.IGNORECASE,
 )
+NOTIFICATION_PREAMBLE_RE = re.compile(
+    r"\s+and\s+(?:notify|tell|alert)\s+me\s+if\s+it(?:\s+drops?)?\s*$",
+    re.IGNORECASE,
+)
 DEFAULT_STATE = Path(
     os.environ.get(
         "PRICE_WATCHER_STATE",
@@ -105,12 +109,7 @@ def parse_watch_request(text: str) -> tuple[str, float | None, str]:
         query = text[: match.start()].strip()
     query = re.sub(r"^(watch|track|monitor)\s+", "", query, flags=re.IGNORECASE).strip()
     query = NOTIFICATION_CLAUSE_RE.sub("", query).strip()
-    query = re.sub(
-        r"\s+and\s+(notify|tell|alert)\s+me\s+if\s+it\s*$",
-        "",
-        query,
-        flags=re.IGNORECASE,
-    ).strip()
+    query = NOTIFICATION_PREAMBLE_RE.sub("", query).strip()
     return query or text.strip(), target, currency
 
 


### PR DESCRIPTION
feat: add price-watcher skill package (#35)

## Summary

Adds a Codex-compatible price watcher practitioner skill package. The package lets users register watched products from natural-language requests, discover and associate multiple source URLs, persist watch state and price history in SQLite, compare prices against thresholds, and generate lowest-price-first Markdown reports.

Notifications are treated as out of scope for v1; the package stores state and writes reports only.

## Target Branch

- `develop`

## Contribution Type

- practitioner skill package

## Placement

- Target path: `skills/price-watcher/`
- Links or indexes updated: none
- Closes #35

## Source Lineage

Based on the in-repo `skills/garbage-collector/` package structure and the requirements from issue #35.

## Review Checklist

- [x] The contribution type is explicit.
- [x] The file or folder is in the correct path for that artifact type.
- [x] I followed the matching template or contributor guidance where relevant.
- [x] The change stays repo-native and does not copy upstream material into public tracked paths.
- [x] Citations, source notes, or attribution boundaries are clear where needed.
- [x] Relevant README, reading-path, or contributor links were added or updated for discoverability.
- [x] If I added or revised a practitioner skill package, it includes a human-facing `README.md` and an agent-facing `SKILL.md`.
- [x] Status and maintenance expectations are clear.
- [x] If I changed example code, I ran `python3 scripts/verify_example_projects.py`.
- [x] If I renamed files or changed paths, I ran `python3 scripts/check_filename_casing.py`.