### PR TITLE
[dprat0821] Add agentic shopping assistant radar note

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -98,6 +98,7 @@
                 "group": "Radar",
                 "pages": [
                   "radar/index",
+                  "radar/2026-05-agentic-shopping-assistant-watch",
                   "radar/2026-04-assistant-safety-escalation-watch",
                   "radar/2026-04-defense-agent-training-loop-watch",
                   "radar/2026-04-portable-assistant-memory-watch",

--- a/docs.json
+++ b/docs.json
@@ -98,7 +98,6 @@
                 "group": "Radar",
                 "pages": [
                   "radar/index",
-                  "radar/2026-05-agentic-shopping-assistant-watch",
                   "radar/2026-04-assistant-safety-escalation-watch",
                   "radar/2026-04-defense-agent-training-loop-watch",
                   "radar/2026-04-portable-assistant-memory-watch",

--- a/radar/2026-05-agentic-shopping-assistant-watch.mdx
+++ b/radar/2026-05-agentic-shopping-assistant-watch.mdx
@@ -1,0 +1,96 @@
+---
+title: May 2026 Agentic Shopping Assistant Watch
+owner: Prompthon IO
+updated: 2026-05-13
+time_scope: 2026-05
+status: draft
+---
+
+import SupportCTA from "/snippets/support-cta.mdx";
+
+<SupportCTA />
+
+## Summary
+
+Amazon's May 2026 Alexa for Shopping launch pushes the phrase "AI assistant"
+into a more transactional product shape: a shopping assistant can remember
+preferences, compare products, track prices, schedule recurring purchase
+actions, build carts, and hand off between phone, web, and Echo Show surfaces.
+
+For handbook readers, the useful signal is not that commerce has another chat
+box. It is that an assistant is being framed as a cross-surface system with
+memory, product search, user preferences, purchase intent, automation, and
+checkout review living in the same flow.
+
+## Why It Matters
+
+Shopping assistants are a practical test case for agent systems because they
+sit near money, personal preferences, household context, and irreversible
+actions. That makes the design boundary sharper than a general Q&A assistant:
+the system needs to know when it is researching, recommending, cart-building,
+scheduling, or asking a human to confirm a purchase.
+
+This note connects to four durable handbook topics:
+
+- [agent runtime building blocks](/patterns/agent-runtime-building-blocks),
+  because the assistant needs a message layer, tool boundary, memory layer, and
+  action layer that do not blur together
+- [agent memory and retrieval](/patterns/agent-memory-and-retrieval), because
+  preferences, past purchases, and current research context need separate
+  storage and review rules
+- [evaluation and observability](/systems/evaluation-and-observability),
+  because product comparisons, scheduled actions, and cart changes need audit
+  trails that are easy to replay
+- [messaging transaction assistant starter](/ecosystem/examples/messaging-transaction-assistant-starter),
+  because checkout-adjacent assistants should keep payment execution outside
+  the assistant until a user has reviewed the proposed action
+
+## Evidence And Sources
+
+- [Alexa for Shopping](https://www.aboutamazon.com/news/retail/alexa-for-shopping-ai-assistant):
+  Amazon describes a personalized, agentic shopping assistant that combines
+  Rufus product knowledge, Alexa+ context, shopping history, preferences,
+  product comparisons, price history, scheduled actions, cart building, and
+  cross-web purchase assistance.
+- [Echo Show shopping with Alexa+](https://www.aboutamazon.com/news/devices/echo-show-alexa-plus-shopping):
+  Amazon is moving the full shopping interface onto Echo Show, where customers
+  can browse, compare, review, and order with voice, touch, or both.
+- [Amazon's generative and agentic AI shopping overview](https://www.aboutamazon.com/news/retail/amazon-agentic-ai-gen-ai-shopping/):
+  Amazon positions shopping assistance as an agentic commerce surface, including
+  price tracking, recommendations, and the Buy for Me flow for eligible products
+  outside Amazon's own store.
+
+## Signals To Watch
+
+- Whether shopping assistants separate research, recommendation, cart changes,
+  scheduled actions, and purchase confirmation in the user interface and logs.
+- Whether personal preference memory can be reviewed, corrected, scoped, or
+  deleted separately from shopping history and order history.
+- Whether "buy for me" style flows make the merchant, payment method, shipping
+  address, refund path, and cancellation boundary explicit before completion.
+- Whether cross-device assistants expose enough context transfer state for a
+  user to understand why a suggestion appeared on a different surface.
+
+## Editorial Take
+
+This belongs in `radar/` for now. The durable lesson is not "shopping assistant
+as a category" yet. The reusable pattern is narrower: transactional assistants
+need a clear action ladder.
+
+One useful ladder is:
+
+1. answer a product or category question
+2. compare options with visible sources and criteria
+3. propose a cart or scheduled action
+4. ask for explicit user review
+5. execute only the approved purchase or reminder
+6. preserve an audit trail for what changed and why
+
+Future evergreen updates should treat that ladder as a transaction-safety
+pattern, not as a vendor-specific shopping story.
+
+## Update Log
+
+- 2026-05-13: Added a radar note on agentic shopping assistants, cross-surface
+  shopping memory, scheduled purchase actions, and review-before-checkout
+  boundaries.

--- a/radar/README.md
+++ b/radar/README.md
@@ -19,6 +19,10 @@ without destabilizing the evergreen structure.
 
 ## Current notes
 
+- [May 2026 Agentic Shopping Assistant Watch](./2026-05-agentic-shopping-assistant-watch.mdx):
+  a current signal on AI assistants moving from search and product comparison
+  into scheduled actions, cart building, cross-device shopping memory, and
+  review-before-checkout boundaries.
 - [April 2026 Assistant Safety Escalation Watch](./2026-04-assistant-safety-escalation-watch.mdx):
   a current signal on credible violence flags, duty-to-report boundaries,
   repeat policy violators, and audit-ready safety handoffs.

--- a/radar/index.mdx
+++ b/radar/index.mdx
@@ -25,6 +25,10 @@ without destabilizing the evergreen structure.
 
 ## Current notes
 
+- [May 2026 Agentic Shopping Assistant Watch](/radar/2026-05-agentic-shopping-assistant-watch):
+  a current signal on AI assistants moving from search and product comparison
+  into scheduled actions, cart building, cross-device shopping memory, and
+  review-before-checkout boundaries.
 - [April 2026 Assistant Safety Escalation Watch](/radar/2026-04-assistant-safety-escalation-watch):
   a current signal on credible violence flags, duty-to-report boundaries,
   repeat policy violators, and audit-ready safety handoffs.


### PR DESCRIPTION
## Summary
- Add a May 2026 radar note for the article-backed `AI assistant` trend, refined to agentic shopping assistants.
- Connect Amazon's Alexa for Shopping launch to runtime boundaries, memory/retrieval, evaluation, and the existing transaction-assistant starter.
- Add the note to the radar README and site index.

## Sources
- https://www.aboutamazon.com/news/retail/alexa-for-shopping-ai-assistant
- https://www.aboutamazon.com/news/devices/echo-show-alexa-plus-shopping
- https://www.aboutamazon.com/news/retail/amazon-agentic-ai-gen-ai-shopping

## Validation
- `python3 scripts/verify_example_projects.py`
- `git diff --check`

Rotated author account: `dprat0821`
Shared executor account: `dprat0821`