### PR TITLE
[dprat0821] Add AG-UI and generative UI systems page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -72,6 +72,7 @@
                 "pages": [
                   "systems/index",
                   "systems/context-engineering",
+                  "systems/agent-ui-protocols-and-generative-ui",
                   "systems/protocols-and-interoperability",
                   "systems/evaluation-and-observability"
                 ]
@@ -291,6 +292,7 @@
                 "pages": [
                   "zh-Hans/systems/index",
                   "zh-Hans/systems/context-engineering",
+                  "zh-Hans/systems/agent-ui-protocols-and-generative-ui",
                   "zh-Hans/systems/protocols-and-interoperability",
                   "zh-Hans/systems/evaluation-and-observability"
                 ]

--- a/systems/README.md
+++ b/systems/README.md
@@ -24,6 +24,9 @@ and operational tradeoffs.
 
 - [Context Engineering](./context-engineering.mdx): how systems write, select,
   compress, and isolate context for reliable multi-step work.
+- [Agent UI Protocols And Generative UI](./agent-ui-protocols-and-generative-ui.mdx):
+  how AG-UI and A2UI separate user-facing interaction from tool and agent
+  protocols.
 - [Protocols And Interoperability](./protocols-and-interoperability.mdx): how
   tool access, agent collaboration, and network discovery fit together.
 - [Evaluation And Observability](./evaluation-and-observability.mdx): how to

--- a/systems/agent-ui-protocols-and-generative-ui.mdx
+++ b/systems/agent-ui-protocols-and-generative-ui.mdx
@@ -1,0 +1,152 @@
+---
+title: Agent UI Protocols And Generative UI
+owner: Prompthon IO
+updated: 2026-05-06
+depth: advanced
+region_tags:
+  - global
+coding_required: optional
+external_readings:
+  - title: "A2UI v0.9: The New Standard for Portable, Framework-Agnostic Generative UI"
+    url: https://developers.googleblog.com/a2ui-v0-9-generative-ui/
+  - title: "AG-UI Overview"
+    url: https://docs.ag-ui.com/introduction
+  - title: "AG-UI Protocol"
+    url: https://www.copilotkit.ai/ag-ui
+status: draft
+---
+
+import SupportCTA from "/snippets/support-cta.mdx";
+
+<SupportCTA />
+
+## Summary
+
+User-facing agents need an interface contract in addition to tool and
+agent-to-agent contracts. `AG-UI` defines the event-driven runtime connection
+between an agentic backend and an application. `A2UI` defines how an agent can
+declare portable UI intent against an existing component catalog.
+
+The practical point is simple: do not force UI interaction into `MCP` or
+`A2A`. Treat the user-facing surface as its own system boundary.
+
+## Why It Matters
+
+Chatboxes are a weak default for many agentic products. Real applications often
+need:
+
+- streaming status while long tasks run
+- typed frontend actions and approvals
+- shared state between the app and the agent
+- widgets, forms, charts, or editors that stay under application control
+
+That is a different job from tool access or inter-agent delegation.
+
+When teams skip this distinction, they usually end up with one of two bad
+outcomes:
+
+- a tool protocol is overloaded with UI concerns it was not designed to carry
+- a frontend grows a pile of ad hoc event wiring that becomes hard to debug
+
+## Mental Model
+
+The current signal is cleaner than that:
+
+- `AG-UI`: the runtime interaction layer between a user-facing application and
+  an agentic backend
+- `A2UI`: the UI-intent layer for portable generative widgets
+- `MCP`: the tool and data access layer
+- `A2A`: the inter-agent delegation layer
+
+These layers can work together without collapsing into one protocol.
+
+| If the question is... | Start with... | Because... |
+| --- | --- | --- |
+| How does the app stream messages, tool events, approvals, and shared state to and from an agent? | AG-UI | The boundary is live application runtime behavior. |
+| How does the agent propose a portable widget or interface shape? | A2UI | The boundary is UI intent against an app-controlled component catalog. |
+| How does the agent call tools or read external resources? | MCP | The boundary is capability access. |
+| How does one agent hand work to another agent-like service? | A2A | The boundary is delegation and collaboration. |
+
+Useful default:
+
+- use `AG-UI` when the product embeds an agent inside an application
+- add `A2UI` when portable widget declarations matter across clients or teams
+- keep `MCP` and `A2A` focused on their own boundaries
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+  User["User"] --> App["User-facing application"]
+  App --> AGUI["AG-UI runtime channel"]
+  AGUI --> Agent["Agent runtime"]
+  Agent --> A2UI["A2UI UI intent"]
+  A2UI --> Catalog["App component catalog"]
+  Agent --> MCP["MCP tool and data access"]
+  MCP --> Services["Tools, files, APIs, data"]
+  Agent --> A2A["A2A delegation"]
+  A2A --> Specialists["Specialist agents"]
+```
+
+The app still owns the rendered experience. The agent proposes, streams, or
+coordinates. The application validates, mounts, and governs what the user
+actually sees.
+
+## Tool Landscape
+
+AG-UI is useful when the interaction is stateful and eventful:
+
+- token or event streaming
+- long-running tasks that need progress updates
+- frontend tool calls or approvals
+- shared application state
+- human-in-the-loop interrupts
+
+A2UI is useful when the agent should describe UI in a portable way rather than
+hardcoding a single frontend implementation.
+
+That does not mean every agentic product needs both:
+
+- use plain application-owned components when a stable workflow only needs a
+  few known states
+- use AG-UI when the agent must stay connected to a live product surface
+- add A2UI only when declarative, portable UI intent creates real leverage
+
+The design goal is controlled flexibility, not limitless UI generation.
+
+## Tradeoffs
+
+- More expressive UI protocols make products feel more native, but they add
+  validation and governance work.
+- A runtime channel improves traceability, but it introduces event schemas and
+  lifecycle handling that simple request-response apps can avoid.
+- Portable UI intent can reduce duplicate frontend wiring, but only if the
+  component catalog stays disciplined.
+- If the agent can mutate the interface too freely, debugging and trust get
+  worse instead of better.
+
+Strong defaults:
+
+- keep the application in control of rendered components
+- validate agent-proposed UI before mounting it
+- separate UI state from tool permissions
+- treat human approvals as first-class events, not special-case hacks
+
+## Citations
+
+- Official source: [A2UI v0.9: The New Standard for Portable, Framework-Agnostic Generative UI](https://developers.googleblog.com/a2ui-v0-9-generative-ui/)
+- Official source: [AG-UI Overview](https://docs.ag-ui.com/introduction)
+- Official source: [AG-UI Protocol](https://www.copilotkit.ai/ag-ui)
+- High-signal repository: [ag-ui-protocol/ag-ui](https://github.com/ag-ui-protocol/ag-ui)
+- High-signal repository: [CopilotKit/CopilotKit](https://github.com/CopilotKit/CopilotKit)
+
+## Reading Extensions
+
+- [Protocols And Interoperability](/systems/protocols-and-interoperability)
+- [Evaluation And Observability](/systems/evaluation-and-observability)
+- [Systems Overview](/systems)
+
+## Update Log
+
+- 2026-05-06: Added a repo-native systems page for AG-UI, A2UI, and the
+  agent-to-UI boundary.

--- a/systems/index.mdx
+++ b/systems/index.mdx
@@ -30,6 +30,9 @@ and operational tradeoffs.
 
 - [Context Engineering](/systems/context-engineering): how systems write, select,
   compress, and isolate context for reliable multi-step work.
+- [Agent UI Protocols And Generative UI](/systems/agent-ui-protocols-and-generative-ui):
+  how AG-UI and A2UI separate user-facing interaction from tool and agent
+  protocols.
 - [Protocols And Interoperability](/systems/protocols-and-interoperability): how
   tool access, agent collaboration, and network discovery fit together.
 - [Evaluation And Observability](/systems/evaluation-and-observability): how to

--- a/systems/protocols-and-interoperability.mdx
+++ b/systems/protocols-and-interoperability.mdx
@@ -67,6 +67,12 @@ That layer split gives readers a quick test:
 | How does one agent hand work to another agent-like service? | A2A | The boundary is delegation and collaboration. |
 | How are agents discovered across a larger network? | ANP | The boundary is routing and discovery. |
 
+One more boundary is now worth naming explicitly: user-facing agent interfaces.
+When the question is how an agent streams state into an application, asks for
+approval, or proposes portable widgets, `AG-UI` and `A2UI` are usually a
+better fit than forcing UI concerns into `MCP` or `A2A`. See
+[Agent UI Protocols And Generative UI](/systems/agent-ui-protocols-and-generative-ui).
+
 For local-agent systems, MCP also adds two important context-boundary concepts:
 
 - `roots`: filesystem boundaries that tell a server which local directories or
@@ -183,12 +189,15 @@ Two practical defaults help:
 
 ## Reading Extensions
 
+- [Agent UI Protocols And Generative UI](/systems/agent-ui-protocols-and-generative-ui)
 - [Context Engineering](/systems/context-engineering)
 - [Evaluation And Observability](/systems/evaluation-and-observability)
 - [Systems Overview](/systems)
 
 ## Update Log
 
+- 2026-05-06: Added a user-facing protocol boundary note linking AG-UI and
+  A2UI to the broader interoperability map.
 - 2026-04-24: Clarified protocol-layer boundaries and added a quick decision
   table for MCP, A2A, ANP, roots, resources, and remote MCP.
 - 2026-04-23: Refreshed the protocol guidance with local roots, resources, and

--- a/zh-Hans/systems/README.md
+++ b/zh-Hans/systems/README.md
@@ -20,6 +20,8 @@
 
 - [上下文工程](./context-engineering.mdx): 说明系统如何写入、选择、
   压缩和隔离上下文，以实现可靠的多步骤工作。
+- [智能体界面协议与生成式 UI](./agent-ui-protocols-and-generative-ui.mdx):
+  说明 AG-UI 与 A2UI 如何把面向用户的交互从工具协议和智能体协议中分离出来。
 - [协议与互操作](./protocols-and-interoperability.mdx): 说明工具访问、
   智能体协作和网络发现如何协同工作。
 - [评估与可观测性](./evaluation-and-observability.mdx): 说明如何

--- a/zh-Hans/systems/agent-ui-protocols-and-generative-ui.mdx
+++ b/zh-Hans/systems/agent-ui-protocols-and-generative-ui.mdx
@@ -1,0 +1,143 @@
+---
+title: 智能体界面协议与生成式 UI
+owner: Prompthon IO
+updated: 2026-05-06
+depth: advanced
+region_tags:
+  - global
+coding_required: optional
+external_readings:
+  - title: "A2UI v0.9: The New Standard for Portable, Framework-Agnostic Generative UI"
+    url: https://developers.googleblog.com/a2ui-v0-9-generative-ui/
+  - title: "AG-UI Overview"
+    url: https://docs.ag-ui.com/introduction
+  - title: "AG-UI Protocol"
+    url: https://www.copilotkit.ai/ag-ui
+status: draft
+---
+
+import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
+
+<SupportCTA />
+
+## 摘要
+
+面向用户的智能体除了工具契约和智能体间契约之外，还需要自己的界面契约。
+`AG-UI` 定义了智能体后端与应用之间的事件驱动运行时连接。`A2UI`
+定义了智能体如何针对既有组件目录声明可移植的 UI 意图。
+
+实际要点很简单：不要把界面交互硬塞进 `MCP` 或 `A2A`。应把面向用户的
+表面视为一个独立的系统边界。
+
+## 重要性
+
+对于很多智能体产品来说，聊天框只是一个较弱的默认形态。真正的应用通常需
+要：
+
+- 在长任务运行时持续流式反馈状态
+- 类型化的前端动作与人工批准
+- 应用与智能体之间的共享状态
+- 仍然由应用控制的组件、表单、图表或编辑器
+
+这和工具访问或智能体委派是不同的问题。
+
+如果团队跳过这一区分，通常会出现两种糟糕结果：
+
+- 把本来不是为 UI 设计的工具协议硬塞入界面关注点
+- 前端累积出一堆临时事件连线，最终很难调试
+
+## 心智模型
+
+当前信号比这更清晰：
+
+- `AG-UI`：面向用户应用与智能体后端之间的运行时交互层
+- `A2UI`：面向可移植生成式组件的 UI 意图层
+- `MCP`：工具与数据访问层
+- `A2A`：智能体间委派层
+
+这些层可以协同工作，而不必坍塌成单一协议。
+
+| 如果问题是... | 从...开始 | 因为... |
+| --- | --- | --- |
+| 应用如何与智能体双向传输消息、工具事件、批准与共享状态？ | AG-UI | 边界是实时应用运行时行为。 |
+| 智能体如何提出一个可移植的组件或界面形态？ | A2UI | 边界是针对应用控制的组件目录表达 UI 意图。 |
+| 智能体如何调用工具或读取外部资源？ | MCP | 边界在于能力访问。 |
+| 一个智能体如何把工作交给另一个类智能体服务？ | A2A | 边界在于委派与协作。 |
+
+有用的默认做法：
+
+- 当产品把智能体嵌入应用内部时，使用 `AG-UI`
+- 当跨客户端或跨团队的可移植组件声明很重要时，再加上 `A2UI`
+- 让 `MCP` 与 `A2A` 保持在各自边界内
+
+## 架构图
+
+```mermaid
+flowchart TD
+  User["用户"] --> App["面向用户的应用"]
+  App --> AGUI["AG-UI 运行时通道"]
+  AGUI --> Agent["智能体运行时"]
+  Agent --> A2UI["A2UI 界面意图"]
+  A2UI --> Catalog["应用组件目录"]
+  Agent --> MCP["MCP 工具与数据访问"]
+  MCP --> Services["工具、文件、API、数据"]
+  Agent --> A2A["A2A 委派"]
+  A2A --> Specialists["专业化智能体"]
+```
+
+应用仍然拥有最终渲染体验。智能体负责提出、流式传递或协调，应用负责验证、
+挂载并治理用户最终看到的内容。
+
+## 工具体系
+
+当交互本身是有状态且事件密集的，AG-UI 就很有用：
+
+- token 或事件流
+- 需要进度反馈的长任务
+- 前端工具调用或人工批准
+- 共享应用状态
+- 人在回路中的中断
+
+当智能体需要以可移植方式描述 UI，而不是硬编码某个单一前端实现时，A2UI
+就很有用。
+
+这并不意味着每个智能体产品都需要两者：
+
+- 当稳定工作流只需要少数已知状态时，优先用应用自有组件
+- 当智能体必须持续连接到真实产品界面时，使用 AG-UI
+- 只有当声明式、可移植 UI 意图确实带来杠杆时，才加入 A2UI
+
+设计目标应是“受控的灵活性”，而不是“无限制的界面生成”。
+
+## 取舍
+
+- 更强的界面协议能让产品更像原生应用，但也会增加验证与治理工作。
+- 运行时通道能改善可追踪性，但也会引入事件 schema 与生命周期处理，而这些是简单请求-响应应用可以避免的。
+- 可移植 UI 意图可以减少重复的前端连线，但前提是组件目录本身保持纪律性。
+- 如果智能体可以过于自由地修改界面，调试性与信任度往往会下降而不是上升。
+
+强默认：
+
+- 保持由应用控制最终渲染组件
+- 在挂载前验证智能体提出的 UI
+- 把界面状态与工具权限分开
+- 把人工批准视为一等事件，而不是特殊补丁
+
+## 引用
+
+- 官方来源：[A2UI v0.9: The New Standard for Portable, Framework-Agnostic Generative UI](https://developers.googleblog.com/a2ui-v0-9-generative-ui/)
+- 官方来源：[AG-UI Overview](https://docs.ag-ui.com/introduction)
+- 官方来源：[AG-UI Protocol](https://www.copilotkit.ai/ag-ui)
+- 高信号仓库：[ag-ui-protocol/ag-ui](https://github.com/ag-ui-protocol/ag-ui)
+- 高信号仓库：[CopilotKit/CopilotKit](https://github.com/CopilotKit/CopilotKit)
+
+## 延伸阅读
+
+- [协议与互操作](/zh-Hans/systems/protocols-and-interoperability)
+- [评估与可观测性](/zh-Hans/systems/evaluation-and-observability)
+- [系统概览](/zh-Hans/systems)
+
+## 更新日志
+
+- 2026-05-06：新增一个仓库原生的系统页面，用来解释 AG-UI、A2UI 以及
+  智能体到界面的边界。

--- a/zh-Hans/systems/index.mdx
+++ b/zh-Hans/systems/index.mdx
@@ -26,6 +26,8 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 - [上下文工程](/zh-Hans/systems/context-engineering): 说明系统如何写入、选择、
   压缩和隔离上下文，以实现可靠的多步骤工作。
+- [智能体界面协议与生成式 UI](/zh-Hans/systems/agent-ui-protocols-and-generative-ui):
+  说明 AG-UI 与 A2UI 如何把面向用户的交互从工具协议和智能体协议中分离出来。
 - [协议与互操作](/zh-Hans/systems/protocols-and-interoperability): 说明工具访问、
   智能体协作和网络发现如何协同工作。
 - [评估与可观测性](/zh-Hans/systems/evaluation-and-observability): 说明如何

--- a/zh-Hans/systems/protocols-and-interoperability.mdx
+++ b/zh-Hans/systems/protocols-and-interoperability.mdx
@@ -58,6 +58,11 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 | 一个智能体如何把工作交给另一个类智能体服务？ | A2A | 边界在于委派与协作。 |
 | 智能体如何在更大网络中被发现？ | ANP | 边界在于路由与发现。 |
 
+还有一个边界现在值得被明确命名：面向用户的智能体界面。当问题变成智能体
+如何把状态流式传进应用、请求批准，或者提出可移植组件时，`AG-UI` 与
+`A2UI` 往往比把 UI 关注点硬塞进 `MCP` 或 `A2A` 更合适。参见
+[智能体界面协议与生成式 UI](/zh-Hans/systems/agent-ui-protocols-and-generative-ui)。
+
 对于本地智能体系统，MCP 还引入了两个重要的上下文边界概念：
 
 - `roots`：文件系统边界，告诉服务器哪些本地目录或文件在作用域内。
@@ -142,12 +147,15 @@ OpenAI 在 Responses API 中对远程 MCP 的支持，使远程一侧对于 API 
 
 ## 延伸阅读
 
+- [智能体界面协议与生成式 UI](/zh-Hans/systems/agent-ui-protocols-and-generative-ui)
 - [上下文工程](/zh-Hans/systems/context-engineering)
 - [评估与可观测性](/zh-Hans/systems/evaluation-and-observability)
 - [系统概览](/zh-Hans/systems)
 
 ## 更新日志
 
+- 2026-05-06：新增面向用户协议边界说明，并把 AG-UI 与 A2UI 链接进更广
+  的互操作地图。
 - 2026-04-24：澄清了协议层边界，并为 MCP、A2A、ANP、roots、resources 和 remote MCP 增加了快速决策表。
 - 2026-04-23：结合本地 roots、resources 和 remote MCP 边界说明，更新了协议指南。
 - 2026-04-21：基于导入的参考材料和实验室重写规则形成的仓库原生初稿。


### PR DESCRIPTION
## Summary
- add a new `systems/agent-ui-protocols-and-generative-ui` page and `zh-Hans` mirror
- link the new page from the systems overviews and the broader interoperability guide
- add the new systems page to `docs.json` so it appears in navigation

## Trend selection
This run used the stored seven-day article corpus and narrowed the strongest reviewable signal to `AG-UI` / `generative UI` after the deterministic selector returned mostly broad umbrella terms.

## Verification sources
- stored article signal: TechCrunch on CopilotKit and app-native AI agents
- official source: Google A2UI v0.9 post
- official source: AG-UI docs
- official source: CopilotKit AG-UI page
- high-signal repositories: `ag-ui-protocol/ag-ui`, `CopilotKit/CopilotKit`

## Verification
- `python3 scripts/verify_example_projects.py`
- `git diff --check`
