### PR TITLE
[generalkim00] Refresh retrieval starter for verifiable RAG

### DIFF
--- a/patterns/README.md
+++ b/patterns/README.md
@@ -34,5 +34,5 @@ They should stay useful even as individual frameworks rise or fall.
 ## Example starters
 
 - [Agent Memory Retrieval Starter](./examples/agent-memory-retrieval-starter/index.mdx):
-  a small code sketch for separating active notes, retrieval inputs, and
-  durable artifacts.
+  a small code sketch for separating active notes, verifiable RAG retrieval
+  inputs, citations, and durable artifacts.

--- a/patterns/agent-memory-and-retrieval.mdx
+++ b/patterns/agent-memory-and-retrieval.mdx
@@ -170,6 +170,7 @@ but it does not replace task memory, decision logs, or artifact management.
 
 ## Reading Extensions
 
+- [Agent Memory Retrieval Starter](/patterns/examples/agent-memory-retrieval-starter)
 - [Context Engineering](/systems/context-engineering)
 - [Customer Support Agents](/case-studies/customer-support-agents)
 - [Deep Research Agents](/case-studies/deep-research-agents)

--- a/patterns/examples/agent-memory-retrieval-starter/index.mdx
+++ b/patterns/examples/agent-memory-retrieval-starter/index.mdx
@@ -9,8 +9,8 @@ import SupportCTA from "/snippets/support-cta.mdx";
 ## Summary
 
 This starter shows one clean way to separate active notes, working memory,
-imported personal context, retrieval inputs, and durable artifacts in a small
-agent loop.
+imported personal context, retrieval inputs, citation-bearing verifiable RAG,
+and durable artifacts in a small agent loop.
 
 ## Status
 
@@ -23,7 +23,13 @@ Source code: [patterns/examples/agent-memory-retrieval-starter](https://github.c
 Memory examples often collapse everything into one vague history object. This
 starter is intentionally narrower: it highlights the boundary between what the
 agent is currently holding, what a user imported from another assistant, what
-it can retrieve, and what it should preserve as an artifact.
+it can retrieve, what must remain an external file-search corpus, and what it
+should preserve as an artifact.
+
+The May 2026 multimodal file-search updates from Google made that retrieval
+boundary easier to teach. A useful starter should show metadata filters,
+page-level citations, and multimodal chunks without pretending that retrieval
+stores are the same thing as agent memory.
 
 ## Related Lab Pages
 
@@ -39,15 +45,21 @@ agent-memory-retrieval-starter/
     ├── artifact_policy.py
     ├── memory_flow.py
     ├── personal_context.py
-    └── retrieval_trace.py
+    ├── retrieval_trace.py
+    └── verifiable_rag.py
 ```
 
 ## Quick Start
 
-This is a starter, not a runnable application. Read `src/memory_flow.py` for
-the minimal state shape and use it as a base for a fuller example later. For a
-repo-level smoke check, run `python3 scripts/verify_example_projects.py` from
-the repository root.
+From the repository root:
+
+```bash
+python3 scripts/verify_example_projects.py
+```
+
+This is still a starter, not a full application. Read `src/memory_flow.py` for
+the state boundary and `src/verifiable_rag.py` for the retrieval-side citation
+surface.
 
 ## Included Sample Files
 
@@ -58,6 +70,8 @@ the repository root.
   preference facts separate from retrieval results and artifacts
 - `src/retrieval_trace.py`: a tiny ranking and trace surface for making
   retrieval decisions inspectable
+- `src/verifiable_rag.py`: a tiny filter-and-citation surface for metadata
+  filters, page numbers, and multimodal grounding output
 - `src/artifact_policy.py`: one place to show how a starter can separate
   artifact-promotion rules from raw note capture
 
@@ -65,10 +79,30 @@ the repository root.
 
 - No storage backend is wired yet.
 - No embedding or vector-store integration is included.
+- No provider SDK is called directly.
 - Imported personal context stays deliberately small and reviewable.
 - The example favors clear boundaries over completeness.
+- Citations are modeled as output artifacts, not as proof that retrieval is
+  always correct.
+
+## Flow Boundaries
+
+The starter may:
+
+- keep working memory and personal context separate from retrieval inputs
+- apply metadata filters before selecting chunks
+- surface page-level and media citations as part of the returned artifact
+- keep retrieval traces inspectable enough for review
+
+The starter must not:
+
+- treat a file-search store as durable agent memory
+- silently promote retrieved snippets into long-term memory
+- hide filter decisions or cited locations from the reviewer
 
 ## Next Steps
 
 - Add a simple persistence layer for imported context and durable artifacts.
 - Add a clearer review workflow for memory imports before they become active.
+- Add a provider adapter for one real file-search API without collapsing the
+  retrieval store into the memory layer.

--- a/patterns/examples/agent-memory-retrieval-starter/src/verifiable_rag.py
+++ b/patterns/examples/agent-memory-retrieval-starter/src/verifiable_rag.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class StoredFile:
+    file_id: str
+    title: str
+    modality: str
+    metadata: dict[str, str | int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RetrievedChunk:
+    file_id: str
+    snippet: str
+    score: float
+    page_number: int | None = None
+    media_id: str | None = None
+    metadata: dict[str, str | int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Citation:
+    file_id: str
+    title: str
+    snippet: str
+    page_number: int | None = None
+    media_id: str | None = None
+    metadata: dict[str, str | int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class GroundedAnswerPlan:
+    query: str
+    applied_filters: dict[str, str | int]
+    selected_file_ids: list[str]
+    citations: list[Citation]
+
+
+def filter_files(
+    files: list[StoredFile],
+    required_filters: dict[str, str | int],
+) -> list[StoredFile]:
+    if not required_filters:
+        return list(files)
+
+    selected: list[StoredFile] = []
+    for stored_file in files:
+        if all(stored_file.metadata.get(key) == value for key, value in required_filters.items()):
+            selected.append(stored_file)
+    return selected
+
+
+def build_grounded_plan(
+    query: str,
+    files: list[StoredFile],
+    chunks: list[RetrievedChunk],
+    required_filters: dict[str, str | int],
+    *,
+    min_score: float = 0.75,
+    limit: int = 3,
+) -> GroundedAnswerPlan:
+    allowed_files = {
+        stored_file.file_id: stored_file
+        for stored_file in filter_files(files, required_filters)
+    }
+    ranked_chunks = sorted(chunks, key=lambda chunk: chunk.score, reverse=True)
+
+    selected_file_ids: list[str] = []
+    citations: list[Citation] = []
+
+    for chunk in ranked_chunks:
+        if chunk.score < min_score:
+            continue
+        stored_file = allowed_files.get(chunk.file_id)
+        if stored_file is None:
+            continue
+        if chunk.file_id not in selected_file_ids:
+            selected_file_ids.append(chunk.file_id)
+        citations.append(
+            Citation(
+                file_id=chunk.file_id,
+                title=stored_file.title,
+                snippet=chunk.snippet,
+                page_number=chunk.page_number,
+                media_id=chunk.media_id,
+                metadata={**stored_file.metadata, **chunk.metadata},
+            )
+        )
+        if len(citations) >= limit:
+            break
+
+    return GroundedAnswerPlan(
+        query=query,
+        applied_filters=dict(required_filters),
+        selected_file_ids=selected_file_ids,
+        citations=citations,
+    )
+
+
+def render_citation_lines(plan: GroundedAnswerPlan) -> list[str]:
+    lines: list[str] = []
+    for citation in plan.citations:
+        location_parts: list[str] = []
+        if citation.page_number is not None:
+            location_parts.append(f"p{citation.page_number}")
+        if citation.media_id:
+            location_parts.append(f"media:{citation.media_id}")
+        location_text = f" ({', '.join(location_parts)})" if location_parts else ""
+        lines.append(f"{citation.title}{location_text}")
+    return lines

--- a/patterns/index.mdx
+++ b/patterns/index.mdx
@@ -40,8 +40,8 @@ They should stay useful even as individual frameworks rise or fall.
 ## Example starters
 
 - [Agent Memory Retrieval Starter](/patterns/examples/agent-memory-retrieval-starter):
-  a small code sketch for separating active notes, retrieval inputs, and
-  durable artifacts.
+  a small code sketch for separating active notes, verifiable RAG retrieval
+  inputs, citations, and durable artifacts.
 - [Prompt Cache Agent Starter](/patterns/examples/prompt-cache-agent-starter):
   a small code sketch for keeping stable prompt prefixes separate from dynamic
   memory and current-turn inputs.

--- a/scripts/verify_example_projects.py
+++ b/scripts/verify_example_projects.py
@@ -42,6 +42,10 @@ def check_memory_starter() -> None:
         "personal_context",
         "patterns/examples/agent-memory-retrieval-starter/src/personal_context.py",
     )
+    rag_module = load_module(
+        "verifiable_rag",
+        "patterns/examples/agent-memory-retrieval-starter/src/verifiable_rag.py",
+    )
     state = module.AgentState()
     module.add_observation(state, "capture the latest user request")
     module.queue_retrieval(state, "previous agent memory decisions")
@@ -113,6 +117,68 @@ def check_memory_starter() -> None:
         "America/Toronto",
     }
     assert all(item.source == "imported-summary" for item in merged_context)
+
+    files = [
+        rag_module.StoredFile(
+            file_id="refund-policy",
+            title="Refund Policy",
+            modality="document",
+            metadata={"account": "acme", "corpus": "support"},
+        ),
+        rag_module.StoredFile(
+            file_id="product-shot",
+            title="Product Shot",
+            modality="image",
+            metadata={"account": "acme", "corpus": "catalog"},
+        ),
+        rag_module.StoredFile(
+            file_id="other-tenant",
+            title="Other Tenant Policy",
+            modality="document",
+            metadata={"account": "otherco", "corpus": "support"},
+        ),
+    ]
+    filtered_files = rag_module.filter_files(files, {"account": "acme"})
+    plan = rag_module.build_grounded_plan(
+        "What can I cite for the refund answer?",
+        files,
+        [
+            rag_module.RetrievedChunk(
+                file_id="refund-policy",
+                snippet="Refunds are available within 30 days of purchase.",
+                score=0.96,
+                page_number=12,
+                metadata={"section": "refunds"},
+            ),
+            rag_module.RetrievedChunk(
+                file_id="product-shot",
+                snippet="Blue backpack with front zipper pocket.",
+                score=0.83,
+                media_id="media-7",
+            ),
+            rag_module.RetrievedChunk(
+                file_id="other-tenant",
+                snippet="Should never be selected due to tenant filter.",
+                score=0.99,
+                page_number=1,
+            ),
+        ],
+        {"account": "acme"},
+    )
+    citation_lines = rag_module.render_citation_lines(plan)
+
+    assert [item.file_id for item in filtered_files] == [
+        "refund-policy",
+        "product-shot",
+    ]
+    assert plan.selected_file_ids == ["refund-policy", "product-shot"]
+    assert plan.citations[0].page_number == 12
+    assert plan.citations[0].metadata["section"] == "refunds"
+    assert plan.citations[1].media_id == "media-7"
+    assert citation_lines == [
+        "Refund Policy (p12)",
+        "Product Shot (media:media-7)",
+    ]
 
 
 def check_prompt_cache_starter() -> None:

--- a/zh-Hans/patterns/README.md
+++ b/zh-Hans/patterns/README.md
@@ -33,4 +33,4 @@
 ## 示例入门项目
 
 - [Agent Memory Retrieval Starter](./examples/agent-memory-retrieval-starter/index.mdx):
-  一个用于分离活动笔记、检索输入和持久化工件的小型代码示意。
+  一个用于分离活动笔记、可验证 RAG 检索输入、citations 和持久化工件的小型代码示意。

--- a/zh-Hans/patterns/agent-memory-and-retrieval.mdx
+++ b/zh-Hans/patterns/agent-memory-and-retrieval.mdx
@@ -127,6 +127,7 @@ flowchart LR
 
 ## 延伸阅读
 
+- [Agent Memory Retrieval Starter](/zh-Hans/patterns/examples/agent-memory-retrieval-starter)
 - [上下文工程](/zh-Hans/systems/context-engineering)
 - [Customer Support Agents](/zh-Hans/case-studies/customer-support-agents)
 - [Deep Research Agents](/zh-Hans/case-studies/deep-research-agents)

--- a/zh-Hans/patterns/examples/agent-memory-retrieval-starter/index.mdx
+++ b/zh-Hans/patterns/examples/agent-memory-retrieval-starter/index.mdx
@@ -8,7 +8,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 ## 摘要
 
-这个入门项目展示了一种清晰的方式，如何在一个小型智能体循环中分离活动笔记、工作记忆、导入的 personal context、检索输入和持久化工件。
+这个入门项目展示了一种清晰的方式，如何在一个小型智能体循环中分离活动笔记、工作记忆、导入的 personal context、检索输入、带 citations 的可验证 RAG，以及持久化工件。
 
 ## 状态
 
@@ -18,7 +18,9 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 ## 其存在的原因
 
-记忆示例通常会把所有内容都压缩到一个含糊的历史对象中。这个入门项目刻意缩小了范围：它强调了智能体当前持有的内容、从其他助手导入的上下文、可以检索的内容，以及应该作为工件保留的内容之间的边界。
+记忆示例通常会把所有内容都压缩到一个含糊的历史对象中。这个入门项目刻意缩小了范围：它强调了智能体当前持有的内容、从其他助手导入的上下文、可以检索的内容、必须继续留在外部 file-search corpus 中的内容，以及应该作为工件保留的内容之间的边界。
+
+2026 年 5 月 Google 对 multimodal file search 的更新，让“检索边界”更容易讲清楚。一个有用的入门项目，应该把 metadata filters、页级 citations 和 multimodal chunks 展示出来，而不是把 retrieval store 假装成智能体记忆。
 
 ## 相关实验室页面
 
@@ -34,28 +36,54 @@ agent-memory-retrieval-starter/
     ├── artifact_policy.py
     ├── memory_flow.py
     ├── personal_context.py
-    └── retrieval_trace.py
+    ├── retrieval_trace.py
+    └── verifiable_rag.py
 ```
 
 ## 快速开始
 
-这是一个入门项目，不是可运行的应用程序。阅读 `src/memory_flow.py`，了解最小状态形状，并将其作为后续更完整示例的基础。对于仓库级别的冒烟检查，请在仓库根目录运行 `python3 scripts/verify_example_projects.py`。
+在仓库根目录运行：
+
+```bash
+python3 scripts/verify_example_projects.py
+```
+
+这个目录仍然是 starter，而不是完整应用。阅读 `src/memory_flow.py` 了解状态边界，再阅读 `src/verifiable_rag.py` 了解检索侧的 citation surface。
 
 ## 包含的示例文件
 
 - `src/memory_flow.py`：用于活动笔记、任务范围内工作记忆、导入的 personal context、检索输入和持久化工件的最小有用状态容器
 - `src/personal_context.py`：一个轻量的规范化界面，用于把导入的偏好事实与检索结果、持久化工件区分开来
 - `src/retrieval_trace.py`：一个用于让检索决策可检查的轻量排名与追踪界面
+- `src/verifiable_rag.py`：一个轻量的 filter-and-citation 界面，用于展示 metadata filters、页码和 multimodal grounding 输出
 - `src/artifact_policy.py`：展示入门项目如何将工件提升规则与原始笔记捕获分离的单一位置
 
 ## 约束
 
 - 目前尚未接入存储后端。
 - 不包含嵌入或向量数据库集成。
+- 不直接调用任何 provider SDK。
 - 导入的 personal context 仍然被刻意保持为小而可审查的形态。
 - 该示例更强调清晰的边界，而非完整性。
+- citations 被建模为输出工件的一部分，而不是“检索永远正确”的证明。
+
+## 流程边界
+
+这个 starter 可以：
+
+- 把工作记忆、personal context 与检索输入分开
+- 在选 chunk 之前先应用 metadata filters
+- 将页级和媒体 citations 作为返回工件的一部分暴露出来
+- 让 retrieval trace 足够可检查，便于人工 review
+
+这个 starter 不应该：
+
+- 把 file-search store 当成持久化智能体记忆
+- 悄悄把检索片段提升进长期记忆
+- 向 reviewer 隐藏 filter 决策或 citation 位置
 
 ## 下一步
 
 - 为导入上下文与持久化工件添加一个简单的持久化层。
 - 增加一个更清晰的 memory import review workflow，再决定是否激活。
+- 为一个真实 file-search API 增加 provider adapter，但不要把 retrieval store 折叠成 memory layer。

--- a/zh-Hans/patterns/index.mdx
+++ b/zh-Hans/patterns/index.mdx
@@ -39,7 +39,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 ## 示例入门项目
 
 - [Agent Memory Retrieval Starter](/zh-Hans/patterns/examples/agent-memory-retrieval-starter):
-  一个用于分离活动笔记、检索输入和持久化工件的小型代码示意。
+  一个用于分离活动笔记、可验证 RAG 检索输入、citations 和持久化工件的小型代码示意。
 - [Prompt Cache Agent Starter](/zh-Hans/patterns/examples/prompt-cache-agent-starter):
   一个用于把稳定提示词前缀与动态记忆、当前回合输入分开的
   小型代码示意。


### PR DESCRIPTION
## Summary
- refresh the agent memory retrieval starter around verifiable RAG instead of generic retrieval
- add a small Python citation/filter module for metadata filters, page citations, and multimodal grounding
- strengthen English and Simplified Chinese pattern links around the starter

## Validation
- python3 scripts/verify_example_projects.py
- npx mint validate

Executor account: dprat0821
Commit author: generalkim00