### PR TITLE
Skip track guard for release PRs

### DIFF
--- a/.github/scripts/prompthon-track-guard.mjs
+++ b/.github/scripts/prompthon-track-guard.mjs
@@ -96,6 +96,12 @@ function failureComment({ allowedPaths, invalidFiles, track }) {
   ].join("\n");
 }
 
+function isReleasePullRequest(pullRequest, repo) {
+  return pullRequest.base?.ref === "main" &&
+    pullRequest.head?.ref === "develop" &&
+    pullRequest.head?.repo?.full_name === repo;
+}
+
 async function main() {
   const dryRun = process.argv.includes("--dry-run");
   const event = readEventPayload();
@@ -103,6 +109,14 @@ async function main() {
   const repo = event.repository?.full_name || process.env.GITHUB_REPOSITORY;
   if (!pullRequest?.number || !repo) {
     console.log(JSON.stringify({ skipped: true, reason: "missing_pull_request_payload" }, null, 2));
+    return;
+  }
+
+  if (isReleasePullRequest(pullRequest, repo)) {
+    console.log(JSON.stringify({
+      skipped: true,
+      reason: "develop_to_main_release_pr",
+    }, null, 2));
     return;
   }
 


### PR DESCRIPTION
## Summary

Release PRs from same-repository `develop` into `main` intentionally aggregate multiple contribution tracks. Skip `prompthon-track-guard` for that release path while keeping normal contributor PR path validation unchanged.

## Verification

- `GITHUB_EVENT_PATH=<tmp release event> GITHUB_REPOSITORY=Prompthon-IO/agent-systems-handbook node .github/scripts/prompthon-track-guard.mjs --dry-run`
- `node --test .github/scripts/prompthon-activity-policy.test.mjs`
- `git diff --check`

## Contribution Type

- repo/process/meta

## Placement

- Target path: `.github/scripts/prompthon-track-guard.mjs`
- Related issue: none
