### PR TITLE
[gongxiaojing0825] Add AI education policy-to-practice workshop note

### DIFF
--- a/contributor-kit/reference-notes/README.md
+++ b/contributor-kit/reference-notes/README.md
@@ -14,6 +14,9 @@ material and they are not replacements for lab pages.
 
 ## Current notes
 
+- [AI Education Policy To Practice](./ai-education-policy-to-practice.mdx): a
+  product-agnostic education workshop planning note on shared AI language,
+  teacher-led implementation, peer learning, and practical roadmaps.
 - [Enterprise Agent Control Planes](./enterprise-agent-control-planes.mdx): a
   contributor-facing note on separating managed runtimes from cross-agent
   control planes in enterprise agent systems.

--- a/contributor-kit/reference-notes/ai-education-policy-to-practice.mdx
+++ b/contributor-kit/reference-notes/ai-education-policy-to-practice.mdx
@@ -1,0 +1,109 @@
+---
+title: AI Education Policy To Practice
+owner: Prompthon IO
+updated: 2026-05-27
+scope: education AI policy-to-practice workshop planning
+status: draft
+---
+
+import SupportCTA from "/snippets/support-cta.mdx";
+
+<SupportCTA />
+
+## Summary
+
+This note captures a product-agnostic education workshop signal from Google for
+Education's May 2026 AI Policy & Guidance Labs: schools do not move from AI
+principles to classroom practice by publishing a policy alone. They need shared
+language, teacher-led implementation, peer examples, and a concrete planning
+cycle.
+
+For Prompthon contributors, the useful lesson is not tied to one vendor tool.
+It is a workshop design pattern for turning high-level AI guidance into a
+responsible agent-system learning activity.
+
+## Why It Matters
+
+Education teams often start AI adoption from different mental models:
+administrators may talk about risk, IT leaders may talk about access and data,
+teachers may talk about learning design, and students may talk about shortcuts.
+Without shared language, a workshop can become tool demo theater instead of a
+practice plan.
+
+The handbook can help by giving educators and community builders a neutral
+agent-systems vocabulary: what the model does, what the tool boundary is, what
+the human reviews, what data is allowed, and what evidence shows that a learner
+understood the work.
+
+## Scope Notes
+
+Included:
+
+- shared vocabulary for education AI adoption
+- teacher-led implementation as a workshop constraint
+- 12-month roadmap thinking as a planning artifact
+- peer learning and case studies as a way to make policy concrete
+- links to handbook surfaces that support practical learning activities
+
+Excluded:
+
+- product endorsement or platform-specific setup
+- classroom legal advice
+- school policy templates that should be owned by local education leaders
+- student surveillance or cheating-detection workflows
+
+## Source Map
+
+- [From policy to practice: supporting the future of AI in education](https://blog.google/products-and-platforms/products/education/ai-policy-guidance-labs/):
+  Google for Education describes global AI Policy & Guidance Labs that brought
+  education policy experts together with primary, secondary, and higher
+  education leaders. The public write-up emphasizes product-agnostic planning,
+  shared language, peer learning, educator leadership, and 12-month
+  implementation roadmaps.
+
+## Synthesis
+
+Three workshop design lessons transfer cleanly into this handbook:
+
+- **Start with common language.** Before a group builds with AI, align on
+  terms such as model, tool, workflow, source, artifact, review, and policy
+  boundary. This prevents a tool feature from becoming the whole conversation.
+- **Keep educators in the lead.** A learning activity should make the teacher
+  or facilitator responsible for goals, constraints, and review. The agent
+  system can assist with drafting, retrieval, feedback, or simulation, but it
+  should not decide the learning objective.
+- **Turn policy into a roadmap.** A useful workshop output is not "we tried an
+  AI tool." It is a short plan: what will be piloted, what data is allowed,
+  what learner artifact will be reviewed, what risks will be monitored, and
+  what feedback loop decides whether the activity continues.
+
+## Workshop Translation Notes
+
+For future Prompthon education or community workshops, a compact flow could be:
+
+1. Read [The Agent System](/foundations/the-agent-system) to define the
+   operating loop.
+2. Use [Agents Vs Workflows](/foundations/agents-vs-workflows) to separate
+   deterministic classroom process from bounded AI assistance.
+3. Pick one practical activity from [Workshop Materials](/workshops/index) or
+   [Sample Projects](/reading-paths/sample-projects).
+4. Ask participants to write a one-page policy-to-practice plan covering
+   allowed sources, human review, learner artifact, evaluation method, and next
+   30-day experiment.
+
+That structure keeps the workshop grounded in practice without turning the
+session into a single-vendor product lesson.
+
+## Gaps And Follow-up
+
+- Add an education-oriented workshop page only if there is a real session plan,
+  audience, and facilitator owner.
+- Pair any future classroom example with [Evaluation And Observability](/systems/evaluation-and-observability)
+  so participants can discuss how learning outcomes would be checked.
+- Keep future sources official and product-agnostic where possible, especially
+  when the page is meant for educators rather than developers.
+
+## Update Log
+
+- 2026-05-27: Added a product-agnostic education policy-to-practice reference
+  note based on Google for Education's AI Policy & Guidance Labs write-up.

--- a/contributor-kit/reference-notes/index.mdx
+++ b/contributor-kit/reference-notes/index.mdx
@@ -20,6 +20,9 @@ material and they are not replacements for lab pages.
 
 ## Current notes
 
+- [AI Education Policy To Practice](/contributor-kit/reference-notes/ai-education-policy-to-practice):
+  a product-agnostic education workshop planning note on shared AI language,
+  teacher-led implementation, peer learning, and practical roadmaps.
 - [Enterprise Agent Control Planes](/contributor-kit/reference-notes/enterprise-agent-control-planes):
   a contributor-facing note on treating observability, governance, and security
   as a separate enterprise control-plane layer for agent systems.

--- a/reading-paths/explorer.mdx
+++ b/reading-paths/explorer.mdx
@@ -36,6 +36,9 @@ committing to a strict build sequence.
   go here if you want the minimum model literacy behind modern agents.
 - [Context Engineering](../systems/context-engineering): go here if you
   want the production-minded view of how context is managed over time.
+- [AI Education Policy To Practice](../contributor-kit/reference-notes/ai-education-policy-to-practice):
+  go here if you want a product-agnostic example of turning AI policy language
+  into a practical learning activity.
 
 ## What this guide optimizes for
 


### PR DESCRIPTION
## Summary
- Add a product-agnostic AI education policy-to-practice reference note based on Google for Education's AI Policy & Guidance Labs write-up
- Link the note from the reference-notes index and Explorer reading path
- Keep the note scoped to shared language, teacher-led implementation, peer learning, and practical roadmaps

## Verification
- python3 scripts/verify_example_projects.py
- git diff --check

Executor account: dprat0821

Closes #129