### PR TITLE
[dprat0821] Refresh retrieval pattern with multimodal file search

### DIFF
--- a/patterns/agent-memory-and-retrieval.mdx
+++ b/patterns/agent-memory-and-retrieval.mdx
@@ -1,12 +1,20 @@
 ---
 title: Agent Memory And Retrieval
 owner: Prompthon IO
-updated: 2026-04-21
+updated: 2026-05-06
 depth: intermediate
 region_tags:
   - global
 coding_required: optional
-external_readings: []
+external_readings:
+  - title: Gemini API File Search is now multimodal
+    url: https://blog.google/innovation-and-ai/technology/developers-tools/expanded-gemini-api-file-search-multimodal-rag/
+  - title: Gemini API File Search documentation
+    url: https://ai.google.dev/gemini-api/docs/file-search
+  - title: OpenAI Responses API tools and remote MCP support
+    url: https://openai.com/index/new-tools-and-features-in-the-responses-api/
+  - title: google-gemini/cookbook
+    url: https://github.com/google-gemini/cookbook
 status: draft
 ---
 
@@ -99,6 +107,35 @@ case well. Keyword matching helps with exact entities and literals. Dense
 retrieval helps with semantic similarity. Structured filters help with time
 range, user scope, or document type. The right system usually combines them.
 
+## Retrieval Boundaries
+
+Current hosted file-search tools make the memory-versus-retrieval split easier
+to explain. A managed file-search store is not the agent's memory. It is an
+external corpus with its own indexing rules, filters, and citation surface.
+
+Useful distinctions:
+
+- Use `memory` for continuity across tasks, decisions, and prior actions.
+- Use `retrieval` for external evidence that should stay outside the prompt
+  until a question or task asks for it.
+- Use `metadata filters` to narrow scope before semantic matching, not as a
+  replacement for relevance ranking.
+- Use `citations` as part of the output artifact when users need to verify what
+  document or page grounded the answer.
+
+The May 2026 Gemini File Search update is a concrete example of the direction.
+Google now exposes multimodal file search with `gemini-embedding-2`, custom
+metadata filtering, and page-level citations. The docs also make the lifecycle
+boundary explicit: raw uploaded files expire on a shorter path, while imported
+file-search store data persists until deletion. That is useful for verifiable
+RAG, but it is still retrieval, not memory.
+
+Managed file-search products also impose architecture choices. Google's current
+docs note that File Search cannot yet be combined with tools like Google Search
+or URL Context in the same call, and that audio and video are not currently
+supported. Teams still need orchestration above the retrieval layer to decide
+which tool, corpus, and evidence path fits the task.
+
 ## Tradeoffs
 
 - Session memory is fast and cheap, but it disappears on restart and should not
@@ -107,6 +144,8 @@ range, user scope, or document type. The right system usually combines them.
   bad memories are expensive because they keep returning.
 - Retrieval gives freshness and breadth, but it also creates latency, ranking
   errors, and citation risk.
+- Managed file-search tools reduce infrastructure work, but they constrain
+  corpus lifecycle, tool composition, and storage shape.
 - Notes and artifacts improve traceability, but they require governance so the
   agent does not create an unbounded pile of stale documents.
 
@@ -124,13 +163,21 @@ but it does not replace task memory, decision logs, or artifact management.
 
 - Source input: [Chapter 8 Memory and Retrieval](https://github.com/datawhalechina/Hello-Agents/blob/main/docs/chapter8/Chapter8-Memory-and-Retrieval.md)
 - Source input: [Hello-Agents upstream repository](https://github.com/datawhalechina/Hello-Agents)
+- Official source: [Gemini API File Search is now multimodal](https://blog.google/innovation-and-ai/technology/developers-tools/expanded-gemini-api-file-search-multimodal-rag/)
+- Official source: [Gemini API File Search documentation](https://ai.google.dev/gemini-api/docs/file-search)
+- Official source: [OpenAI Responses API tools and remote MCP support](https://openai.com/index/new-tools-and-features-in-the-responses-api/)
+- High-signal repository: [google-gemini/cookbook](https://github.com/google-gemini/cookbook)
 
 ## Reading Extensions
 
 - [Context Engineering](/systems/context-engineering)
+- [Customer Support Agents](/case-studies/customer-support-agents)
 - [Deep Research Agents](/case-studies/deep-research-agents)
 - [Patterns Overview](/patterns)
 
 ## Update Log
 
+- 2026-05-06: Added a retrieval-boundary refresh covering multimodal file
+  search, metadata filters, citation-bearing RAG, and the difference between
+  managed retrieval stores and agent memory.
 - 2026-04-21: Initial repo-native draft based on imported reference material and lab rewrite rules.

--- a/zh-Hans/patterns/agent-memory-and-retrieval.mdx
+++ b/zh-Hans/patterns/agent-memory-and-retrieval.mdx
@@ -1,12 +1,20 @@
 ---
 title: 智能体记忆与检索
 owner: Prompthon IO
-updated: 2026-04-21
+updated: 2026-05-06
 depth: intermediate
 region_tags:
   - global
 coding_required: optional
-external_readings: []
+external_readings:
+  - title: Gemini API File Search is now multimodal
+    url: https://blog.google/innovation-and-ai/technology/developers-tools/expanded-gemini-api-file-search-multimodal-rag/
+  - title: Gemini API File Search documentation
+    url: https://ai.google.dev/gemini-api/docs/file-search
+  - title: OpenAI Responses API tools and remote MCP support
+    url: https://openai.com/index/new-tools-and-features-in-the-responses-api/
+  - title: google-gemini/cookbook
+    url: https://github.com/google-gemini/cookbook
 status: draft
 ---
 
@@ -77,11 +85,27 @@ flowchart LR
 
 在实践中，混合检索很常见，因为没有一种单一方法能很好地处理所有情况。关键词匹配有助于精确实体和字面值。稠密检索有助于语义相似性。结构化过滤有助于时间范围、用户范围或文档类型。合适的系统通常会把它们组合起来。
 
+## 检索边界
+
+当前的托管式 file search 工具，让“记忆”和“检索”的区别更容易讲清楚。一个托管 file-search store 并不是智能体的记忆。它是一个外部语料面，拥有自己的索引规则、过滤器和引用表面。
+
+有用的区分方式：
+
+- 当你需要跨任务、决策和历史动作保持连续性时，用 `memory`。
+- 当你需要外部证据，而且这些证据应当在问题真正提出前留在提示词之外时，用 `retrieval`。
+- 把 `metadata filters` 当作语义匹配之前的范围收窄手段，而不是相关性排序的替代品。
+- 当用户需要验证答案基于哪份文档或哪一页时，把 `citations` 视为输出工件的一部分。
+
+2026 年 5 月的 Gemini File Search 更新，就是这一方向的一个具体例子。Google 现在提供基于 `gemini-embedding-2` 的多模态 file search、自定义 metadata filtering，以及页级 citations。文档还明确了生命周期边界：原始上传文件走的是更短的保留路径，而导入后的 file-search store 数据会持续保留，直到被删除。这对可验证 RAG 很有价值，但它仍然属于检索，而不是记忆。
+
+托管式 file-search 产品也会带来架构选择。Google 当前文档指出，File Search 还不能与 Google Search 或 URL Context 之类的工具在同一次调用中组合使用，而且目前不支持音频和视频。因此，团队仍然需要在检索层之上保留编排逻辑，用来决定哪一种工具、语料和证据路径适合当前任务。
+
 ## 权衡
 
 - 会话记忆速度快、成本低，但重启后会消失，不能被当作持久记录。
 - 持久记忆提升连续性，但会引入写入质量问题：错误记忆的代价很高，因为它们会反复返回。
 - 检索带来新鲜度和广度，但也会引入延迟、排序错误和引用风险。
+- 托管式 file-search 工具减少了自建基础设施工作，但也会限制语料生命周期、工具组合方式和存储形态。
 - 笔记和工件提升可追溯性，但它们需要治理，否则智能体会生成无限堆积的过时文档。
 
 有三个设计选择会反复出现：
@@ -96,13 +120,19 @@ flowchart LR
 
 - 来源说明：[Chapter 8 Memory and Retrieval](https://github.com/datawhalechina/Hello-Agents/blob/main/docs/chapter8/Chapter8-Memory-and-Retrieval.md)
 - 来源说明：[Hello-Agents upstream repository](https://github.com/datawhalechina/Hello-Agents)
+- 官方来源：[Gemini API File Search is now multimodal](https://blog.google/innovation-and-ai/technology/developers-tools/expanded-gemini-api-file-search-multimodal-rag/)
+- 官方来源：[Gemini API File Search documentation](https://ai.google.dev/gemini-api/docs/file-search)
+- 官方来源：[OpenAI Responses API tools and remote MCP support](https://openai.com/index/new-tools-and-features-in-the-responses-api/)
+- 高信号仓库：[google-gemini/cookbook](https://github.com/google-gemini/cookbook)
 
 ## 延伸阅读
 
 - [上下文工程](/zh-Hans/systems/context-engineering)
+- [Customer Support Agents](/zh-Hans/case-studies/customer-support-agents)
 - [Deep Research Agents](/zh-Hans/case-studies/deep-research-agents)
 - [模式总览](/zh-Hans/patterns)
 
 ## 更新日志
 
+- 2026-05-06：补充了检索边界刷新，覆盖多模态 file search、metadata filters、带 citations 的 RAG，以及托管检索 store 与智能体记忆之间的区别。
 - 2026-04-21：基于导入的参考材料和实验室重写规则生成的初始仓库原生草稿。


### PR DESCRIPTION
## Summary
- refresh the retrieval pattern page around multimodal file search and verifiable RAG boundaries
- add current official readings for Gemini File Search, hosted file search, and citation-bearing retrieval
- mirror the same refresh in Simplified Chinese

## Verification
- python3 scripts/verify_example_projects.py
- git diff --check
- PATH="$HOME/.nvm/versions/node/v20.20.2/bin:$PATH" npx mint validate
