### PR TITLE
[gongxiaojing0825] Add AI builder tools directory

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -82,8 +82,7 @@
                 "pages": [
                   "ecosystem/index",
                   "ecosystem/agent-frameworks",
-                  "ecosystem/agent-platforms-and-low-code-builders",
-                  "ecosystem/ai-builder-tools-directory"
+                  "ecosystem/agent-platforms-and-low-code-builders"
                 ]
               },
               {
@@ -304,8 +303,7 @@
                 "pages": [
                   "zh-Hans/ecosystem/index",
                   "zh-Hans/ecosystem/agent-frameworks",
-                  "zh-Hans/ecosystem/agent-platforms-and-low-code-builders",
-                  "zh-Hans/ecosystem/ai-builder-tools-directory"
+                  "zh-Hans/ecosystem/agent-platforms-and-low-code-builders"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -82,7 +82,8 @@
                 "pages": [
                   "ecosystem/index",
                   "ecosystem/agent-frameworks",
-                  "ecosystem/agent-platforms-and-low-code-builders"
+                  "ecosystem/agent-platforms-and-low-code-builders",
+                  "ecosystem/ai-builder-tools-directory"
                 ]
               },
               {
@@ -303,7 +304,8 @@
                 "pages": [
                   "zh-Hans/ecosystem/index",
                   "zh-Hans/ecosystem/agent-frameworks",
-                  "zh-Hans/ecosystem/agent-platforms-and-low-code-builders"
+                  "zh-Hans/ecosystem/agent-platforms-and-low-code-builders",
+                  "zh-Hans/ecosystem/ai-builder-tools-directory"
                 ]
               },
               {

--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -25,6 +25,9 @@ options, hosted options, and clear guidance on who should care.
   conversation-oriented, graph-oriented, and engineering-first frameworks.
 - [Agent Platforms And Low-Code Builders](./agent-platforms-and-low-code-builders.mdx):
   when to choose builder-first, platform-first, or automation-first surfaces.
+- [AI Builder Tools Directory](./ai-builder-tools-directory.mdx): a beginner
+  directory for choosing assistant, automation, app-builder, and template tools
+  by outcome.
 
 ## Example starters
 

--- a/ecosystem/ai-builder-tools-directory.mdx
+++ b/ecosystem/ai-builder-tools-directory.mdx
@@ -1,0 +1,112 @@
+---
+title: AI Builder Tools Directory
+owner: Prompthon IO
+updated: 2026-05-19
+depth: beginner
+region_tags:
+  - global
+coding_required: optional
+external_readings:
+  - title: ChatGPT capabilities overview
+    url: https://help.openai.com/en/articles/9260256-chatgpt-capabilities-overview
+  - title: Claude artifacts overview
+    url: https://support.anthropic.com/en/articles/9487310-what-are-artifacts-and-how-do-i-use-them
+  - title: Build an agent in Zapier Agents
+    url: https://help.zapier.com/hc/en-us/articles/24393442652557-Build-an-agent-in-Zapier-Agents
+  - title: Make AI Agents
+    url: https://www.make.com/en/ai-agents
+  - title: About Bubble AI app generation
+    url: https://manual.bubble.io/help-guides/ai/bubbles-ai-app-generator/about-ai-app-generation
+  - title: Replit Agent
+    url: https://docs.replit.com/core-concepts/agent
+  - title: Vercel templates
+    url: https://vercel.com/docs/getting-started-with-vercel/template
+status: draft
+---
+
+import SupportCTA from "/snippets/support-cta.mdx";
+
+<SupportCTA />
+
+## Summary
+
+AI builder tools help beginners move from idea to artifact faster: a draft,
+diagram, automation, app prototype, codebase, or deployable starter. This
+directory is for choosing a first tool by task shape, not for ranking every
+tool in the market.
+
+## How To Read This Directory
+
+Start with the outcome you want, then choose the smallest surface that can
+teach the workflow.
+
+- Use assistant tools when the output is mainly writing, analysis, planning, or
+  file review.
+- Use automation tools when the output should connect apps and repeat work.
+- Use app builders when the output should become a working web or mobile app.
+- Use developer templates when the learner is ready to inspect code and deploy.
+
+## Tool Directory
+
+| Tool | Category | What it does | Example use case | Difficulty | Cost model |
+| --- | --- | --- | --- | --- | --- |
+| ChatGPT | General assistant and workspace tool | Supports conversation, search, deep research, image input and generation, file uploads, data analysis, Canvas, Projects, and custom GPT-style assistants depending on plan and settings. | Turn a class topic into a study guide, analyze a CSV, draft a project plan, or generate a first visual concept. | Beginner | Free and paid plans; advanced tools and limits vary by plan and workspace controls. |
+| Claude | General assistant and artifact workspace | Produces long-form text, code, diagrams, and shareable artifacts that can be edited or reused outside the chat. | Draft a lesson handout, build a small interactive artifact, or review a long document. | Beginner | Free and paid plans; organization controls and feature availability vary. |
+| Zapier Agents | Automation agent builder | Creates AI agents that can use connected apps, actions, triggers, and knowledge sources inside Zapier's automation environment. | Build a personal assistant that watches a form, drafts follow-up messages, and updates a spreadsheet. | Beginner to intermediate | Plan and activity based; agents consume usage when they run or use actions. |
+| Make AI Agents | Visual automation agent builder | Builds agents directly inside a visual automation canvas so teams can connect apps, inspect steps, and manage workflows. | Route support requests, summarize inbox items, or coordinate an approval workflow across apps. | Beginner to intermediate | Plan based; check Make plan limits, app operations, and AI-agent availability. |
+| Bubble AI app generation | No-code app builder | Generates a working app foundation from a plain-language prompt, then lets the builder refine it with Bubble's visual editor. | Prototype a marketplace, booking app, internal tracker, or student project without starting from blank screens. | Beginner to intermediate | Builder plan based; hosting, capacity, and production needs depend on the Bubble plan. |
+| Replit Agent | AI app and code workspace | Turns plain-language app ideas into files and working projects inside a hosted development workspace. | Build a small web app, classroom demo, internal tool, or prototype that students can inspect as code. | Intermediate | Replit plan and usage based; project hosting and agent usage can affect cost. |
+| Vercel templates | Developer starter templates | Provides deployable templates, including AI-oriented examples, for learners ready to work with code and production hosting. | Start from a Next.js or AI template, customize it, and deploy a public demo. | Intermediate | Templates can be free; deployment, usage, and add-ons depend on the Vercel project. |
+
+## Choosing By Outcome
+
+| Outcome | Start here | Move next when |
+| --- | --- | --- |
+| I need to understand, write, or analyze. | ChatGPT or Claude. | The work needs repeatable app connections or deployment. |
+| I need to automate work across apps. | Zapier Agents or Make AI Agents. | The workflow needs custom UI, custom data model, or code-level control. |
+| I need a working app without coding. | Bubble AI app generation. | The app needs source-code ownership, custom infrastructure, or a development team workflow. |
+| I need a codebase students can inspect. | Replit Agent or Vercel templates. | The prototype needs tests, version control discipline, and production observability. |
+
+## Beginner Workflow
+
+1. Pick one real task, such as a club event signup tracker.
+2. Ask ChatGPT or Claude to turn the task into user stories and acceptance
+   checks.
+3. Build the first workflow in Zapier or Make if the task is mostly app
+   coordination.
+4. Build the first app in Bubble if the task needs screens, forms, and data.
+5. Move to Replit or a Vercel template when students are ready to inspect code,
+   use GitHub, and deploy.
+
+## Evaluation Checklist
+
+Before recommending a tool to students, check:
+
+- Can a beginner produce a useful artifact in one session?
+- Can the teacher explain where the data goes?
+- Can the student revise the output without starting over?
+- Does the free or classroom-accessible plan support the exercise?
+- Does the tool fit the learning goal, or only produce an impressive demo?
+- Is there a clear next step from prototype to maintained project?
+
+## Common Mistakes
+
+- Listing too many tools before students understand the task categories.
+- Treating a generated demo as a maintained product.
+- Ignoring where data, files, credentials, and generated code are stored.
+- Choosing a no-code builder for a code-learning exercise.
+- Choosing a code-first template when the lesson is really about workflow
+  design or product thinking.
+
+## Citations
+
+- Current official product readings are listed in `external_readings`.
+
+## Reading Extensions
+
+- [Agent Platforms And Low-Code Builders](/ecosystem/agent-platforms-and-low-code-builders)
+- [Sample Projects](/reading-paths/sample-projects)
+
+## Update Log
+
+- 2026-05-19: Added the beginner AI builder tools directory from issue #30.

--- a/ecosystem/index.mdx
+++ b/ecosystem/index.mdx
@@ -31,6 +31,9 @@ options, hosted options, and clear guidance on who should care.
   conversation-oriented, graph-oriented, and engineering-first frameworks.
 - [Agent Platforms And Low-Code Builders](/ecosystem/agent-platforms-and-low-code-builders):
   when to choose builder-first, platform-first, or automation-first surfaces.
+- [AI Builder Tools Directory](/ecosystem/ai-builder-tools-directory): a
+  beginner directory for choosing assistant, automation, app-builder, and
+  template tools by outcome.
 
 ## Example starters
 

--- a/zh-Hans/ecosystem/ai-builder-tools-directory.mdx
+++ b/zh-Hans/ecosystem/ai-builder-tools-directory.mdx
@@ -1,0 +1,103 @@
+---
+title: AI 构建工具目录
+owner: Prompthon IO
+updated: 2026-05-19
+depth: beginner
+region_tags:
+  - global
+coding_required: optional
+external_readings:
+  - title: ChatGPT capabilities overview
+    url: https://help.openai.com/en/articles/9260256-chatgpt-capabilities-overview
+  - title: Claude artifacts overview
+    url: https://support.anthropic.com/en/articles/9487310-what-are-artifacts-and-how-do-i-use-them
+  - title: Build an agent in Zapier Agents
+    url: https://help.zapier.com/hc/en-us/articles/24393442652557-Build-an-agent-in-Zapier-Agents
+  - title: Make AI Agents
+    url: https://www.make.com/en/ai-agents
+  - title: About Bubble AI app generation
+    url: https://manual.bubble.io/help-guides/ai/bubbles-ai-app-generator/about-ai-app-generation
+  - title: Replit Agent
+    url: https://docs.replit.com/core-concepts/agent
+  - title: Vercel templates
+    url: https://vercel.com/docs/getting-started-with-vercel/template
+status: draft
+---
+
+import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
+
+<SupportCTA />
+
+## 摘要
+
+AI 构建工具可以帮助初学者更快从想法走到产物：草稿、图表、自动化、应用原型、代码库，或可部署的起步项目。这个目录用于按任务形态选择第一个工具，而不是给所有工具做排名。
+
+## 如何阅读这个目录
+
+先看你想得到什么结果，再选择能教会这个流程的最小界面。
+
+- 输出主要是写作、分析、规划或文件审阅时，使用助手型工具。
+- 输出需要连接应用并重复执行时，使用自动化工具。
+- 输出需要成为一个可用网页或移动应用时，使用应用构建器。
+- 学生已经准备好看代码和部署时，使用开发者模板。
+
+## 工具目录
+
+| 工具 | 类别 | 它做什么 | 示例用途 | 难度 | 成本模式 |
+| --- | --- | --- | --- | --- | --- |
+| ChatGPT | 通用助手与工作空间工具 | 根据计划和设置，支持对话、搜索、深度研究、图像输入与生成、文件上传、数据分析、Canvas、Projects 和自定义 GPT 风格助手。 | 把课堂主题变成学习指南、分析 CSV、起草项目计划，或生成第一个视觉概念。 | 入门 | 免费和付费计划并存；高级工具与额度随计划和工作区控制而变化。 |
+| Claude | 通用助手与 artifact 工作区 | 生成长文、代码、图表和可分享的 artifact，方便在对话之外编辑或复用。 | 起草课程讲义、构建小型交互 artifact，或审阅长文档。 | 入门 | 免费和付费计划并存；组织控制和功能可用性会变化。 |
+| Zapier Agents | 自动化智能体构建器 | 在 Zapier 自动化环境中创建可以使用连接应用、动作、触发器和知识源的 AI 智能体。 | 构建个人助理，监听表单、起草跟进消息，并更新电子表格。 | 入门到中级 | 按计划和 activity 使用量计费；智能体运行或使用动作时会消耗额度。 |
+| Make AI Agents | 可视化自动化智能体构建器 | 在可视化自动化画布内构建智能体，让团队连接应用、检查步骤并管理工作流。 | 分流支持请求、总结收件箱项目，或跨应用协调审批流程。 | 入门到中级 | 按计划计费；需要检查 Make 计划限制、应用操作数和 AI agent 可用性。 |
+| Bubble AI app generation | 无代码应用构建器 | 根据自然语言提示生成应用基础，然后用 Bubble 的可视化编辑器继续调整。 | 原型化 marketplace、预约应用、内部 tracker，或学生项目。 | 入门到中级 | 按构建器计划计费；托管、容量和生产需求取决于 Bubble 计划。 |
+| Replit Agent | AI 应用与代码工作区 | 在托管开发工作区中，把自然语言应用想法转成文件和可运行项目。 | 构建小型 Web 应用、课堂 demo、内部工具，或可让学生查看代码的原型。 | 中级 | 按 Replit 计划和使用量计费；项目托管与 agent 使用会影响成本。 |
+| Vercel templates | 开发者起步模板 | 提供可部署模板，包括 AI 相关示例，适合准备使用代码和生产托管的学习者。 | 从 Next.js 或 AI 模板开始，修改后部署公开 demo。 | 中级 | 模板可以免费；部署、使用量和附加服务取决于 Vercel 项目。 |
+
+## 按结果选择
+
+| 结果 | 从哪里开始 | 什么时候继续升级 |
+| --- | --- | --- |
+| 我需要理解、写作或分析。 | ChatGPT 或 Claude。 | 工作需要可重复的应用连接或部署。 |
+| 我需要跨应用自动化。 | Zapier Agents 或 Make AI Agents。 | 工作流需要自定义 UI、自定义数据模型，或代码级控制。 |
+| 我需要不用写代码的工作应用。 | Bubble AI app generation。 | 应用需要源码所有权、自定义基础设施，或开发团队工作流。 |
+| 我需要学生能查看的代码库。 | Replit Agent 或 Vercel templates。 | 原型需要测试、GitHub 流程和生产可观测性。 |
+
+## 初学者工作流
+
+1. 选择一个真实任务，例如社团活动报名 tracker。
+2. 让 ChatGPT 或 Claude 把任务转成用户故事和验收检查。
+3. 如果任务主要是应用协作，在 Zapier 或 Make 中构建第一个工作流。
+4. 如果任务需要界面、表单和数据，在 Bubble 中构建第一个应用。
+5. 当学生准备好查看代码、使用 GitHub 和部署时，转到 Replit 或 Vercel 模板。
+
+## 评估清单
+
+向学生推荐工具之前，先检查：
+
+- 初学者能否在一次课程中产出有用结果？
+- 老师能否解释数据会去哪里？
+- 学生能否修改结果，而不是每次都重新开始？
+- 免费或课堂可访问计划是否支持这个练习？
+- 这个工具符合学习目标，还是只是 demo 看起来很酷？
+- 从原型到可维护项目是否有清晰下一步？
+
+## 常见错误
+
+- 在学生理解任务类别之前列出太多工具。
+- 把生成出来的 demo 当成可维护产品。
+- 忽视数据、文件、凭据和生成代码的存储位置。
+- 在代码学习练习中选择无代码构建器。
+- 当课程目标其实是工作流设计或产品思考时，选择代码优先模板。
+
+## 引用
+
+- 当前官方产品阅读材料列在 `external_readings` 中。
+
+## 延伸阅读
+
+- [智能体平台与低代码构建器](/zh-Hans/ecosystem/agent-platforms-and-low-code-builders)
+- [示例项目](/zh-Hans/reading-paths/sample-projects)
+
+## 更新日志
+
+- 2026-05-19：根据 issue #30 添加入门 AI 构建工具目录。

--- a/zh-Hans/ecosystem/index.mdx
+++ b/zh-Hans/ecosystem/index.mdx
@@ -26,6 +26,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 - [Agent Frameworks](/zh-Hans/ecosystem/agent-frameworks)：按主题优先，对面向对话、面向图以及工程优先的框架进行对比。
 - [智能体平台与低代码构建器](/zh-Hans/ecosystem/agent-platforms-and-low-code-builders)：何时选择以构建器为先、以平台为先，或以自动化为先的界面。
+- [AI 构建工具目录](/zh-Hans/ecosystem/ai-builder-tools-directory)：按结果选择助手、自动化、应用构建器和模板工具的入门目录。
 
 ## 示例入门项目
 


### PR DESCRIPTION
## Summary
- Adds a beginner-facing AI Builder Tools Directory page for issue #30.
- Adds English and Simplified Chinese pages.
- Links the new page from the ecosystem overview and README surfaces.

## Rotation
- rotation_account: `gongxiaojing0825`
- executor_account: `dprat0821`

## Verification
- `python3 scripts/verify_example_projects.py`
- `python3 -m json.tool docs.json >/dev/null`
- `git diff --check`
- `PATH=/Users/liqingpan/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm_config_cache=/tmp/codex-mint-cache-ai-builder npx mint validate`

Closes #30
