### PR TITLE
[Bug]: Fix broken Recommended Reads links in Explorer reading path

### DIFF
--- a/reading-paths/explorer.mdx
+++ b/reading-paths/explorer.mdx
@@ -12,30 +12,29 @@ committing to a strict build sequence.
 ## Recommended reads
 
 
-- [The Agent Systems](../foundations/the-agent-system.mdx): start
-
+- [The Agent Systems](../foundations/the-agent-system): start
 
   with the core definition and operating loop.
-- [History Of Agent Ideas](../foundations/history-of-agent-ideas.mdx): use the
+- [History Of Agent Ideas](../foundations/history-of-agent-ideas): use the
   short historical arc to understand why the field looks the way it does.
-- [Agents Vs Workflows](../foundations/agents-vs-workflows.mdx): clarify the
+- [Agents Vs Workflows](../foundations/agents-vs-workflows): clarify the
   boundary between deterministic orchestration and bounded autonomy.
-- [Deep Research Agents](../case-studies/deep-research-agents.mdx): see how one
+- [Deep Research Agents](../case-studies/deep-research-agents): see how one
   of the clearest modern agent products is structured.
-- [Ecosystem](../ecosystem/index.mdx): compare the major tools, platforms, and
+- [Ecosystem](../ecosystem/index): compare the major tools, platforms, and
   market categories.
-- [Radar](../radar/index.mdx): track what is changing quickly across the field.
+- [Radar](../radar/index): track what is changing quickly across the field.
 
 ## Optional deeper dives
 
-- [Agent Memory And Retrieval](../patterns/agent-memory-and-retrieval.mdx): go
+- [Agent Memory And Retrieval](../patterns/agent-memory-and-retrieval): go
   here if you want a practical mental model for memory, retrieval, and
   artifacts.
-- [Reasoning And Control Patterns](../patterns/reasoning-and-control-patterns.mdx):
+- [Reasoning And Control Patterns](../patterns/reasoning-and-control-patterns):
   go here if you want the control-loop view of agent behavior.
-- [LLM Foundations For Agent Systems](../foundations/llm-foundations-for-agent-systems.mdx):
+- [LLM Foundations For Agent Systems](../foundations/llm-foundations-for-agent-systems):
   go here if you want the minimum model literacy behind modern agents.
-- [Context Engineering](../systems/context-engineering.mdx): go here if you
+- [Context Engineering](../systems/context-engineering): go here if you
   want the production-minded view of how context is managed over time.
 
 ## What this guide optimizes for


### PR DESCRIPTION
Resolves #136

## What this fixes

The Explorer reading path page (`reading-paths/explorer.mdx`) had 10 internal markdown links with `.mdx` extensions (e.g., `../foundations/the-agent-system.mdx`). Mintlify's routing expects extensionless paths, so all "Recommended Reads" and "Optional Deeper Dives" links resolved to 404 pages.

## Fix

Removed `.mdx` from all 10 internal links:
- 6 links in "Recommended reads" section
- 4 links in "Optional deeper dives" section
The MDX import statement (`import SupportCTA from "/snippets/support-cta.mdx"`) was left unchanged -- file system imports in MDX require the extension.

## Verification

- Confirmed the repo uses Mintlify (docs.json schema)
- Confirmed docs.json navigation references are all extensionless
- Confirmed only internal page links were modified, not file system imports

**Note:** The same `.mdx` extension issue may exist in `practitioner.mdx`, `builder.mdx`, and `contributor.mdx` reading path files, but those were out of scope for this issue.

_Rebased from #141 (base: main → develop)_