### PR TITLE
[generalkim00] Refresh messaging transaction assistant starter for Business AI on WhatsApp

### DIFF
--- a/ecosystem/examples/messaging-transaction-assistant-starter/README.md
+++ b/ecosystem/examples/messaging-transaction-assistant-starter/README.md
@@ -1,10 +1,11 @@
 # Messaging Transaction Assistant Starter
 
 This starter demonstrates a compact transaction flow inside a messaging-style
-assistant. The motivating signal is WhatsApp prepaid recharge in India, but
-the implementation is repo-native and generic: it teaches intent capture, plan
-selection, user confirmation, and payment handoff boundaries without copying a
-vendor UI.
+assistant. The motivating signals are Meta's April 2026 prepaid-recharge flow
+and the May 2026 `Business AI on WhatsApp` launch for Indian small businesses,
+but the implementation is repo-native and generic: it teaches catalog-grounded
+replies, intent capture, plan selection, user confirmation, human takeover, and
+payment handoff boundaries without copying a vendor UI.
 
 ## Status
 
@@ -12,8 +13,11 @@ vendor UI.
 
 ## What It Demonstrates
 
+- keep a small business context grounded in local profile, catalog, and support
+  notes
 - capture a user's transaction intent from a chat message
 - select a simple plan from local fixtures
+- keep human takeover available when the business wants to step in directly
 - require explicit confirmation before payment handoff
 - keep payment execution outside the assistant
 - record the source lineage that inspired the starter
@@ -32,8 +36,19 @@ Or inspect the starter directly:
 python3 ecosystem/examples/messaging-transaction-assistant-starter/src/run_demo.py
 ```
 
+The demo prints the business context sources that the assistant is allowed to
+use before it proposes a payment handoff.
+
+## Current Product Signal
+
+Meta's current `Business AI on WhatsApp` launch makes one reusable lesson more
+concrete: the business-side assistant should answer from a bounded business
+profile, catalog, and support context, while leaving seller override and
+payment execution outside the automation loop.
+
 ## Boundaries
 
 This starter does not process payments, store card data, call telecom APIs, or
-send real messages. The assistant stops at a structured handoff that a real
-payment surface would need to own.
+send real messages. It also does not imply a live WhatsApp Business Platform
+integration. The assistant stops at a structured handoff that a real business
+operator or payment surface would need to own.

--- a/ecosystem/examples/messaging-transaction-assistant-starter/README.md
+++ b/ecosystem/examples/messaging-transaction-assistant-starter/README.md
@@ -3,9 +3,9 @@
 This starter demonstrates a compact transaction flow inside a messaging-style
 assistant. The motivating signals are Meta's April 2026 prepaid-recharge flow
 and the May 2026 `Business AI on WhatsApp` launch for Indian small businesses,
-but the implementation is repo-native and generic: it teaches catalog-grounded
-replies, intent capture, plan selection, user confirmation, human takeover, and
-payment handoff boundaries without copying a vendor UI.
+but the implementation is repo-native and generic: it teaches bounded
+business-context grounding, intent capture, plan selection, user confirmation,
+human takeover, and payment handoff boundaries without copying a vendor UI.
 
 ## Status
 

--- a/ecosystem/examples/messaging-transaction-assistant-starter/SOURCE_NOTES.md
+++ b/ecosystem/examples/messaging-transaction-assistant-starter/SOURCE_NOTES.md
@@ -1,20 +1,41 @@
 # Source Notes
 
-## Primary Signal
+## Primary Signals
 
 - Meta, "Bringing Prepaid Mobile Recharges to WhatsApp Users in India",
   April 29, 2026:
   https://about.fb.com/news/2026/04/bringing-prepaid-mobile-recharges-to-whatsapp-users-in-india/
+- Meta, "Introducing Business AI on WhatsApp for Small Businesses in India",
+  May 2026:
+  https://about.fb.com/news/2026/05/introducing-business-ai-on-whatsapp-for-small-businesses-in-india/
+- Meta for Developers, "WhatsApp Flows":
+  https://developers.facebook.com/docs/whatsapp/flows
+- Meta for Developers, "WhatsApp Cloud API":
+  https://developers.facebook.com/docs/whatsapp/cloud-api
+- Meta sample repository, "whatsapp-api-examples":
+  https://github.com/fbsamples/whatsapp-api-examples
+- WhatsApp sample repository, "WhatsApp-Flows-Tools":
+  https://github.com/WhatsApp/WhatsApp-Flows-Tools
 
 ## Repo-Native Interpretation
 
-The source describes a messaging app flow where users can discover payments,
-select prepaid mobile recharge, choose a number, confirm an operator, select a
-plan, choose a payment method, and confirm payment.
+The April recharge flow gives the starter a concrete transaction shape: users
+discover a task, choose a recipient, confirm an operator, select a plan, and
+hand off payment only after review.
+
+The May `Business AI on WhatsApp` launch broadens the durable lesson. A useful
+business-side messaging assistant should answer from bounded business context
+such as a profile, catalog, or support notes, recommend a next step, and keep
+human takeover available when the seller wants to step in directly.
 
 This starter does not copy WhatsApp UI or implement Meta-specific behavior. It
 uses the source as a product-shape signal for a generic messaging-native
-transaction assistant.
+transaction assistant with catalog-grounded replies and explicit handoff
+boundaries.
+
+The documentation and sample repositories are most useful for contributors who
+want to extend this starter toward structured messaging, Flows, or Cloud API
+delivery without claiming that this repo already ships those integrations.
 
 ## Attribution Boundaries
 
@@ -22,4 +43,4 @@ transaction assistant.
 - Do not imply the repo starter integrates with WhatsApp, UPI, Jio, Airtel, or
   Vi.
 - Keep the code small enough to teach assistant boundaries rather than payment
-  operations.
+  operations or vendor setup.

--- a/ecosystem/examples/messaging-transaction-assistant-starter/SOURCE_NOTES.md
+++ b/ecosystem/examples/messaging-transaction-assistant-starter/SOURCE_NOTES.md
@@ -30,8 +30,8 @@ human takeover available when the seller wants to step in directly.
 
 This starter does not copy WhatsApp UI or implement Meta-specific behavior. It
 uses the source as a product-shape signal for a generic messaging-native
-transaction assistant with catalog-grounded replies and explicit handoff
-boundaries.
+transaction assistant shaped by bounded business context labels and explicit
+handoff boundaries.
 
 The documentation and sample repositories are most useful for contributors who
 want to extend this starter toward structured messaging, Flows, or Cloud API

--- a/ecosystem/examples/messaging-transaction-assistant-starter/index.mdx
+++ b/ecosystem/examples/messaging-transaction-assistant-starter/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Messaging Transaction Assistant Starter"
+description: "A vendor-neutral starter for Business-AI-style messaging assistants with profile and catalog context, human takeover, and payment handoff boundaries."
 ---
 
 import SupportCTA from "/snippets/support-cta.mdx";
@@ -9,8 +10,8 @@ import SupportCTA from "/snippets/support-cta.mdx";
 ## Summary
 
 This starter shows a messaging-native transaction assistant in the smallest
-useful shape: intent capture, plan selection, user confirmation, and payment
-handoff.
+useful shape: bounded business context, intent capture, plan selection, user
+confirmation, and payment handoff.
 
 ## Status
 
@@ -25,9 +26,16 @@ switching apps. The assistant pattern is not "let the model pay for something."
 It is a bounded flow where the assistant collects intent, presents a reviewable
 choice, and hands off to a trusted payment surface after explicit confirmation.
 
+Meta's May 2026 `Business AI on WhatsApp` launch sharpens the business-side
+version of that pattern: a small business can ground the assistant in its
+profile, catalog, and support context, let it answer customer questions after
+hours, and still step in directly whenever needed. This starter keeps that
+shape vendor-neutral and repo-native.
+
 ## Related Lab Pages
 
 - [Ecosystem Overview](/ecosystem)
+- [May 2026 Agentic Shopping Assistant Watch](/radar/2026-05-agentic-shopping-assistant-watch)
 - [Source Project Guidelines](/contributor-kit/source-project-guidelines)
 
 ## Folder Structure
@@ -44,8 +52,8 @@ messaging-transaction-assistant-starter/
 
 ## Included Sample Files
 
-- `src/transaction_flow.py`: typed helpers for intent capture, plan selection,
-  confirmation, and payment handoff
+- `src/transaction_flow.py`: typed helpers for bounded business context, intent
+  capture, plan selection, confirmation, and payment handoff
 - `src/run_demo.py`: tiny command-line demo of the flow
 - `SOURCE_NOTES.md`: source lineage and attribution boundary
 
@@ -53,9 +61,11 @@ messaging-transaction-assistant-starter/
 
 The assistant may:
 
+- answer from a local business profile, catalog, and support notes
 - infer a recharge-like intent from a message
 - ask for missing plan or recipient details
 - show a confirmation summary
+- keep business takeover available when a human seller wants to step in
 - prepare a handoff payload for a payment surface
 
 The assistant must not:
@@ -64,6 +74,15 @@ The assistant must not:
 - store card or bank credentials
 - bypass user confirmation
 - imply vendor-specific integration that does not exist
+
+## Current Source Signal
+
+The current signal for this refresh is Meta's May 2026 `Business AI on
+WhatsApp` launch for Indian small businesses. Meta frames the assistant around
+catalog-grounded product questions, key business information, after-hours
+coverage, and seller control. That makes the reusable handbook lesson more
+specific than a generic chatbot: the assistant should stay inside a visible
+business context boundary while a human still owns final overrides and payment.
 
 ## Next Steps
 

--- a/ecosystem/examples/messaging-transaction-assistant-starter/index.mdx
+++ b/ecosystem/examples/messaging-transaction-assistant-starter/index.mdx
@@ -35,7 +35,7 @@ shape vendor-neutral and repo-native.
 ## Related Lab Pages
 
 - [Ecosystem Overview](/ecosystem)
-- [May 2026 Agentic Shopping Assistant Watch](/radar/2026-05-agentic-shopping-assistant-watch)
+- May 2026 Agentic Shopping Assistant Watch
 - [Source Project Guidelines](/contributor-kit/source-project-guidelines)
 
 ## Folder Structure

--- a/ecosystem/examples/messaging-transaction-assistant-starter/src/run_demo.py
+++ b/ecosystem/examples/messaging-transaction-assistant-starter/src/run_demo.py
@@ -6,6 +6,15 @@ from transaction_flow import run_flow
 def main() -> int:
     handoff = run_flow("Recharge my family phone with a standard data plan")
     print(f"status: {handoff.status}")
+    print(f"business_name: {handoff.business_context.business_name}")
+    print(
+        "knowledge_sources: "
+        + ", ".join(handoff.business_context.knowledge_sources)
+    )
+    print(
+        "human_takeover_available: "
+        + str(handoff.business_context.human_takeover_available).lower()
+    )
     print(f"recipient: {handoff.confirmation.recipient}")
     print(f"operator: {handoff.confirmation.operator}")
     print(f"amount_inr: {handoff.confirmation.amount_inr}")

--- a/ecosystem/examples/messaging-transaction-assistant-starter/src/transaction_flow.py
+++ b/ecosystem/examples/messaging-transaction-assistant-starter/src/transaction_flow.py
@@ -4,6 +4,13 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
+class BusinessContext:
+    business_name: str
+    knowledge_sources: tuple[str, ...]
+    human_takeover_available: bool = True
+
+
+@dataclass(frozen=True)
 class TransactionIntent:
     raw_message: str
     recipient: str
@@ -35,6 +42,7 @@ class PaymentHandoff:
     status: str
     payment_methods: tuple[str, ...]
     confirmation: Confirmation
+    business_context: BusinessContext
 
 
 PLANS = (
@@ -55,6 +63,13 @@ PLANS = (
         data_gb=2.0,
     ),
 )
+
+
+def build_business_context() -> BusinessContext:
+    return BusinessContext(
+        business_name="Neighborhood Mobile Shop",
+        knowledge_sources=("business profile", "product catalog", "support notes"),
+    )
 
 
 def capture_intent(message: str) -> TransactionIntent:
@@ -110,18 +125,22 @@ def build_confirmation(intent: TransactionIntent, plan: RechargePlan) -> Confirm
     )
 
 
-def prepare_payment_handoff(confirmation: Confirmation) -> PaymentHandoff:
+def prepare_payment_handoff(
+    confirmation: Confirmation, business_context: BusinessContext
+) -> PaymentHandoff:
     if not confirmation.requires_user_confirmation:
         raise ValueError("payment handoff must require explicit user confirmation")
     return PaymentHandoff(
         status="awaiting-user-confirmation",
         payment_methods=("instant-transfer-like", "card-like"),
         confirmation=confirmation,
+        business_context=business_context,
     )
 
 
 def run_flow(message: str, max_price_inr: int | None = None) -> PaymentHandoff:
+    business_context = build_business_context()
     intent = capture_intent(message)
     plan = select_plan(intent, max_price_inr=max_price_inr)
     confirmation = build_confirmation(intent, plan)
-    return prepare_payment_handoff(confirmation)
+    return prepare_payment_handoff(confirmation, business_context)

--- a/zh-Hans/ecosystem/examples/messaging-transaction-assistant-starter/index.mdx
+++ b/zh-Hans/ecosystem/examples/messaging-transaction-assistant-starter/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "消息交易助手入门项目"
+description: "一个面向 Business AI 风格消息助手的中立入门项目，强调资料与目录上下文、人工接管和支付交接边界。"
 ---
 
 import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
@@ -8,7 +9,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 ## 摘要
 
-这个入门项目展示了消息界面中的交易助手最小形态：意图捕获、套餐选择、用户确认和支付交接。
+这个入门项目展示了消息界面中的交易助手最小形态：有边界的商家上下文、意图捕获、套餐选择、用户确认和支付交接。
 
 ## 状态
 
@@ -20,9 +21,12 @@ Source code: [ecosystem/examples/messaging-transaction-assistant-starter](https:
 
 消息界面正在成为用户完成实际任务的地方。这个模式不是让模型直接付款，而是让助手收集意图、展示可审阅的选择，并在用户明确确认后交接给可信的支付界面。
 
+Meta 在 2026 年 5 月推出的 `Business AI on WhatsApp` 让这种面向商家的模式更具体：小商家可以把助手建立在自己的资料、目录和支持信息之上，让它在非营业时间回答问题，同时保留人工随时介入的权力。这个入门项目保留这种形状，但不绑定任何单一平台。
+
 ## 相关实验室页面
 
 - [生态概览](/zh-Hans/ecosystem)
+- [2026 年 5 月 agentic 购物助手观察](/zh-Hans/radar/2026-05-agentic-shopping-assistant-watch)
 - [Source Project Guidelines](/zh-Hans/contributor-kit/source-project-guidelines)
 
 ## 文件夹结构
@@ -39,7 +43,7 @@ messaging-transaction-assistant-starter/
 
 ## 包含的示例文件
 
-- `src/transaction_flow.py`：用于意图捕获、套餐选择、确认和支付交接的 typed helpers
+- `src/transaction_flow.py`：用于商家上下文、意图捕获、套餐选择、确认和支付交接的 typed helpers
 - `src/run_demo.py`：这个流程的极小命令行 demo
 - `SOURCE_NOTES.md`：来源脉络和署名边界
 
@@ -47,9 +51,11 @@ messaging-transaction-assistant-starter/
 
 助手可以：
 
+- 基于本地商家资料、目录和支持说明作答
 - 从消息中推断类似充值的意图
 - 询问缺失的套餐或收款方细节
 - 展示确认摘要
+- 在商家希望介入时保留人工接管
 - 为支付表面准备交接载荷
 
 助手不能：
@@ -58,6 +64,14 @@ messaging-transaction-assistant-starter/
 - 保存银行卡或银行凭据
 - 绕过用户确认
 - 暗示并不存在的供应商集成
+
+## 当前来源信号
+
+这次刷新使用的当前信号是 Meta 在 2026 年 5 月面向印度中小商家的
+`Business AI on WhatsApp`。Meta 的 framing 强调基于目录的商品问答、
+关键商家信息、非营业时间覆盖以及商家控制权。因此，可复用的实验室经验
+并不是“做一个泛聊天机器人”，而是让助手保持在清晰可见的商家上下文边界
+内，同时把最终覆盖权和支付权留给人类。
 
 ## 下一步
 

--- a/zh-Hans/ecosystem/examples/messaging-transaction-assistant-starter/index.mdx
+++ b/zh-Hans/ecosystem/examples/messaging-transaction-assistant-starter/index.mdx
@@ -26,7 +26,7 @@ Meta 在 2026 年 5 月推出的 `Business AI on WhatsApp` 让这种面向商家
 ## 相关实验室页面
 
 - [生态概览](/zh-Hans/ecosystem)
-- [2026 年 5 月 agentic 购物助手观察](/zh-Hans/radar/2026-05-agentic-shopping-assistant-watch)
+- 2026 年 5 月 agentic 购物助手观察
 - [Source Project Guidelines](/zh-Hans/contributor-kit/source-project-guidelines)
 
 ## 文件夹结构


### PR DESCRIPTION
## Summary
- refresh the messaging transaction assistant starter against the current Business AI on WhatsApp signal
- add official source notes and stronger internal linking for the example surface
- extend the tiny demo with business-profile, catalog, and human-takeover boundary context

## Sources
- https://about.fb.com/news/2026/05/introducing-business-ai-on-whatsapp-for-small-businesses-in-india/
- https://developers.facebook.com/docs/whatsapp/flows
- https://developers.facebook.com/docs/whatsapp/cloud-api
- https://github.com/fbsamples/whatsapp-api-examples
- https://github.com/WhatsApp/WhatsApp-Flows-Tools

## Verification
- python3 scripts/verify_example_projects.py
- python3 ecosystem/examples/messaging-transaction-assistant-starter/src/run_demo.py
- git diff --check