### PR TITLE
[dprat0821] Add June watch for open agent training environments

### DIFF
--- a/radar/2026-06-open-agent-training-environments-watch.mdx
+++ b/radar/2026-06-open-agent-training-environments-watch.mdx
@@ -1,0 +1,119 @@
+---
+title: June 2026 Open Agent Training Environments Watch
+owner: Prompthon IO
+updated: 2026-06-10
+time_scope: 2026-06
+status: draft
+---
+
+import SupportCTA from "/snippets/support-cta.mdx";
+
+<SupportCTA />
+
+## Summary
+
+Hugging Face's June 8, 2026 OpenEnv governance update points to a sharper
+category boundary: open agent training environments are becoming shared
+infrastructure for stateful agent work, not just another reward-tuning library.
+
+For handbook readers, the signal is not simply "agentic RL." It is that coding,
+browsing, and other multi-step agent tasks increasingly need portable
+environments that can be trained, evaluated, and sometimes exposed through the
+same interface layer.
+
+## Why It Matters
+
+Public agent discussion still overweights model releases and harness UX. Once
+an agent acts across turns, another system layer matters just as much: the
+environment that holds state, returns observations, and constrains what the
+agent can do next.
+
+That makes this radar signal useful because it surfaces five reusable
+questions:
+
+- when should a team move from stateless tool calls to a true environment loop
+- how much of the environment should be packaged as reusable infrastructure
+- whether training, evaluation, and production-adjacent execution can share one
+  interface
+- how to keep reward logic separate from the environment protocol itself
+- how open communities might converge on portable environment patterns for
+  browser, coding, and workflow agents
+
+## Evidence And Sources
+
+- [The Open Source Community is backing OpenEnv for Agentic RL](https://huggingface.co/blog/openenv-agentic-rl):
+  Hugging Face's June 8, 2026 announcement says OpenEnv is tightening into an
+  interoperability layer for RL environments, not a reward framework, and says
+  MCP is a first-class citizen so the same environment can behave consistently
+  in simulation and production modes.
+- [OpenEnv: Agentic Execution Environments](https://huggingface.co/docs/openenv/index):
+  the official docs describe OpenEnv as a unified framework for isolated
+  execution environments with Gymnasium-style APIs, container packaging, HTTP
+  deployment, secure isolation, and environment libraries for coding, web
+  browsing, and games.
+- [OpenEnv Integration for Training LLMs with Environments](https://huggingface.co/docs/trl/en/openenv):
+  Hugging Face's TRL docs make the boundary explicit: use tools for stateless
+  calls, and use environments when the task is genuinely multi-turn and future
+  observations depend on prior actions.
+- [huggingface/OpenEnv](https://github.com/huggingface/OpenEnv):
+  the official repository shows active RFCs around baseline APIs,
+  discoverability, MCP support, delayed rewards, and harness integration.
+- [huggingface/openenv-course](https://github.com/huggingface/openenv-course):
+  the course repo shows the category is already being taught as practical
+  builder workflow rather than as a purely research-side abstraction.
+
+## Signals To Watch
+
+- Whether more trainers and harnesses adopt a shared environment protocol
+  instead of bespoke wrappers.
+- Whether MCP-aware environments remain a niche capability or become a common
+  bridge between training, evaluation, and production-facing agent execution.
+- Whether the strongest early use cases stay near coding and browser tasks or
+  expand into customer operations, research, and embodied environments.
+- Whether committee governance keeps the API stable enough for outside
+  environment authors to build on it.
+- Whether future agent comparison work starts discussing the model, harness,
+  environment, and reward loop as four separate layers instead of one blob.
+
+## Design Implications
+
+The durable lesson is not the product name. It is the architectural split that
+contributors should preserve:
+
+1. the harness or client surface the agent uses
+2. the environment that holds state and emits observations
+3. the reward or scoring logic that judges trajectories
+4. the trainer or evaluation loop that improves or compares behavior
+
+For handbook readers, this suggests a cleaner rule:
+
+- use plain tool calling when each action is independent
+- move to an environment layer when actions change what the agent sees next
+- treat packaging, isolation, and reproducibility as first-class parts of the
+  environment choice
+- avoid collapsing environment protocol, reward design, and trainer logic into
+  one vague "agent stack"
+
+## Related Handbook Paths
+
+- [Radar](/radar)
+- [April 2026 Defense Agent Training Loop Watch](/radar/2026-04-defense-agent-training-loop-watch)
+- [Evaluation And Observability](/systems/evaluation-and-observability)
+- [Coding Agents](/case-studies/coding-agents)
+- [Reference Note Guidelines](/contributor-kit/reference-note-guidelines)
+
+## Editorial Take
+
+This belongs in `radar/`, not in evergreen systems guidance yet. The category
+is still early, the APIs are still marked experimental, and the strongest
+examples are still clustered around training and benchmark infrastructure.
+
+The durable takeaway is narrower and more useful: open agent builders are
+trying to standardize the environment layer for stateful agent work, the same
+way other parts of the stack have started standardizing tool or protocol
+boundaries.
+
+## Update Log
+
+- 2026-06-10: Added a June radar note on OpenEnv and the rise of open agent
+  training environments as a distinct systems layer.

--- a/radar/README.md
+++ b/radar/README.md
@@ -19,6 +19,9 @@ without destabilizing the evergreen structure.
 
 ## Current notes
 
+- [June 2026 Open Agent Training Environments Watch](./2026-06-open-agent-training-environments-watch.mdx):
+  a current signal on OpenEnv, stateful execution environments, and the
+  separation between agent harnesses, environments, and reward loops.
 - [June 2026 Agent-First Devices Watch](./2026-06-agent-first-devices-watch.mdx):
   a current signal on Project Solara, agent-native runtimes, just-in-time UI,
   OS-enforced containment, and control-plane governance for local agents.

--- a/radar/index.mdx
+++ b/radar/index.mdx
@@ -25,6 +25,9 @@ without destabilizing the evergreen structure.
 
 ## Current notes
 
+- [June 2026 Open Agent Training Environments Watch](/radar/2026-06-open-agent-training-environments-watch):
+  a current signal on OpenEnv, stateful execution environments, and the
+  separation between agent harnesses, environments, and reward loops.
 - [June 2026 Agent-First Devices Watch](/radar/2026-06-agent-first-devices-watch):
   a current signal on Project Solara, agent-native runtimes, just-in-time UI,
   OS-enforced containment, and control-plane governance for local agents.

--- a/zh-Hans/radar/2026-06-open-agent-training-environments-watch.mdx
+++ b/zh-Hans/radar/2026-06-open-agent-training-environments-watch.mdx
@@ -1,0 +1,84 @@
+---
+title: 2026年6月开放式智能体训练环境观察
+owner: Prompthon IO
+updated: 2026-06-10
+time_scope: 2026-06
+status: draft
+---
+
+import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
+
+<SupportCTA />
+
+## 摘要
+
+Hugging Face 在 2026 年 6 月 8 日对 OpenEnv 的治理更新，指向一个更清晰的类别边界：开放式智能体训练环境正在变成有状态智能体工作的共享基础设施，而不只是另一个 reward-tuning library。
+
+对手册读者来说，信号不只是“agentic RL”。真正值得关注的是：代码、浏览器以及其他多步骤智能体任务，越来越需要一种可移植的环境层，既能用于训练和评估，有时也能通过同一接口层暴露到生产相邻场景。
+
+## 为什么这很重要
+
+公共智能体讨论仍然过度强调模型发布和 harness 体验。但只要智能体要跨多轮行动，另一个系统层就会同样重要：保存状态、返回 observations，并约束下一步动作的 environment。
+
+这条 radar 信号之所以有用，是因为它把五个可复用问题摆到了台前：
+
+- 团队何时应从无状态 tool calling 转向真正的 environment loop
+- 环境里有多少部分应该被打包成可复用基础设施
+- 训练、评估和生产相邻执行是否能共享一个接口
+- 如何把 reward logic 和 environment protocol 本身分开
+- 开放社区是否会围绕浏览器、代码和工作流智能体收敛出可移植的 environment 模式
+
+## 证据与来源
+
+- [The Open Source Community is backing OpenEnv for Agentic RL](https://huggingface.co/blog/openenv-agentic-rl):
+  Hugging Face 在 2026 年 6 月 8 日的公告表示，OpenEnv 正在收紧为 RL environments 的 interoperability layer，而不是 reward framework；同时说明 MCP 是 first-class citizen，因此同一个 environment 可以在 simulation 和 production modes 中保持一致行为。
+- [OpenEnv: Agentic Execution Environments](https://huggingface.co/docs/openenv/index):
+  官方文档将 OpenEnv 描述为一个统一框架，用于构建隔离执行环境，提供 Gymnasium 风格 API、容器打包、HTTP 部署、安全隔离，以及面向 coding、web browsing 和 games 的环境库。
+- [OpenEnv Integration for Training LLMs with Environments](https://huggingface.co/docs/trl/en/openenv):
+  Hugging Face 的 TRL 文档把边界说得很清楚：无状态调用用 tools，而当任务是真正的多轮交互、且未来 observation 依赖先前动作时，就该使用 environments。
+- [huggingface/OpenEnv](https://github.com/huggingface/OpenEnv):
+  官方仓库显示项目正围绕 baseline APIs、discoverability、MCP support、delayed rewards 和 harness integration 维护活跃 RFC。
+- [huggingface/openenv-course](https://github.com/huggingface/openenv-course):
+  课程仓库说明这个类别已经被当作实践型 builder workflow 来教学，而不只是纯研究抽象。
+
+## 需要关注的信号
+
+- 是否会有更多 trainer 和 harness 采用共享的 environment protocol，而不是各自维护定制包装层。
+- 具备 MCP 感知能力的 environments 是会停留在小众能力，还是会成为连接训练、评估和生产型智能体执行的常见桥梁。
+- 最强的早期用例会继续集中在 coding 和 browser tasks，还是会扩展到 customer operations、research 和 embodied environments。
+- 技术委员会治理是否能让 API 足够稳定，进而吸引外部 environment 作者参与。
+- 未来的智能体比较工作是否会开始把 model、harness、environment 和 reward loop 当作四个独立层，而不是一个模糊的整体。
+
+## 设计启发
+
+真正持久的经验不是产品名，而是贡献者应保留的架构拆分：
+
+1. 智能体使用的 harness 或 client surface
+2. 保存状态并发出 observations 的 environment
+3. 评判轨迹的 reward 或 scoring logic
+4. 用来改进或比较行为的 trainer 或 evaluation loop
+
+对手册读者来说，这提示出一条更清晰的规则：
+
+- 当每个动作彼此独立时，使用普通 tool calling
+- 当动作会改变智能体下一步看到的内容时，转向 environment layer
+- 把 packaging、isolation 和 reproducibility 视为 environment 选择的一等因素
+- 不要把 environment protocol、reward design 和 trainer logic 混成一个模糊的“agent stack”
+
+## 相关手册路径
+
+- [雷达](/zh-Hans/radar)
+- [2026 年 4 月防务智能体训练循环观察](/zh-Hans/radar/2026-04-defense-agent-training-loop-watch)
+- [评估与可观测性](/zh-Hans/systems/evaluation-and-observability)
+- [Coding Agents](/zh-Hans/case-studies/coding-agents)
+- [参考笔记指南](/zh-Hans/contributor-kit/reference-note-guidelines)
+
+## 编辑判断
+
+这个主题目前应放在 `radar/`，而不是直接写入常青系统指导。类别仍然很早，API 仍被标记为 experimental，最强的案例也还集中在训练和 benchmark 基础设施。
+
+更持久、也更有用的结论是：开放式智能体构建者正在尝试为有状态智能体工作标准化 environment layer，就像栈的其他部分已经开始标准化 tool 或 protocol boundaries 一样。
+
+## 更新日志
+
+- 2026-06-10：新增一条 6 月 radar 笔记，关注 OpenEnv 以及开放式智能体训练环境如何成为独立系统层。

--- a/zh-Hans/radar/README.md
+++ b/zh-Hans/radar/README.md
@@ -16,6 +16,8 @@
 
 ## 当前笔记
 
+- [2026 年 6 月开放式智能体训练环境观察](./2026-06-open-agent-training-environments-watch.mdx):
+  一则当前信号，聚焦 OpenEnv、有状态执行环境，以及 agent harness、environment 和 reward loop 之间的分层。
 - [2026 年 6 月 Agent-First 设备观察](./2026-06-agent-first-devices-watch.mdx):
   一则当前信号，聚焦 Project Solara、agent-native runtimes、just-in-time UI、
   操作系统强制约束，以及面向本地智能体的控制平面治理。

--- a/zh-Hans/radar/index.mdx
+++ b/zh-Hans/radar/index.mdx
@@ -22,6 +22,8 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 ## 当前笔记
 
+- [2026 年 6 月开放式智能体训练环境观察](/zh-Hans/radar/2026-06-open-agent-training-environments-watch):
+  一则当前信号，聚焦 OpenEnv、有状态执行环境，以及 agent harness、environment 和 reward loop 之间的分层。
 - [2026 年 6 月 Agent-First 设备观察](/zh-Hans/radar/2026-06-agent-first-devices-watch):
   一则当前信号，聚焦 Project Solara、agent-native runtimes、just-in-time UI、
   操作系统强制约束，以及面向本地智能体的控制平面治理。


### PR DESCRIPTION
## Summary
- add a new June 2026 radar note for open agent training environments
- map OpenEnv to the handbook's environment-layer framing in English and Chinese
- surface the note from the radar README and index pages

## Verification
- python3 scripts/verify_example_projects.py
- git diff --check

## Primary sources
- https://huggingface.co/blog/openenv-agentic-rl
- https://huggingface.co/docs/openenv/index
- https://huggingface.co/docs/trl/en/openenv
- https://github.com/huggingface/OpenEnv
- https://github.com/huggingface/openenv-course
