### PR TITLE
Skip track guard for release PRs (#164)

### DIFF
--- a/.github/scripts/prompthon-track-guard.mjs
+++ b/.github/scripts/prompthon-track-guard.mjs
@@ -96,6 +96,12 @@ function failureComment({ allowedPaths, invalidFiles, track }) {
   ].join("\n");
 }
 
+function isReleasePullRequest(pullRequest, repo) {
+  return pullRequest.base?.ref === "main" &&
+    pullRequest.head?.ref === "develop" &&
+    pullRequest.head?.repo?.full_name === repo;
+}
+
 async function main() {
   const dryRun = process.argv.includes("--dry-run");
   const event = readEventPayload();
@@ -103,6 +109,14 @@ async function main() {
   const repo = event.repository?.full_name || process.env.GITHUB_REPOSITORY;
   if (!pullRequest?.number || !repo) {
     console.log(JSON.stringify({ skipped: true, reason: "missing_pull_request_payload" }, null, 2));
+    return;
+  }
+
+  if (isReleasePullRequest(pullRequest, repo)) {
+    console.log(JSON.stringify({
+      skipped: true,
+      reason: "develop_to_main_release_pr",
+    }, null, 2));
     return;
   }
 

--- a/contributor-kit/reference-notes/README.md
+++ b/contributor-kit/reference-notes/README.md
@@ -23,4 +23,5 @@ material and they are not replacements for lab pages.
 - [Deep Research Source Map](./deep-research-source-map.mdx)
 - [Local Agent Tooling Source Map](./local-agent-tooling-source-map.mdx): a
   contributor briefing for keeping local runtimes, skills, MCP roots,
-  resources, connectors, and file-grounded workflows distinct in future drafts.
+  resources, connectors, and file-grounded workflows distinct in future drafts
+  while adding prompt-injection and local authority-boundary guidance.

--- a/contributor-kit/reference-notes/local-agent-tooling-source-map.mdx
+++ b/contributor-kit/reference-notes/local-agent-tooling-source-map.mdx
@@ -1,7 +1,7 @@
 ---
 title: Local Agent Tooling Source Map
 owner: Prompthon IO
-updated: 2026-05-17
+updated: 2026-05-27
 scope: local agent tooling, skills, roots, resources, connectors, and file-grounded workflows
 status: draft
 ---
@@ -63,8 +63,9 @@ Included:
 
 - official OpenAI source material on Responses API tools, file search, remote
   MCP support, and computer environments
-- official OpenAI, Claude Code, and MCP security guidance on prompt injection,
-  sandboxing, and trust boundaries for local agents
+- official OpenAI, Microsoft, Claude Code, and MCP security guidance on
+  indirect prompt injection, sandboxing, scope minimization, and trust
+  boundaries for local agents
 - official MCP material on roots and resources
 - official Claude Code material on local stdio servers, project/user scopes,
   and MCP resources
@@ -85,10 +86,14 @@ Excluded:
 - [OpenAI computer environment for agents](https://openai.com/index/equip-responses-api-computer-environment/):
   use this for claims about execution environments, persistent files, shell
   access, compaction, and agent skills as runtime support.
-- [Designing AI agents to resist prompt injection](https://openai.com/index/designing-agents-to-resist-prompt-injection/):
-  use this when the draft needs a current OpenAI framing for source-sink
-  analysis, user confirmation, and constraining what untrusted content can
-  cause an agent to do.
+- [Understanding prompt injections](https://openai.com/safety/prompt-injections/):
+  use this when the draft needs OpenAI's current plain-language framing for
+  third-party instructions, layered defenses, sandboxing, and user
+  confirmations around agent actions.
+- [Defend against indirect prompt injection attacks](https://learn.microsoft.com/en-us/security/zero-trust/sfi/defend-indirect-prompt-injection):
+  use this for a current enterprise defense stack that names prompt shields,
+  spotlighting, plan-drift detection, critic agents, tool-chain analysis,
+  information-flow control, and least privilege.
 - [MCP introduction](https://modelcontextprotocol.io/docs/getting-started/intro):
   use this for a stable, high-level explanation of MCP as a connection layer
   between AI applications and external systems.
@@ -111,6 +116,12 @@ Excluded:
   use this when the draft needs concrete language for local MCP server
   compromise, one-click startup-command consent, scope minimization, and why
   stdio or authenticated transports matter.
+- [modelcontextprotocol/modelcontextprotocol](https://github.com/modelcontextprotocol/modelcontextprotocol):
+  use this as the high-signal implementation and specification repo for
+  checking current MCP adoption, issue flow, and security-surface maintenance.
+- [microsoft/BIPIA](https://github.com/microsoft/BIPIA):
+  use this as a benchmark-oriented repo when the draft needs a concrete example
+  of evaluating indirect prompt-injection robustness.
 - [promptfoo/promptfoo](https://github.com/promptfoo/promptfoo):
   use this as a high-signal implementation repo for red-teaming and CI-level
   prompt-injection checks around agents, tools, and RAG systems.
@@ -156,6 +167,35 @@ or send data elsewhere?"
 - Add prompt-injection and tool-misuse checks to eval or red-team workflows
   before calling a local-agent setup production-ready.
 
+## Authority Boundary Matrix
+
+The source map is easier to apply when contributors compare local-agent
+surfaces side by side instead of treating them all as "tool access."
+
+| Surface | Main boundary question | Main failure mode | Baseline defenses |
+| --- | --- | --- | --- |
+| Direct local script | Which user or service account executes the command? | Broad shell authority turns one bad instruction into immediate file or credential access. | Minimal default privileges, explicit input review, isolated runtime, and auditable outputs. |
+| Local `stdio` MCP server | Which startup command and local directories are in scope? | A trusted-looking local server can execute opaque startup commands or overreach into local files. | Exact startup-command review, sandboxing, restricted filesystem access, and narrow directory scope. |
+| Remote MCP server | Which remote scopes, tokens, and outbound actions are delegated? | Over-broad tokens or weak auth let untrusted content trigger high-impact remote actions. | Scope minimization, short-lived tokens, authenticated transport, per-action confirmation, and request logging. |
+| Platform-hosted tool | Which product-layer guardrails sit between the model and the action? | The platform hides the transport, so prompt injection can surface as plan drift or silent data overreach. | Layered prompt-injection defenses, tool-chain analysis, human confirmation, and policy-level review of high-risk actions. |
+
+## Where To Deepen This In The Handbook
+
+- [Reference Notes](/contributor-kit/reference-notes): keep the source-map and
+  contributor-briefing layer clear before drafting durable handbook pages.
+- [Protocols and Interoperability](/systems/protocols-and-interoperability):
+  use this when the draft needs the MCP, A2A, and remote-boundary comparison.
+- [Agent UI Protocols and Generative UI](/systems/agent-ui-protocols-and-generative-ui):
+  use this when the draft needs to separate tool permissions from UI state.
+- [Weather MCP Server Starter](/systems/examples/weather-mcp-server-starter):
+  use this as the repo-native example surface for explaining MCP boundaries in
+  runnable form.
+- [April 2026 Assistant Safety Escalation Watch](/radar/2026-04-assistant-safety-escalation-watch):
+  use this when a draft needs to connect local authority boundaries to human
+  escalation and audit paths.
+- [GitHub Issue Guide](/contributor-kit/github-issue-guide): use this when the
+  note turns into a scoped contribution proposal or issue claim.
+
 ## Case-Study Hooks
 
 Good local-agent case studies should make the boundary visible:
@@ -171,15 +211,18 @@ requires human review.
 
 ## Gaps And Follow-up
 
-- Add a small matrix comparing direct local scripts, local stdio MCP servers,
-  remote MCP servers, and platform-hosted tools.
 - Expand the customer-support case study once the starter code includes a real
   mailbox or Gmail adapter.
 - Add a future starter or case-study note showing how source-aware authority
   enforcement or prompt-injection red-teaming fits into a local-agent workflow.
+- Add a narrow walkthrough for turning indirect prompt-injection findings into
+  repo-native eval checks or contribution-ready issue templates.
 
 ## Update Log
 
+- 2026-05-27: Replaced the older prompt-injection source with current OpenAI
+  and Microsoft guidance, added an authority-boundary matrix, and linked the
+  note to related handbook surfaces.
 - 2026-05-17: Added prompt-injection, sandboxing, trust-boundary, and
   red-teaming guidance to the local-agent source map.
 - 2026-04-24: Refined the note for contributor comprehension with usage

--- a/zh-Hans/contributor-kit/reference-notes/README.md
+++ b/zh-Hans/contributor-kit/reference-notes/README.md
@@ -16,4 +16,4 @@
 - [企业级智能体控制平面](./enterprise-agent-control-planes.mdx): 一份面向贡献者的 note，说明在企业级智能体系统里应区分 managed runtimes 和跨智能体 control planes。
 - [Deep Research Product Signals](./deep-research-product-signals.mdx): 面向贡献者的当前 OpenAI 和 Google deep-research 产品信号对比。
 - [Deep Research Source Map](./deep-research-source-map.mdx)
-- [Local Agent Tooling Source Map](./local-agent-tooling-source-map.mdx): 一份面向贡献者的简报，用于在未来草稿中保持本地运行时、技能、MCP roots、resources、connectors 和基于文件的工作流彼此区分。
+- [Local Agent Tooling Source Map](./local-agent-tooling-source-map.mdx): 一份面向贡献者的简报，用于在未来草稿中保持本地运行时、技能、MCP roots、resources、connectors 和基于文件的工作流彼此区分，同时也把 prompt injection 与本地 authority boundary 保持明确。

--- a/zh-Hans/contributor-kit/reference-notes/index.mdx
+++ b/zh-Hans/contributor-kit/reference-notes/index.mdx
@@ -22,5 +22,4 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 - [企业级智能体控制平面](/zh-Hans/contributor-kit/reference-notes/enterprise-agent-control-planes): 一份面向贡献者的 note，说明在企业级智能体系统里应区分 managed runtimes 和跨智能体 control planes。
 - [Deep Research Product Signals](/zh-Hans/contributor-kit/reference-notes/deep-research-product-signals): 面向贡献者的当前 OpenAI 和 Google deep-research 产品信号对比。
 - [Deep Research Source Map](/zh-Hans/contributor-kit/reference-notes/deep-research-source-map)
-- [Local Agent Tooling Source Map](/zh-Hans/contributor-kit/reference-notes/local-agent-tooling-source-map): 一份面向贡献者的简报，用于在未来草稿中保持本地运行时、技能、MCP roots、resources、connectors 和基于文件的工作流彼此区分。
-  同时也把 prompt injection 信任边界保持明确。
+- [Local Agent Tooling Source Map](/zh-Hans/contributor-kit/reference-notes/local-agent-tooling-source-map): 一份面向贡献者的简报，用于在未来草稿中保持本地运行时、技能、MCP roots、resources、connectors 和基于文件的工作流彼此区分，同时也把 prompt injection 与本地 authority boundary 保持明确。

--- a/zh-Hans/contributor-kit/reference-notes/local-agent-tooling-source-map.mdx
+++ b/zh-Hans/contributor-kit/reference-notes/local-agent-tooling-source-map.mdx
@@ -1,7 +1,7 @@
 ---
 title: 本地智能体工具链来源图谱
 owner: Prompthon IO
-updated: 2026-05-17
+updated: 2026-05-27
 scope: local agent tooling, skills, roots, resources, connectors, and file-grounded workflows
 status: draft
 ---
@@ -56,8 +56,8 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 包括：
 
 - 关于 Responses API 工具、文件搜索、远程 MCP 支持和计算环境的 OpenAI 官方来源材料
-- 关于 prompt injection、沙箱和本地智能体信任边界的 OpenAI、Claude
-  Code 与 MCP 官方安全指引
+- 关于 indirect prompt injection、沙箱、scope minimization 与本地智能体
+  信任边界的 OpenAI、Microsoft、Claude Code 与 MCP 官方安全指引
 - 关于 roots 和 resources 的官方 MCP 材料
 - 关于本地 stdio 服务器、项目/用户作用域以及 MCP resources 的官方 Claude Code 材料
 
@@ -74,8 +74,10 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
   适用于关于托管工具、远程 MCP 支持、文件搜索和长时间运行后台工作的主张。
 - [OpenAI computer environment for agents](https://openai.com/index/equip-responses-api-computer-environment/):
   适用于关于执行环境、持久文件、shell 访问、压缩，以及作为运行时支持的智能体技能的主张。
-- [Designing AI agents to resist prompt injection](https://openai.com/index/designing-agents-to-resist-prompt-injection/):
-  当草稿需要引用 OpenAI 关于 source-sink analysis、用户确认，以及如何限制不可信内容驱动智能体动作的当前 framing 时使用。
+- [Understanding prompt injections](https://openai.com/safety/prompt-injections/):
+  当草稿需要引用 OpenAI 当前对第三方指令、分层防御、沙箱以及智能体动作用户确认的通俗 framing 时使用。
+- [Defend against indirect prompt injection attacks](https://learn.microsoft.com/en-us/security/zero-trust/sfi/defend-indirect-prompt-injection):
+  适用于需要引用当前企业级防御栈时：其中明确列出 prompt shields、spotlighting、plan-drift detection、critic agents、tool-chain analysis、information-flow control 和 least privilege。
 - [MCP introduction](https://modelcontextprotocol.io/docs/getting-started/intro):
   适用于将 MCP 作为 AI 应用与外部系统之间连接层的稳定、高层级说明。
 - [MCP roots](https://modelcontextprotocol.io/specification/2025-06-18/client/roots):
@@ -90,6 +92,10 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
   适用于关于文件系统与网络隔离如何在 prompt injection 成功时限制损害的主张。
 - [MCP security best practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices):
   当草稿需要讨论本地 MCP server compromise、一键配置时的启动命令确认、scope minimization，以及为什么 `stdio` 或受认证传输很重要时使用。
+- [modelcontextprotocol/modelcontextprotocol](https://github.com/modelcontextprotocol/modelcontextprotocol):
+  适合作为高信号的 MCP 实现与规范仓库，用于检查当前 adoption、issue 流向与 security surface 维护情况。
+- [microsoft/BIPIA](https://github.com/microsoft/BIPIA):
+  当草稿需要一个评估 indirect prompt-injection robustness 的具体 benchmark 仓库示例时使用。
 - [promptfoo/promptfoo](https://github.com/promptfoo/promptfoo):
   适合作为针对 agents、tools 与 RAG systems 的 red teaming 与 CI 级 prompt-injection 检查的高信号实现仓库。
 
@@ -117,6 +123,26 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 - 对发送消息、修改工单、向第三方系统迁移数据等后果明确的动作，应把人工确认保留在写路径中。
 - 在称一个本地智能体配置达到 production-ready 之前，应把 prompt injection 和 tool misuse 检查纳入 eval 或 red-team workflow。
 
+## Authority Boundary Matrix
+
+当贡献者把不同本地智能体表面并排比较，而不是都笼统当作“tool access”时，这份来源图谱会更容易落地。
+
+| 表面 | 主要边界问题 | 主要失效模式 | 基线防御 |
+| --- | --- | --- | --- |
+| 直接本地脚本 | 哪个用户或服务账号在执行命令？ | 过宽的 shell authority 会把一条坏指令立刻放大成文件或凭证访问。 | 最小默认权限、显式输入审阅、隔离运行时，以及可审计的输出。 |
+| 本地 `stdio` MCP server | 哪条启动命令和哪些本地目录在作用范围内？ | 看似可信的本地 server 也可能执行不透明的启动命令，或越权读取本地文件。 | 完整启动命令审阅、沙箱、受限文件系统访问，以及窄目录范围。 |
+| 远程 MCP server | 委派了哪些远程 scope、token 和对外动作？ | 过宽 token 或薄弱认证会让不可信内容触发高影响远程动作。 | scope minimization、短时 token、受认证传输、逐动作确认，以及请求日志。 |
+| 平台托管工具 | 模型与动作之间有哪些产品层 guardrails？ | 平台隐藏了传输层，因此 prompt injection 往往会表现成 plan drift 或静默数据越界。 | 分层 prompt-injection 防御、tool-chain analysis、人工确认，以及高风险动作的策略级审查。 |
+
+## 在手册中继续展开的位置
+
+- [参考说明](/zh-Hans/contributor-kit/reference-notes)：在起草长期页面前，先把 source-map 与 contributor briefing 这一层讲清楚。
+- [协议与互操作性](/zh-Hans/systems/protocols-and-interoperability)：当草稿需要 MCP、A2A 与远程边界的对比时使用。
+- [智能体 UI 协议与生成式 UI](/zh-Hans/systems/agent-ui-protocols-and-generative-ui)：当草稿需要把工具权限与 UI 状态分开时使用。
+- [Weather MCP Server Starter](/zh-Hans/systems/examples/weather-mcp-server-starter)：适合作为解释 MCP 边界的仓库内可运行示例表面。
+- [2026 年 4 月助手安全升级观察](/zh-Hans/radar/2026-04-assistant-safety-escalation-watch)：当草稿需要把本地 authority boundary 与人工升级、审计路径联系起来时使用。
+- [GitHub Issue Guide](/zh-Hans/contributor-kit/github-issue-guide)：当这份说明要落成一个范围清晰的贡献提案或 issue claim 时使用。
+
 ## 案例研究切入点
 
 好的本地智能体案例研究应当让边界可见：
@@ -130,12 +156,13 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 ## 缺口与后续工作
 
-- 增加一个小型矩阵，对比直接本地脚本、本地 stdio MCP 服务器、远程 MCP 服务器和平台托管工具。
 - 一旦 starter code 包含真实邮箱或 Gmail 适配器，扩展客户支持案例研究。
 - 增加一个未来的 starter 或案例研究说明，展示 source-aware authority enforcement 或 prompt-injection red teaming 如何嵌入本地智能体工作流。
+- 增加一份狭义 walkthrough，说明如何把 indirect prompt injection 发现转成仓库原生的 eval 检查或可认领的 issue 模板。
 
 ## 更新日志
 
+- 2026-05-27：把较旧的 prompt-injection 来源替换为当前的 OpenAI 与 Microsoft 指引，补上 authority-boundary matrix，并把这份说明连接到相关手册表面。
 - 2026-05-17：为本地智能体来源图谱补充了 prompt injection、沙箱、信任边界和 red-teaming 指引。
 - 2026-04-24：通过使用指导、术语边界和更清晰的来源到主张映射，提升了该说明对贡献者的可理解性。
 - 2026-04-23：新增面向贡献者的本地智能体工具链、skills、roots、resources 和 file-grounded workflows 来源图谱。


### PR DESCRIPTION
## Summary

Release PRs from same-repository `develop` into `main` intentionally aggregate multiple contribution tracks. Skip `prompthon-track-guard` for that release path while keeping normal contributor PR path validation unchanged.

## Verification

- `GITHUB_EVENT_PATH=<tmp release event> GITHUB_REPOSITORY=Prompthon-IO/agent-systems-handbook node .github/scripts/prompthon-track-guard.mjs --dry-run`
- `node --test .github/scripts/prompthon-activity-policy.test.mjs`
- `git diff --check`

## Contribution Type

- repo/process/meta

## Placement

- Target path: `.github/scripts/prompthon-track-guard.mjs`
- Related issue: none

## Summary

Describe the change in 2-5 sentences. Keep the scope concrete.

## Target Branch

- Normal contributor work targets `develop`.
- Release PRs target `main` only when opened by `dprat0821` from same-repository `develop`.
- `main` is the production Mintlify branch and should not receive direct feature PRs.

## Contribution Type

Select the best match and remove the rest.

- lab article
- major revision to existing page
- radar note
- source project
- curated reference note
- repo/process/meta

## Placement

- Target path:
- Links or indexes updated:
- Related issue:

## Source Lineage

List the outside sources, imported references, or existing repo pages that shaped this change.

## Review Checklist

- [ ] The contribution type is explicit.
- [ ] The file or folder is in the correct path for that artifact type.
- [ ] I followed the matching template or contributor guidance where relevant.
- [ ] The change stays repo-native and does not copy upstream material into public tracked paths.
- [ ] Citations, source notes, or attribution boundaries are clear where needed.
- [ ] Relevant README, reading-path, or contributor links were added or updated for discoverability.
- [ ] If I added or revised a practitioner skill package, it includes a human-facing `README.md` and an agent-facing `SKILL.md`.
- [ ] Status and maintenance expectations are clear.
- [ ] The linked issue has the correct `track:*` and `kind:*` labels, and this PR only changes paths allowed for that track.
- [ ] If I changed example code, I ran `python3 scripts/verify_example_projects.py`.
- [ ] If I renamed files or changed paths, I ran `python3 scripts/check_filename_casing.py`.
