### PR TITLE
[generalkim00] Add model ecosystem map

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -81,7 +81,6 @@
                 "group": "Ecosystem",
                 "pages": [
                   "ecosystem/index",
-                  "ecosystem/model-ecosystem-map",
                   "ecosystem/agent-frameworks",
                   "ecosystem/agent-platforms-and-low-code-builders"
                 ]
@@ -303,7 +302,6 @@
                 "group": "生态",
                 "pages": [
                   "zh-Hans/ecosystem/index",
-                  "zh-Hans/ecosystem/model-ecosystem-map",
                   "zh-Hans/ecosystem/agent-frameworks",
                   "zh-Hans/ecosystem/agent-platforms-and-low-code-builders"
                 ]

--- a/docs.json
+++ b/docs.json
@@ -81,6 +81,7 @@
                 "group": "Ecosystem",
                 "pages": [
                   "ecosystem/index",
+                  "ecosystem/model-ecosystem-map",
                   "ecosystem/agent-frameworks",
                   "ecosystem/agent-platforms-and-low-code-builders"
                 ]
@@ -302,6 +303,7 @@
                 "group": "生态",
                 "pages": [
                   "zh-Hans/ecosystem/index",
+                  "zh-Hans/ecosystem/model-ecosystem-map",
                   "zh-Hans/ecosystem/agent-frameworks",
                   "zh-Hans/ecosystem/agent-platforms-and-low-code-builders"
                 ]

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -21,6 +21,8 @@ options, hosted options, and clear guidance on who should care.
 
 ## Current pages
 
+- [Model Ecosystem Map](./model-ecosystem-map.mdx): a beginner map of model
+  providers, model categories, access patterns, and selection tradeoffs.
 - [Agent Frameworks](./agent-frameworks.mdx): a topic-first comparison of
   conversation-oriented, graph-oriented, and engineering-first frameworks.
 - [Agent Platforms And Low-Code Builders](./agent-platforms-and-low-code-builders.mdx):

--- a/ecosystem/index.mdx
+++ b/ecosystem/index.mdx
@@ -27,6 +27,8 @@ options, hosted options, and clear guidance on who should care.
 
 ## Current pages
 
+- [Model Ecosystem Map](/ecosystem/model-ecosystem-map): a beginner map of
+  model providers, model categories, access patterns, and selection tradeoffs.
 - [Agent Frameworks](/ecosystem/agent-frameworks): a topic-first comparison of
   conversation-oriented, graph-oriented, and engineering-first frameworks.
 - [Agent Platforms And Low-Code Builders](/ecosystem/agent-platforms-and-low-code-builders):

--- a/ecosystem/model-ecosystem-map.mdx
+++ b/ecosystem/model-ecosystem-map.mdx
@@ -1,0 +1,138 @@
+---
+title: Model Ecosystem Map
+owner: Prompthon IO
+updated: 2026-05-19
+depth: beginner
+region_tags:
+  - global
+  - china
+coding_required: no
+external_readings:
+  - title: OpenAI API models
+    url: https://platform.openai.com/docs/models
+  - title: Claude models overview
+    url: https://docs.anthropic.com/en/docs/about-claude/models/all-models
+  - title: Gemini API models
+    url: https://ai.google.dev/gemini-api/docs/models
+  - title: Meta Llama get started
+    url: https://ai.meta.com/llama/get-started/
+  - title: Alibaba Cloud Model Studio model list
+    url: https://www.alibabacloud.com/help/en/model-studio/models
+  - title: Baidu Qianfan model list
+    url: https://cloud.baidu.com/doc/qianfan-docs/s/7m95lyy43
+  - title: Moonshot Kimi API concepts
+    url: https://platform.moonshot.cn/docs/introduction
+status: draft
+---
+
+import SupportCTA from "/snippets/support-cta.mdx";
+
+<SupportCTA />
+
+## Summary
+
+The model ecosystem is easier to understand when it is grouped by what a
+learner can do with each family: chat and reasoning, multimodal input,
+generation, open-weight deployment, or regional cloud access. This page is a
+high-level map for choosing a starting point, not a benchmark ranking.
+
+## Why It Matters
+
+Students and early builders often hear model names before they understand the
+product shape behind them. A useful map should answer four questions:
+
+- What kind of work can this model family support?
+- How do I access it: consumer app, API, open weights, or cloud platform?
+- Is it better for learning, prototyping, or deployment?
+- What should I check before using it in a real project?
+
+## Architecture Diagram
+
+```mermaid
+flowchart LR
+  Need["User need"] --> Chat["Chat and reasoning"]
+  Need --> Multimodal["Image, audio, video, and files"]
+  Need --> Build["API and app building"]
+  Need --> Open["Open-weight or self-hosted options"]
+  Need --> Region["Regional cloud ecosystem"]
+  Chat --> OpenAI["OpenAI / Claude / Gemini / Kimi"]
+  Multimodal --> Multi["OpenAI / Gemini / Qianfan / Model Studio"]
+  Build --> API["OpenAI API / Claude API / Gemini API"]
+  Open --> Llama["Llama and Qwen-style open ecosystems"]
+  Region --> China["Alibaba Cloud / Baidu Qianfan / Moonshot"]
+```
+
+## Provider Map
+
+| Provider family | What students should remember | Common access pattern | Good first use |
+| --- | --- | --- | --- |
+| OpenAI | Broad model platform across text, reasoning, image, audio, video, realtime, and agentic development surfaces. | ChatGPT for app use; OpenAI API for builders. | General assistants, coding help, multimodal prototypes, and agent workflows. |
+| Anthropic Claude | Strong document, reasoning, coding, and workspace-oriented assistant family with API and app surfaces. | Claude app and Claude API. | Long-document review, careful writing, coding assistance, and artifact-style outputs. |
+| Google Gemini | Google model family with API access and strong integration with Google AI Studio and Google Cloud surfaces. | Gemini app, Google AI Studio, Gemini API, and cloud deployment paths. | Multimodal experiments, search-grounded prototypes, and Google-stack applications. |
+| Meta Llama | Open-weight model ecosystem that can be accessed through Meta and partner channels. | Download, partner hosting, or cloud/provider APIs. | Learning open-weight tradeoffs, local experimentation, and portability-minded builds. |
+| Alibaba Cloud Qwen / Model Studio | China-linked model platform with Qwen, multimodal options, coding models, and OpenAI-compatible API patterns. | Alibaba Cloud Model Studio and DashScope-style API access. | China-aware app prototypes, Qwen experiments, and cloud-hosted model access. |
+| Baidu Qianfan / ERNIE | China cloud model platform covering ERNIE, DeepSeek, Qwen-linked options, multimodal generation, search, and app builder surfaces. | Baidu Qianfan ModelBuilder and AppBuilder. | Chinese-language product experiments, enterprise app building, and multimodal exploration. |
+| Moonshot Kimi | Kimi API family with long-context text and vision-oriented model options. | Kimi app and Moonshot API. | Chinese-language long-context work, document review, and early API experiments. |
+
+## Capability Map
+
+| Capability | What it means | Typical model families to inspect |
+| --- | --- | --- |
+| Chat and reasoning | Answers questions, drafts text, explains concepts, plans, and solves multi-step tasks. | OpenAI, Claude, Gemini, Kimi, Qianfan, Model Studio. |
+| Vision and file understanding | Reads images, screenshots, diagrams, PDFs, and other uploaded materials. | OpenAI, Claude, Gemini, Qianfan, Model Studio, Kimi vision options. |
+| Image, audio, and video generation | Creates or transforms media rather than only reading it. | OpenAI specialized models, Gemini ecosystem tools, Qianfan, Model Studio. |
+| Tool use and agent workflows | Calls functions, uses tools, or connects to external systems. | OpenAI API, Claude API, Gemini API, Model Studio, Qianfan. |
+| Open-weight deployment | Lets teams study, host, tune, or run models outside a single hosted app. | Llama, Qwen open-source editions, and partner-hosted open model catalogs. |
+| Regional platform access | Helps teams match language, compliance, data residency, billing, and local ecosystem needs. | Alibaba Cloud Model Studio, Baidu Qianfan, Moonshot Kimi, cloud partners. |
+
+## Choosing A Starting Point
+
+Use the simplest surface that teaches the right lesson.
+
+- For first exposure, start with a consumer assistant such as ChatGPT, Claude,
+  Gemini, or Kimi and focus on task design.
+- For API learning, start with one model provider and build a small
+  request-response app before comparing vendors.
+- For multimodal learning, test one input type at a time: image, document,
+  audio, or video.
+- For open-weight learning, start with why portability, local control, or
+  licensing matters before selecting a model.
+- For China-linked deployment, inspect Qianfan, Model Studio, and Kimi from the
+  beginning instead of treating them as late substitutes.
+
+## Common Mistakes
+
+- Treating the newest model name as automatically better for every task.
+- Comparing app features with API features as if they are the same product.
+- Ignoring pricing, rate limits, region availability, safety policy, and data
+  controls until after a prototype works.
+- Choosing an open-weight model for portability without budgeting for hosting,
+  evaluation, monitoring, and updates.
+- Choosing a regional platform only for language coverage instead of checking
+  deployment, billing, and support requirements.
+
+## Suggested Class Exercise
+
+Pick one task, such as "summarize a course reading and produce a study quiz."
+Ask students to compare three access patterns:
+
+- a consumer assistant
+- a hosted API
+- an open-weight or regional cloud option
+
+The output should be a short table: task quality, ease of setup, cost or usage
+limits, and what a production team would need to verify next.
+
+## Citations
+
+- Current official model and platform readings are listed in `external_readings`.
+
+## Reading Extensions
+
+- [Agent Platforms And Low-Code Builders](/ecosystem/agent-platforms-and-low-code-builders)
+- [LLM Foundations For Agent Systems](/foundations/llm-foundations-for-agent-systems)
+- [Evaluation And Observability](/systems/evaluation-and-observability)
+
+## Update Log
+
+- 2026-05-19: Added the beginner model ecosystem map from issue #27.

--- a/zh-Hans/ecosystem/index.mdx
+++ b/zh-Hans/ecosystem/index.mdx
@@ -24,6 +24,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 ## 当前页面
 
+- [模型生态地图](/zh-Hans/ecosystem/model-ecosystem-map)：面向入门者，梳理模型供应商、模型类别、访问方式和选择取舍。
 - [Agent Frameworks](/zh-Hans/ecosystem/agent-frameworks)：按主题优先，对面向对话、面向图以及工程优先的框架进行对比。
 - [智能体平台与低代码构建器](/zh-Hans/ecosystem/agent-platforms-and-low-code-builders)：何时选择以构建器为先、以平台为先，或以自动化为先的界面。
 

--- a/zh-Hans/ecosystem/model-ecosystem-map.mdx
+++ b/zh-Hans/ecosystem/model-ecosystem-map.mdx
@@ -1,0 +1,124 @@
+---
+title: 模型生态地图
+owner: Prompthon IO
+updated: 2026-05-19
+depth: beginner
+region_tags:
+  - global
+  - china
+coding_required: no
+external_readings:
+  - title: OpenAI API models
+    url: https://platform.openai.com/docs/models
+  - title: Claude models overview
+    url: https://docs.anthropic.com/en/docs/about-claude/models/all-models
+  - title: Gemini API models
+    url: https://ai.google.dev/gemini-api/docs/models
+  - title: Meta Llama get started
+    url: https://ai.meta.com/llama/get-started/
+  - title: Alibaba Cloud Model Studio model list
+    url: https://www.alibabacloud.com/help/en/model-studio/models
+  - title: Baidu Qianfan model list
+    url: https://cloud.baidu.com/doc/qianfan-docs/s/7m95lyy43
+  - title: Moonshot Kimi API concepts
+    url: https://platform.moonshot.cn/docs/introduction
+status: draft
+---
+
+import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
+
+<SupportCTA />
+
+## 摘要
+
+理解模型生态时，最好先按学习者可以完成的事情来分组：聊天与推理、多模态输入、生成能力、开源权重部署，以及区域云平台接入。这个页面是一个入门地图，不是模型排行榜。
+
+## 为什么重要
+
+学生和早期构建者常常先听到模型名称，却还不了解它背后的产品形态。一个有用的地图应该回答四个问题：
+
+- 这个模型家族适合什么类型的任务？
+- 我该通过什么方式访问它：消费级应用、API、开源权重，还是云平台？
+- 它更适合学习、原型验证，还是部署？
+- 真正用于项目之前需要检查什么？
+
+## 架构图
+
+```mermaid
+flowchart LR
+  Need["用户需求"] --> Chat["聊天与推理"]
+  Need --> Multimodal["图像、音频、视频与文件"]
+  Need --> Build["API 与应用构建"]
+  Need --> Open["开源权重或自托管"]
+  Need --> Region["区域云生态"]
+  Chat --> OpenAI["OpenAI / Claude / Gemini / Kimi"]
+  Multimodal --> Multi["OpenAI / Gemini / Qianfan / Model Studio"]
+  Build --> API["OpenAI API / Claude API / Gemini API"]
+  Open --> Llama["Llama 与 Qwen 风格开源生态"]
+  Region --> China["Alibaba Cloud / Baidu Qianfan / Moonshot"]
+```
+
+## 供应商地图
+
+| 供应商家族 | 学生应记住什么 | 常见访问方式 | 适合的第一个用途 |
+| --- | --- | --- | --- |
+| OpenAI | 覆盖文本、推理、图像、音频、视频、实时交互和智能体开发的综合模型平台。 | ChatGPT 面向应用使用；OpenAI API 面向构建者。 | 通用助手、编码辅助、多模态原型和智能体工作流。 |
+| Anthropic Claude | 强调文档、推理、编码和工作空间协作的助手家族，同时提供应用和 API。 | Claude 应用与 Claude API。 | 长文档审阅、谨慎写作、编码辅助和 artifact 风格产出。 |
+| Google Gemini | Google 的模型家族，和 Google AI Studio、Gemini API、Google Cloud 路径结合紧密。 | Gemini 应用、Google AI Studio、Gemini API 和云部署路径。 | 多模态实验、带搜索 grounding 的原型，以及 Google 技术栈应用。 |
+| Meta Llama | 开源权重模型生态，可通过 Meta 与合作伙伴渠道获取。 | 下载、合作伙伴托管，或云服务商 API。 | 学习开源权重取舍、本地实验和重视可迁移性的构建。 |
+| Alibaba Cloud Qwen / Model Studio | 中国相关模型平台，覆盖 Qwen、多模态、编码模型和 OpenAI 兼容 API 模式。 | 阿里云百炼 Model Studio 与 DashScope 风格 API。 | 面向中国场景的应用原型、Qwen 实验和云端模型接入。 |
+| Baidu Qianfan / ERNIE | 中国云模型平台，覆盖 ERNIE、DeepSeek、Qwen 相关选项、多模态生成、搜索和应用构建。 | 百度千帆 ModelBuilder 与 AppBuilder。 | 中文产品实验、企业应用构建和多模态探索。 |
+| Moonshot Kimi | Kimi API 家族，包含长上下文文本和视觉相关模型选项。 | Kimi 应用与 Moonshot API。 | 中文长上下文、文档审阅和早期 API 实验。 |
+
+## 能力地图
+
+| 能力 | 含义 | 可以优先查看的模型家族 |
+| --- | --- | --- |
+| 聊天与推理 | 回答问题、起草文本、解释概念、规划和解决多步骤任务。 | OpenAI、Claude、Gemini、Kimi、Qianfan、Model Studio。 |
+| 视觉与文件理解 | 阅读图像、截图、图表、PDF 和其他上传材料。 | OpenAI、Claude、Gemini、Qianfan、Model Studio、Kimi vision 选项。 |
+| 图像、音频和视频生成 | 不只是阅读内容，也能创建或转换媒体。 | OpenAI 专门模型、Gemini 生态工具、Qianfan、Model Studio。 |
+| 工具使用与智能体工作流 | 调用函数、使用工具，或连接外部系统。 | OpenAI API、Claude API、Gemini API、Model Studio、Qianfan。 |
+| 开源权重部署 | 让团队研究、托管、调优，或在单一托管应用之外运行模型。 | Llama、Qwen 开源版本，以及合作伙伴托管的开源模型目录。 |
+| 区域平台接入 | 帮助团队匹配语言、合规、数据区域、计费和本地生态需求。 | Alibaba Cloud Model Studio、Baidu Qianfan、Moonshot Kimi、云合作伙伴。 |
+
+## 如何选择起点
+
+选择能够教会正确问题的最简单界面。
+
+- 第一次接触时，从 ChatGPT、Claude、Gemini 或 Kimi 这类消费级助手开始，重点练习任务设计。
+- 学 API 时，先选一个模型供应商，做一个小的请求-响应应用，再比较不同供应商。
+- 学多模态时，一次只测试一种输入类型：图像、文档、音频或视频。
+- 学开源权重时，先明确为什么需要可迁移、本地控制或许可证灵活性，再选择模型。
+- 做中国相关部署时，从一开始就检查 Qianfan、Model Studio 和 Kimi，而不是最后才把它们当替代项。
+
+## 常见错误
+
+- 把最新模型名称直接等同于所有任务上的最好选择。
+- 把应用功能和 API 功能当成同一个产品来比较。
+- 等原型完成后才检查价格、速率限制、区域可用性、安全政策和数据控制。
+- 因为想要可迁移性而选择开源权重，却没有预算托管、评估、监控和更新成本。
+- 只因为语言覆盖选择区域平台，却没有检查部署、计费和支持要求。
+
+## 课堂练习建议
+
+选择一个任务，例如“总结课程阅读材料并生成复习测验”。让学生比较三种访问模式：
+
+- 消费级助手
+- 托管 API
+- 开源权重或区域云选项
+
+输出应该是一张短表：任务质量、设置难度、成本或使用限制，以及生产团队下一步需要验证什么。
+
+## 引用
+
+- 当前官方模型与平台阅读材料列在 `external_readings` 中。
+
+## 延伸阅读
+
+- [智能体平台与低代码构建器](/zh-Hans/ecosystem/agent-platforms-and-low-code-builders)
+- [智能体系统的 LLM 基础](/zh-Hans/foundations/llm-foundations-for-agent-systems)
+- [评估与可观测性](/zh-Hans/systems/evaluation-and-observability)
+
+## 更新日志
+
+- 2026-05-19：根据 issue #27 添加入门模型生态地图。


### PR DESCRIPTION
## Summary
- Adds a beginner-facing Model Ecosystem Map page for issue #27.
- Adds English and Simplified Chinese pages.
- Links the new page from the ecosystem overview and README surfaces.

## Rotation
- rotation_account: `generalkim00`
- executor_account: `dprat0821`

## Verification
- `python3 scripts/verify_example_projects.py`
- `python3 -m json.tool docs.json >/dev/null`
- `git diff --check`
- `PATH=/Users/liqingpan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm_config_cache=/tmp/codex-mint-cache-model npx mint validate`

Closes #27
