### PR TITLE
[gongxiaojing0825] Refresh the coding agents case study with containment boundaries

### DIFF
--- a/case-studies/coding-agents.mdx
+++ b/case-studies/coding-agents.mdx
@@ -1,7 +1,7 @@
 ---
 title: Coding Agents
 owner: Prompthon IO
-updated: 2026-05-03
+updated: 2026-05-31
 depth: intermediate
 region_tags:
   - global
@@ -11,6 +11,14 @@ external_readings:
     url: https://openai.com/index/introducing-codex/
   - title: Codex CLI documentation
     url: https://developers.openai.com/codex/cli
+  - title: How we contain Claude across products
+    url: https://www.anthropic.com/engineering/how-we-contain-claude
+  - title: Understanding prompt injections
+    url: https://openai.com/safety/prompt-injections/
+  - title: Safety in building agents
+    url: https://developers.openai.com/api/docs/guides/agent-builder-safety
+  - title: MCP security best practices
+    url: https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices
   - title: openai/codex repository
     url: https://github.com/openai/codex
 status: draft
@@ -30,6 +38,11 @@ The current product signal is strong enough to treat this as a real agent shape,
 not just autocomplete with a chat box. OpenAI's Codex positioning now spans a
 cloud software-engineering agent plus a local terminal coding agent, which
 makes the workflow legible for both teams and individual builders.
+
+The newer lesson from this week's source window is that coding-agent quality is
+not only about code generation. It is also about containment: where the agent
+can read, what it can execute, which network paths it can reach, and how much
+untrusted content can flow into its context before a user establishes trust.
 
 ## Why It Matters
 
@@ -97,16 +110,46 @@ coding assistants:
 That is why coding agents should be taught as an end-to-end system loop, not as
 just model output quality.
 
+## Containment Boundaries
+
+Recent first-party guidance makes the boundary design more explicit.
+
+- `environment`: use sandboxes, VMs, filesystem boundaries, and egress controls
+  to cap what the agent can reach
+- `model`: use prompts, confirmations, and other safeguards to reduce risky
+  behavior, but do not treat them as a complete defense
+- `external content`: treat repositories, MCP servers, tool output, copied
+  prompts, and fetched pages as untrusted inputs that can carry prompt
+  injections
+
+For coding agents, that means "approval-aware" is not enough on its own.
+Current Anthropic engineering guidance frames containment as the hard cap on
+blast radius across Claude.ai, Claude Code, and Cowork. OpenAI's current safety
+guidance makes the same point from another angle: prompt injection is often
+third-party content entering the agent's context, and the risk can include data
+exfiltration or misaligned tool use. MCP security guidance adds the protocol
+layer lesson that tool and scope grants should stay progressive and
+least-privilege.
+
+The practical takeaway is simple: evaluate a coding agent like a bounded
+runtime, not just a model with shell access.
+
 ## Guardrails
 
 Useful defaults for coding agents:
 
 - start from repository inspection, not instant editing
 - keep the write scope as small as possible
+- keep secrets, host credentials, and unrelated folders outside the visible
+  workspace whenever possible
+- keep network access off by default and elevate it only for the specific task
+  that needs it
 - preserve unrelated working-tree changes
 - require explicit verification before claiming completion
 - keep command output, diffs, and test results visible to the reviewer
 - treat secrets, production credentials, and destructive git commands as separate approvals
+- treat repository content, project-local config, MCP tool output, and fetched
+  web pages as untrusted until the boundary is established
 
 If the environment supports both local and cloud execution, keep the trust
 boundary explicit. Local execution can see the developer's real machine state.
@@ -121,6 +164,9 @@ network policy.
   secrets and workstation risk.
 - Cloud sandboxes isolate runs more cleanly, but they can drift from the exact
   local setup if dependencies or secrets differ.
+- Better models can catch more uncertainty and flawed code, but they do not
+  remove the need for containment when the agent can read untrusted content or
+  call powerful tools.
 - Fast patch generation feels productive, but a slower repo-inspect and verify
   loop usually produces better changes.
 
@@ -132,14 +178,18 @@ Practical default:
 
 ## Current Product Signal
 
-The current seven-day signal for this handbook run was `OpenAI Codex`, drawn
-from stored article coverage and then verified against current first-party docs
-and the public GitHub repository.
+The current seven-day signal for this handbook run was `coding agent
+containment`, refined from stored article coverage around Anthropic's
+containment write-up, Anthropic's Claude Opus 4.8 launch, and a current
+prompt-injection incident aimed at coding workflows.
 
 The reusable lesson is broader than one vendor:
 
 - coding agents are becoming a distinct product category
 - the winning shape is repository-first, verification-heavy, and approval-aware
+- the next differentiation layer is containment: workspace-only writes, scoped
+  network policy, controlled tool grants, and explicit treatment of untrusted
+  content
 - teams should evaluate them as agent systems with memory, tools, policies, and
   review artifacts, not as pure prompt UX
 
@@ -155,6 +205,10 @@ From there, connect this case study to:
   verification and trace loop
 - [Context Engineering](/systems/context-engineering) for instruction, state,
   and retrieval boundaries
+- [Claude Code Desktop Agent Setup](/workshops/desktop-agents/claude-code) for
+  a local coding-agent workflow that makes sandbox and approval choices visible
+- [Local Agent Tooling Source Map](/contributor-kit/reference-notes/local-agent-tooling-source-map)
+  for roots, resources, connectors, and file-grounded boundary design
 - [Case Studies Overview](/case-studies) for adjacent product shapes such as
   deep research and customer support agents
 
@@ -162,17 +216,28 @@ From there, connect this case study to:
 
 - Official source: [Introducing Codex](https://openai.com/index/introducing-codex/)
 - Official source: [Codex CLI documentation](https://developers.openai.com/codex/cli)
+- Official source: [How we contain Claude across products](https://www.anthropic.com/engineering/how-we-contain-claude)
+- Official source: [Understanding prompt injections](https://openai.com/safety/prompt-injections/)
+- Official source: [Safety in building agents](https://developers.openai.com/api/docs/guides/agent-builder-safety)
+- Official source: [MCP security best practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices)
 - High-signal repository: [openai/codex](https://github.com/openai/codex)
+- High-signal repository: [modelcontextprotocol/modelcontextprotocol](https://github.com/modelcontextprotocol/modelcontextprotocol)
+- High-signal repository: [anthropics/claude-code-action](https://github.com/anthropics/claude-code-action)
 
 ## Reading Extensions
 
 - [Codex Desktop Agent Setup](/workshops/desktop-agents/codex)
+- [Claude Code Desktop Agent Setup](/workshops/desktop-agents/claude-code)
 - [Evaluation And Observability](/systems/evaluation-and-observability)
 - [Context Engineering](/systems/context-engineering)
+- [Local Agent Tooling Source Map](/contributor-kit/reference-notes/local-agent-tooling-source-map)
 - [Case Studies Overview](/case-studies)
 
 ## Update Log
 
+- 2026-05-31: Refreshed the case study around coding-agent containment
+  boundaries, prompt-injection risk, and stronger source links across Codex,
+  Claude Code, OpenAI safety guidance, and MCP security guidance.
 - 2026-05-03: Added a repo-native coding-agents case study anchored in the
   current OpenAI Codex signal and linked it to the handbook's existing Codex
   workshop.

--- a/zh-Hans/case-studies/coding-agents.mdx
+++ b/zh-Hans/case-studies/coding-agents.mdx
@@ -1,7 +1,7 @@
 ---
 title: 编码智能体
 owner: Prompthon IO
-updated: 2026-05-03
+updated: 2026-05-31
 depth: intermediate
 region_tags:
   - global
@@ -11,6 +11,14 @@ external_readings:
     url: https://openai.com/index/introducing-codex/
   - title: Codex CLI documentation
     url: https://developers.openai.com/codex/cli
+  - title: How we contain Claude across products
+    url: https://www.anthropic.com/engineering/how-we-contain-claude
+  - title: Understanding prompt injections
+    url: https://openai.com/safety/prompt-injections/
+  - title: Safety in building agents
+    url: https://developers.openai.com/api/docs/guides/agent-builder-safety
+  - title: MCP security best practices
+    url: https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices
   - title: openai/codex repository
     url: https://github.com/openai/codex
 status: draft
@@ -28,6 +36,10 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 当前的产品信号已经足够强，不应再把它视为“带聊天框的补全”。OpenAI 对
 Codex 的当前定位同时覆盖云端软件工程智能体和本地终端编码智能体，这让
 团队和个人构建者都能更清楚地理解这类工作流。
+
+本周来源窗口给出的新经验是：编码智能体的质量不只取决于会不会生成代码，
+还取决于 containment。也就是它能读取哪里、能执行什么、能访问哪些网络路
+径，以及在用户建立信任边界之前，有多少不可信内容会流入它的上下文。
 
 ## 为什么这很重要
 
@@ -93,16 +105,41 @@ OpenAI 当前的 Codex 表面比很多早期编码助手更清楚地暴露了这
 因此，编码智能体更适合被教授为一条端到端系统循环，而不只是模型输出质
 量问题。
 
+## Containment 边界
+
+最近的一手资料把边界设计讲得更清楚了：
+
+- `environment`：用 sandbox、VM、文件系统边界和 egress controls 来限制
+  智能体真正能到达的范围
+- `model`：用 prompts、confirmations 和其他 safeguards 来降低风险行为，
+  但不要把它们当成完整防线
+- `external content`：把仓库、MCP servers、tool output、复制进来的 prompt
+  和抓取到的页面都视为不可信输入，因为它们都可能携带 prompt injection
+
+对编码智能体来说，这意味着仅仅“有审批”还不够。Anthropic 当前的工程文档
+把 containment 定义为 Claude.ai、Claude Code 和 Cowork 三类产品的 blast
+radius 硬边界。OpenAI 当前的安全文档则从另一个角度说明了同一件事：prompt
+injection 往往来自第三方内容进入上下文，结果可能是数据外泄或错位的工具调
+用。MCP 的安全文档补上了协议层经验：工具与 scope 的授予应当逐步提升，并
+保持 least-privilege。
+
+实际结论很直接：评估编码智能体时，应把它看作一个有边界的运行时，而不是
+一个单纯“带 shell 的模型”。
+
 ## Guardrails
 
 对编码智能体来说，有用的默认做法包括：
 
 - 从仓库检查开始，而不是立刻编辑
 - 尽量缩小写入范围
+- 尽量把 secrets、宿主机凭据和无关目录排除在可见 workspace 之外
+- 默认关闭网络访问，只在某个具体任务确实需要时再提升权限
 - 保留无关的 working-tree 改动
 - 在宣称完成前要求显式验证
 - 让命令输出、diff 和测试结果对 reviewer 可见
 - 将 secrets、生产凭据和破坏性 git 命令视为单独审批边界
+- 在边界明确之前，把仓库内容、项目本地配置、MCP tool output 和抓取到的
+  网页都视为不可信输入
 
 如果环境同时支持本地执行和云端执行，就要把信任边界讲清楚。本地执行能看
 到开发者真实机器状态，但也会继承更多 secrets 与工作站风险。云端 sandbox
@@ -114,6 +151,8 @@ OpenAI 当前的 Codex 表面比很多早期编码助手更清楚地暴露了这
 - 本地执行能看到真实仓库和环境，但会继承更多 secrets 与工作站风险。
 - 云端 sandbox 更容易隔离，但如果依赖和 secrets 不一致，也可能偏离真实
   本地设置。
+- 更强的模型能更早暴露不确定性和代码缺陷，但当智能体可以读取不可信内容
+  或调用高权限工具时，它们仍然不能替代 containment。
 - 快速生成 patch 看起来很高效，但更慢一点的 inspect 加 verify 循环通常会
   产生更好的改动。
 
@@ -125,13 +164,17 @@ OpenAI 当前的 Codex 表面比很多早期编码助手更清楚地暴露了这
 
 ## 当前产品信号
 
-本次手册运行的当前七日信号是 `OpenAI Codex`。这个词先来自已存储的文章覆
-盖，然后再用当前的一手文档和公开 GitHub 仓库完成核实。
+本次手册运行的当前七日信号是 `coding agent containment`。这个词是从已存
+储文章中围绕 Anthropic containment 说明、Claude Opus 4.8 发布，以及面向
+编码工作流的 prompt-injection 事件提炼出来的，再用当前的一手文档和公开
+GitHub 仓库完成核实。
 
 可复用的经验比某一家供应商更广：
 
 - 编码智能体正在变成一个独立产品类别
 - 最有效的形态是 repository-first、verification-heavy、approval-aware
+- 下一层差异化在于 containment：workspace-only writes、范围化网络策略、
+  受控的工具授权，以及对不可信内容的显式处理
 - 团队应把它们作为带有 memory、tools、policies 和 review artifacts 的
   智能体系统来评估，而不是把它们当作纯 prompt UX
 
@@ -147,6 +190,10 @@ OpenAI 当前的 Codex 表面比很多早期编码助手更清楚地暴露了这
   证和轨迹循环
 - [上下文工程](/zh-Hans/systems/context-engineering)，理解 instruction、
   state 和 retrieval 边界
+- [Claude Code 桌面智能体设置](/zh-Hans/workshops/desktop-agents/claude-code)，
+  查看一个把 sandbox 与 approval 选择显式化的本地编码智能体工作流
+- [本地智能体工具 Source Map](/zh-Hans/contributor-kit/reference-notes/local-agent-tooling-source-map)，
+  对照 roots、resources、connectors 与 file-grounded 边界设计
 - [案例研究总览](/zh-Hans/case-studies)，对照 deep research 与客户支持
   等其他产品形态
 
@@ -154,16 +201,27 @@ OpenAI 当前的 Codex 表面比很多早期编码助手更清楚地暴露了这
 
 - 官方来源：[Introducing Codex](https://openai.com/index/introducing-codex/)
 - 官方来源：[Codex CLI documentation](https://developers.openai.com/codex/cli)
+- 官方来源：[How we contain Claude across products](https://www.anthropic.com/engineering/how-we-contain-claude)
+- 官方来源：[Understanding prompt injections](https://openai.com/safety/prompt-injections/)
+- 官方来源：[Safety in building agents](https://developers.openai.com/api/docs/guides/agent-builder-safety)
+- 官方来源：[MCP security best practices](https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices)
 - 高信号仓库：[openai/codex](https://github.com/openai/codex)
+- 高信号仓库：[modelcontextprotocol/modelcontextprotocol](https://github.com/modelcontextprotocol/modelcontextprotocol)
+- 高信号仓库：[anthropics/claude-code-action](https://github.com/anthropics/claude-code-action)
 
 ## 延伸阅读
 
 - [Codex 桌面智能体设置](/zh-Hans/workshops/desktop-agents/codex)
+- [Claude Code 桌面智能体设置](/zh-Hans/workshops/desktop-agents/claude-code)
 - [评估与可观测性](/zh-Hans/systems/evaluation-and-observability)
 - [上下文工程](/zh-Hans/systems/context-engineering)
+- [本地智能体工具 Source Map](/zh-Hans/contributor-kit/reference-notes/local-agent-tooling-source-map)
 - [案例研究总览](/zh-Hans/case-studies)
 
 ## 更新日志
 
+- 2026-05-31：围绕编码智能体的 containment 边界、prompt-injection 风险和
+  更强的一手来源链接刷新本案例研究，覆盖 Codex、Claude Code、OpenAI
+  安全文档与 MCP 安全文档。
 - 2026-05-03：新增一个 repo 原生的编码智能体案例研究，用当前 OpenAI
   Codex 信号锚定，并与仓库现有的 Codex 工作坊互相链接。


### PR DESCRIPTION
## Summary
- refresh the bilingual coding-agents case study around containment boundaries
- add current first-party sources for Anthropic containment, OpenAI prompt-injection safety, and MCP security guidance
- strengthen internal links to the Claude Code workshop and local-agent source map

## Verification
- python3 scripts/verify_example_projects.py
- git diff --check