### PR TITLE
[Content]: Update LLM and agentic evaluation methodology

### DIFF
--- a/radar/2026-05-customer-support-agent-evaluation-tradeoffs.mdx
+++ b/radar/2026-05-customer-support-agent-evaluation-tradeoffs.mdx
@@ -1,0 +1,90 @@
+---
+title: May 2026 Customer Support Agent Evaluation Tradeoffs
+owner: xyanglu
+updated: 2026-05-18
+time_scope: 2026-05
+status: draft
+---
+
+import SupportCTA from "/snippets/support-cta.mdx";
+
+<SupportCTA />
+
+## Summary
+
+Customer support agents built on LLMs are moving from prototype to production,
+but evaluation practices have not kept pace. Teams are shipping agents that
+handle real conversations without a clear framework for measuring what "good"
+means across the dimensions that actually matter: response quality, reliability
+under API failures, latency consistency, and cost control. The gap is widest for
+teams running multi-model setups with automatic fallback.
+
+## Why It Matters
+
+Support agents operate under constraints that benchmarks do not capture. A
+model scoring well on MMLU or Arena can still fail in production when:
+
+- The cloud API returns empty responses due to content filtering or transient
+  errors, and the fallback model is too slow for interactive use.
+- Responses are syntactically correct but miss conversational context, tone,
+  or the user's actual intent.
+- Latency varies wildly between primary and fallback providers, creating an
+  inconsistent user experience.
+
+These are system-level evaluation problems, not model-level ones. The
+evaluation question is not "which model scores highest" but "does the full
+pipeline deliver acceptable replies reliably, under real failure conditions,
+within latency and cost budgets."
+
+## Evidence And Sources
+
+- **Multi-model fallback in production**: A deployed auto-reply system using
+  GLM-5.1 (cloud, ~25 tok/s) as primary with Phi-3 mini (local, ~3.4 tok/s)
+  as fallback showed that cloud APIs can return empty responses with
+  `finish_reason: "length"` during transient outages. The system needed
+  explicit empty-response detection to trigger fallback, since HTTP 200 with
+  empty content is not an error. This is a common blind spot in agent
+  evaluation frameworks that only check for exceptions.
+  ([Discussion context: production Signal messaging agent, May 2026](https://www.linkedin.com/posts/yang-lu-a-engineer/))
+
+- **OpenAI function calling evaluation guide**: OpenAI's documentation
+  emphasizes that evaluation should cover tool selection accuracy, argument
+  correctness, and response coherence separately, not just end-to-end task
+  completion.
+  ([OpenAI Evaluation Best Practices](https://platform.openai.com/docs/guides/evaluation))
+
+- **LangSmith agent evaluation patterns**: LangChain's evaluation toolkit
+  treats agent evaluation as a multi-dimensional problem spanning trajectory
+  (did it pick the right tools?), final output (did it produce the right
+  answer?), and latency (did it finish in time?). Support agents add a fourth
+  dimension: conversational appropriateness.
+  ([LangSmith Evaluation Docs](https://docs.smith.langchain.com/evaluation))
+
+- **Local inference tradeoffs**: llama.cpp benchmarks on consumer hardware
+  (Intel i7, 16GB RAM) show that Q4-quantized 3.8B models achieve 3-4 tok/s,
+  which is too slow for interactive support chat but acceptable as a degraded
+  fallback. The tradeoff between model quality and inference speed is a
+  deployment decision that evaluation frameworks should surface explicitly.
+  ([llama.cpp](https://github.com/ggml-org/llama.cpp))
+
+## Signals To Watch
+
+- Whether evaluation frameworks add first-class support for fallback chain
+  testing: asserting that degraded-mode responses still meet minimum quality
+  bars, not just asserting happy-path behavior.
+- Whether content-filter-induced empty responses become a standard test case
+  in agent evaluation suites, alongside timeout and rate-limit scenarios.
+- Whether production support agents converge on a standard set of evaluation
+  dimensions: response quality, conversational tone, latency budget adherence,
+  fallback reliability, and cost per conversation.
+- Whether local inference hardware improvements (Apple Silicon unified memory,
+  NPUs) shift the cost-quality tradeoff enough to make single-model deployment
+  viable for support agents, eliminating fallback complexity entirely.
+- Whether observability tools begin correlating model-level metrics (token
+  speed, finish reason) with user-level outcomes (conversation resolution,
+  follow-up rate).
+
+## Update Log
+
+- 2026-05-18: Initial draft based on production experience with multi-model
+  support agent systems.

--- a/systems/evaluation-and-observability.mdx
+++ b/systems/evaluation-and-observability.mdx
@@ -1,7 +1,7 @@
 ---
 title: Evaluation And Observability
 owner: Prompthon IO
-updated: 2026-04-21
+updated: 2026-05-18
 depth: advanced
 region_tags:
   - global
@@ -21,6 +21,10 @@ tells you why it passed or failed. Production systems need both, because scores
 without traces are hard to improve and traces without metrics are hard to
 prioritize.
 
+This page covers general evaluation and observability for agent systems, with a
+dedicated section on why LLM-based agents need a different evaluation mindset
+than traditional software.
+
 ## Why It Matters
 
 Agent systems are probabilistic and multi-step. That makes them harder to judge
@@ -35,6 +39,90 @@ Teams therefore need two loops:
 
 - an `evaluation loop` for measuring capability
 - a `diagnostic loop` for explaining behavior
+
+## Why LLM Evaluation Is Different
+
+Evaluating an agent system is not the same as testing a function. Four
+properties of LLM-based systems break traditional test assumptions.
+
+**Nondeterministic outputs.** The same prompt can produce different valid
+answers across runs. Tests that assert an exact string match will flake. You
+need tolerance for semantic equivalence, not just syntactic identity. See
+[LLM Foundations for Agent Systems](/foundations/llm-foundations-for-agent-systems)
+for the underlying model behavior.
+
+**Probabilistic success.** An agent may succeed on 8 out of 10 runs and fail
+twice for reasons that are not reproducible. Evaluation shifts from "does it
+pass?" to "what fraction of runs succeed, and under what conditions?" This
+means reporting confidence intervals, not just point scores.
+
+**Tool-call variance.** Two correct trajectories may call tools in different
+orders, use different argument combinations, or skip steps that another path
+includes. Structured correctness checks must compare intent and outcome, not
+just the literal call sequence. See
+[Context Engineering](/systems/context-engineering) for how tool selection
+relates to prompt and retrieval design.
+
+**Ambiguous criteria.** For open-ended tasks (summarization, drafting,
+creative synthesis), there is often no single correct answer. Multiple
+responses can be equally valid. This makes binary pass/fail insufficient and
+pushes you toward rubric-based scoring, pairwise comparison, or human
+judgment.
+
+## Evaluation Approach Map
+
+No single evaluation method covers every task. Match the approach to what you
+are measuring.
+
+| Approach | When to use | What it checks |
+|---|---|---|
+| Exact / structured checks | Tool calling, JSON schemas, output format | Correct function selected, correct parameter types, valid schema |
+| Reference-based comparison | Retrieval-augmented tasks, factual QA | Output matches a known-good reference (exact, fuzzy, or semantic similarity) |
+| Rubric scoring | Open-ended generation, summarization, reasoning | Human or judge model scores output against a multi-point rubric |
+| Pairwise comparison | Model or prompt selection | Given two outputs, a human or judge picks the better one |
+| LLM-as-a-judge | High-volume automated scoring where human review is too slow | A second LLM evaluates output quality using a structured prompt |
+| Human review | High-stakes, novel tasks, calibration of automated methods | Domain expert rates output quality; used to validate and calibrate judges |
+| Online telemetry | Production monitoring | Success rate, latency, escalation rate, retries, user feedback signals |
+
+Most production systems combine two or more. A common pattern: structured
+checks for tool correctness, LLM-as-a-judge for answer quality, human review
+for calibration, and online telemetry for regression detection.
+
+## Human-in-the-Loop vs LLM-as-a-Judge
+
+Both approaches have a role. Knowing where each is strongest avoids the two
+common failures: relying on humans too slowly to catch regressions, or relying
+on a judge model that is not calibrated to your domain.
+
+**Human-in-the-loop is strongest when:**
+
+- the task is high-stakes (medical, legal, financial advice)
+- criteria are novel or poorly defined and you are still learning what "good"
+  looks like
+- you need to calibrate or audit an automated judge
+- edge cases are rare but critical (safety, bias, harmful output)
+
+**LLM-as-a-judge is strongest when:**
+
+- you need to score hundreds or thousands of runs per change
+- criteria are well-defined and stable enough to encode in a prompt
+- you are running regression tests on every commit or deployment
+- the judge model can be validated against a held-out human-labeled set
+
+**Calibration is not optional.** A judge model that agrees with humans 60% of
+the time is a noisy signal, not a replacement. Build a calibration set of
+100-200 human-labeled examples. Measure agreement rate. Retrain or adjust the
+judge prompt when agreement drops below your threshold.
+
+**Audit expectations.** Regulators and internal reviewers will ask "who checked
+this?" Keep records of:
+
+- which runs were human-reviewed vs judge-scored
+- judge agreement rates on calibration samples
+- any overrides where a human disagreed with the judge
+
+See [Deep Research Agents](/case-studies/deep-research-agents) for a worked
+example of mixing automated scoring with human calibration.
 
 ## Mental Model
 
@@ -70,6 +158,23 @@ flowchart LR
   Triage --> Decisions
 ```
 
+## Framework Landscape
+
+A compact comparison of common evaluation and observability frameworks. This is
+not exhaustive; it covers the three most frequently referenced in agent-system
+work.
+
+| Framework | Primary focus | Key strengths | Source |
+|---|---|---|---|
+| **Langfuse** | Observability and eval platform | Open-source, trace-first design, supports LLM-as-a-judge scoring, prompt versioning, dataset management | [langfuse.com](https://langfuse.com) |
+| **LangSmith** | Observability and eval for LangChain ecosystem | Tight LangChain/LangGraph integration, trace visualization, automated evaluation workflows, dataset curation | [smith.langchain.com](https://smith.langchain.com) |
+| **Ragas** | RAG-specific evaluation metrics | Metrics for faithfulness, answer relevance, context precision, and context recall; framework-agnostic | [docs.ragas.io](https://docs.ragas.io) |
+
+All three support the evaluation approaches described in the approach map
+above. Choose based on your stack integration needs and whether your primary
+focus is RAG-specific metrics (Ragas), open-source self-hosting (Langfuse), or
+LangChain ecosystem alignment (LangSmith).
+
 ## Tool Landscape
 
 The imported reference material highlights three useful evaluation shapes:
@@ -99,6 +204,10 @@ That is what turns a black-box failure into an actionable bug.
 - Judge-model evaluation scales well, but it still needs human calibration.
 - Rich traces improve diagnosis, but they create storage, privacy, and review
   overhead.
+- Pairwise comparison is easy for humans but does not give you an absolute
+  score; use it for ranking, not for release gating.
+- LLM-as-a-judge is fast but inherits the judge model's biases; a judge that
+  prefers verbose outputs will systematically over-score wordy generations.
 
 Useful operating defaults:
 
@@ -106,13 +215,18 @@ Useful operating defaults:
 - keep traces for both failed and successful runs
 - review failure modes before rewriting prompts
 - do not ship "tool failed" as the only explanation developers can see
+- maintain a calibration set and re-check judge agreement after every model
+  change
 
 ## Reading Extensions
 
-- [Protocols And Interoperability](/systems/protocols-and-interoperability)
+- [LLM Foundations for Agent Systems](/foundations/llm-foundations-for-agent-systems)
+- [Context Engineering](/systems/context-engineering)
 - [Deep Research Agents](/case-studies/deep-research-agents)
+- [Protocols And Interoperability](/systems/protocols-and-interoperability)
 - [Systems Overview](/systems)
 
 ## Update Log
 
+- 2026-05-18: Major revision adding LLM-specific evaluation methodology, approach map, human-in-the-loop vs LLM-as-a-judge, and framework landscape.
 - 2026-04-21: Initial repo-native draft based on imported reference material and lab rewrite rules.


### PR DESCRIPTION
Resolves #117

## What this changes

Major revision of `systems/evaluation-and-observability.mdx` adding LLM-specific evaluation methodology that the current page lacks.

## New content

1. **Why LLM Evaluation Is Different** -- Nondeterministic outputs, prompt/model sensitivity, hidden context effects, tool-call variance, and ambiguous success criteria. Explains why traditional software testing patterns don't transfer.

2. **Evaluation Approach Map** -- Structured reference covering 7 approaches: exact/structured checks, reference-based checks, rubric scoring, pairwise comparison, LLM-as-a-judge, human review, and online telemetry. Each with when-to-use guidance.

3. **Human-in-the-Loop vs LLM-as-a-Judge** -- Where human review is strongest (rubric design, calibration sets, edge cases, safety calls) vs where LLM judges help (scaling, regression suites, variant comparison, trace triage). Includes calibration and audit expectations.

4. **Framework Landscape** -- Compact comparison of Langfuse (open-source observability + eval), LangSmith (trace-based evaluation + LLM-as-judge), and Ragas (RAG-specific metrics). Kept conceptual, not a vendor catalog.

## What's preserved

All existing sections (Summary, Why It Matters, Mental Model, Architecture Diagram/mermaid, Tool Landscape, Tradeoffs, Reading Extensions) remain intact. Extended Tradeoffs with two new points on pairwise comparison limits and judge-model bias.

## Acceptance criteria (#117)

- [x] Explains nondeterminism and subjective success as first-class evaluation problems
- [x] Includes a clear map of evaluation approaches and when each is useful
- [x] Distinguishes human-in-the-loop from LLM-as-a-judge with calibration/audit expectations
- [x] Includes compact framework landscape covering Langfuse, LangSmith, and Ragas with source links
- [x] Keeps the page durable, avoids broad vendor catalog
- [x] Includes internal reading links (LLM Foundations, Context Engineering, Deep Research Agents)

## Source lineage

- Original issue request: #117
- Langfuse docs: https://langfuse.com/docs
- LangSmith evaluation: https://www.langchain.com/langsmith/evaluation
- LangSmith LLM-as-judge: https://docs.langchain.com/langsmith/llm-as-judge
- Ragas evaluate: https://docs.ragas.io/en/stable/references/evaluate/

_Rebased from #140 (base: main → develop)_