### PR TITLE
[dprat0821] Fix reading path hyperlinks

### DIFF
--- a/reading-paths/builder.mdx
+++ b/reading-paths/builder.mdx
@@ -11,29 +11,29 @@ applications.
 
 ## Shared starting points
 
-- [Environment Setup](/reading-paths/environment-setup): the shared local setup guide for
+- [Environment Setup](./environment-setup.mdx): the shared local setup guide for
   running starter-code checks before deeper implementation work.
-- [Sample Projects](/reading-paths/sample-projects): the public guide to current example
+- [Sample Projects](./sample-projects.mdx): the public guide to current example
   starters and where they live in the repo.
 
 ## Suggested sequence
 
 
-1. [The Agent Systems](/foundations/the-agent-system)
-2. [History Of Agent Ideas](/foundations/history-of-agent-ideas)
-3. [LLM Foundations For Agent Systems](/foundations/llm-foundations-for-agent-systems)
-4. [Agents Vs Workflows](/foundations/agents-vs-workflows)
-5. [Reasoning And Control Patterns](/patterns/reasoning-and-control-patterns)
-6. [Planning And Reflection](/patterns/planning-and-reflection)
-7. [Agent Memory And Retrieval](/patterns/agent-memory-and-retrieval)
-8. [Agent Runtime Building Blocks](/patterns/agent-runtime-building-blocks)
-9. [Context Engineering](/systems/context-engineering)
-10. [Protocols And Interoperability](/systems/protocols-and-interoperability)
-11. [Evaluation And Observability](/systems/evaluation-and-observability)
-12. [Deep Research Agents](/case-studies/deep-research-agents)
-13. [Agent Frameworks](/ecosystem/agent-frameworks)
-14. [Agent Platforms And Low-Code Builders](/ecosystem/agent-platforms-and-low-code-builders)
-15. [Radar](/radar)
+1. [The Agent Systems](../foundations/the-agent-system.mdx)
+2. [History Of Agent Ideas](../foundations/history-of-agent-ideas.mdx)
+3. [LLM Foundations For Agent Systems](../foundations/llm-foundations-for-agent-systems.mdx)
+4. [Agents Vs Workflows](../foundations/agents-vs-workflows.mdx)
+5. [Reasoning And Control Patterns](../patterns/reasoning-and-control-patterns.mdx)
+6. [Planning And Reflection](../patterns/planning-and-reflection.mdx)
+7. [Agent Memory And Retrieval](../patterns/agent-memory-and-retrieval.mdx)
+8. [Agent Runtime Building Blocks](../patterns/agent-runtime-building-blocks.mdx)
+9. [Context Engineering](../systems/context-engineering.mdx)
+10. [Protocols And Interoperability](../systems/protocols-and-interoperability.mdx)
+11. [Evaluation And Observability](../systems/evaluation-and-observability.mdx)
+12. [Deep Research Agents](../case-studies/deep-research-agents.mdx)
+13. [Agent Frameworks](../ecosystem/agent-frameworks.mdx)
+14. [Agent Platforms And Low-Code Builders](../ecosystem/agent-platforms-and-low-code-builders.mdx)
+15. [Radar](../radar/index.mdx)
 
 
 ## What this path optimizes for

--- a/reading-paths/contributor.mdx
+++ b/reading-paths/contributor.mdx
@@ -9,18 +9,18 @@ import SupportCTA from "/snippets/support-cta.mdx";
 Best for people who want to shape Prompthon Agentic Labs by adding, revising,
 curating, building, or maintaining handbook material.
 
-Start with [Start Here](/contributor-kit/start-here) for the contributor path,
+Start with [Start Here](../contributor-kit/start-here.mdx) for the contributor path,
 then use [Contributing](https://github.com/Prompthon-IO/agent-systems-handbook/blob/main/CONTRIBUTING.md) for the public workflow,
-[Contributor Kit](/contributor-kit) for the working assets, and
-[Prompthon Agentic Labs Structure](/contributor-kit/lab-structure) for the
+[Contributor Kit](../contributor-kit/index.mdx) for the working assets, and
+[Prompthon Agentic Labs Structure](../contributor-kit/lab-structure.mdx) for the
 repo
 map and reference boundary.
 
 ## Shared starting points
 
-- [Environment Setup](/reading-paths/environment-setup): the shared local setup guide for
+- [Environment Setup](./environment-setup.mdx): the shared local setup guide for
   validating the repo-owned starter code.
-- [Sample Projects](/reading-paths/sample-projects): the public map of current starter
+- [Sample Projects](./sample-projects.mdx): the public map of current starter
   projects and their intended scope.
 
 ## Supported contribution types
@@ -33,17 +33,17 @@ map and reference boundary.
 
 ## Suggested sequence
 
-1. [Start Here](/contributor-kit/start-here)
+1. [Start Here](../contributor-kit/start-here.mdx)
 2. [Contributing](https://github.com/Prompthon-IO/agent-systems-handbook/blob/main/CONTRIBUTING.md)
-3. [Basic GitHub Flow For Contributors](/contributor-kit/contribution-workflow)
-4. [GitHub Issue Guide](/contributor-kit/github-issue-guide)
-5. [Contributor Kit](/contributor-kit)
-6. [Article Guidelines](/contributor-kit/article-guidelines)
-7. [Radar Note Guidelines](/contributor-kit/radar-note-guidelines)
-8. [Source Project Guidelines](/contributor-kit/source-project-guidelines)
-9. [Reference Note Guidelines](/contributor-kit/reference-note-guidelines)
-10. [Review Checklist](/contributor-kit/review-checklist)
-11. [Prompthon Agentic Labs Structure](/contributor-kit/lab-structure)
+3. [Basic GitHub Flow For Contributors](../contributor-kit/contribution-workflow.mdx)
+4. [GitHub Issue Guide](../contributor-kit/github-issue-guide.mdx)
+5. [Contributor Kit](../contributor-kit/index.mdx)
+6. [Article Guidelines](../contributor-kit/article-guidelines.mdx)
+7. [Radar Note Guidelines](../contributor-kit/radar-note-guidelines.mdx)
+8. [Source Project Guidelines](../contributor-kit/source-project-guidelines.mdx)
+9. [Reference Note Guidelines](../contributor-kit/reference-note-guidelines.mdx)
+10. [Review Checklist](../contributor-kit/review-checklist.mdx)
+11. [Prompthon Agentic Labs Structure](../contributor-kit/lab-structure.mdx)
 12. [Upstream Hello-Agents](https://github.com/datawhalechina/Hello-Agents)
 
 ## What this path optimizes for

--- a/reading-paths/explorer.mdx
+++ b/reading-paths/explorer.mdx
@@ -12,30 +12,30 @@ committing to a strict build sequence.
 ## Recommended reads
 
 
-- [The Agent Systems](/foundations/the-agent-system): start
+- [The Agent Systems](../foundations/the-agent-system.mdx): start
 
 
   with the core definition and operating loop.
-- [History Of Agent Ideas](/foundations/history-of-agent-ideas): use the
+- [History Of Agent Ideas](../foundations/history-of-agent-ideas.mdx): use the
   short historical arc to understand why the field looks the way it does.
-- [Agents Vs Workflows](/foundations/agents-vs-workflows): clarify the
+- [Agents Vs Workflows](../foundations/agents-vs-workflows.mdx): clarify the
   boundary between deterministic orchestration and bounded autonomy.
-- [Deep Research Agents](/case-studies/deep-research-agents): see how one
+- [Deep Research Agents](../case-studies/deep-research-agents.mdx): see how one
   of the clearest modern agent products is structured.
-- [Ecosystem](/ecosystem): compare the major tools, platforms, and
+- [Ecosystem](../ecosystem/index.mdx): compare the major tools, platforms, and
   market categories.
-- [Radar](/radar): track what is changing quickly across the field.
+- [Radar](../radar/index.mdx): track what is changing quickly across the field.
 
 ## Optional deeper dives
 
-- [Agent Memory And Retrieval](/patterns/agent-memory-and-retrieval): go
+- [Agent Memory And Retrieval](../patterns/agent-memory-and-retrieval.mdx): go
   here if you want a practical mental model for memory, retrieval, and
   artifacts.
-- [Reasoning And Control Patterns](/patterns/reasoning-and-control-patterns):
+- [Reasoning And Control Patterns](../patterns/reasoning-and-control-patterns.mdx):
   go here if you want the control-loop view of agent behavior.
-- [LLM Foundations For Agent Systems](/foundations/llm-foundations-for-agent-systems):
+- [LLM Foundations For Agent Systems](../foundations/llm-foundations-for-agent-systems.mdx):
   go here if you want the minimum model literacy behind modern agents.
-- [Context Engineering](/systems/context-engineering): go here if you
+- [Context Engineering](../systems/context-engineering.mdx): go here if you
   want the production-minded view of how context is managed over time.
 
 ## What this guide optimizes for

--- a/reading-paths/practitioner.mdx
+++ b/reading-paths/practitioner.mdx
@@ -16,24 +16,24 @@ tutorial track.
 
 ## Shared starting points
 
-- [Environment Setup](/reading-paths/environment-setup): the shared local setup guide for
+- [Environment Setup](./environment-setup.mdx): the shared local setup guide for
   trying the repo-owned starter code.
-- [Workshops](/workshops): guided setup tracks for OpenClaw, local desktop agents,
+- [Workshops](../workshops/index.mdx): guided setup tracks for OpenClaw, local desktop agents,
   and skills.
-- [Sample Projects](/reading-paths/sample-projects): the public guide to current example
+- [Sample Projects](./sample-projects.mdx): the public guide to current example
   starters across the repo.
-- [Practitioner Skills](/skills): installable Codex skill packages for local-first,
+- [Practitioner Skills](../skills/index.mdx): installable Codex skill packages for local-first,
   repeatable daily workflows.
 
 ## Suggested sequence
 
-1. [Deep Research Agents](/case-studies/deep-research-agents)
-2. [Agents Vs Workflows](/foundations/agents-vs-workflows)
-3. [Workshops](/workshops)
-4. [Agent Platforms And Low-Code Builders](/ecosystem/agent-platforms-and-low-code-builders)
-5. [Practitioner Skills](/skills)
-6. [Agent Memory And Retrieval](/patterns/agent-memory-and-retrieval)
-7. [Radar](/radar)
+1. [Deep Research Agents](../case-studies/deep-research-agents.mdx)
+2. [Agents Vs Workflows](../foundations/agents-vs-workflows.mdx)
+3. [Workshops](../workshops/index.mdx)
+4. [Agent Platforms And Low-Code Builders](../ecosystem/agent-platforms-and-low-code-builders.mdx)
+5. [Practitioner Skills](../skills/index.mdx)
+6. [Agent Memory And Retrieval](../patterns/agent-memory-and-retrieval.mdx)
+7. [Radar](../radar/index.mdx)
 
 ## What this path optimizes for
 
@@ -45,6 +45,6 @@ tutorial track.
 
 If you want the production-minded view of evaluation, interoperability,
 reliability, and operations, continue into
-[Context Engineering](/systems/context-engineering),
-[Protocols And Interoperability](/systems/protocols-and-interoperability),
-and [Evaluation And Observability](/systems/evaluation-and-observability).
+[Context Engineering](../systems/context-engineering.mdx),
+[Protocols And Interoperability](../systems/protocols-and-interoperability.mdx),
+and [Evaluation And Observability](../systems/evaluation-and-observability.mdx).


### PR DESCRIPTION
## Summary
- Converts reading-path internal links to repo-relative `.mdx` targets so they resolve when opened from GitHub.
- Keeps the target pages unchanged while fixing the broken-link surface reported in the issue.

## Validation
- `python3 scripts/verify_example_projects.py`
- `git diff --check`
- custom reading-path link existence check
- `npx mint@4.2.549 validate` with Node 20.17.0

Executor account: `dprat0821`
Commit author: `dprat0821`

Closes #70
