### PR TITLE
[jiafenglu0623] Add Claude regulated-industry delivery signal

### DIFF
--- a/contributor-kit/reference-notes/enterprise-agent-control-planes.mdx
+++ b/contributor-kit/reference-notes/enterprise-agent-control-planes.mdx
@@ -1,8 +1,8 @@
 ---
 title: Enterprise Agent Control Planes
 owner: Prompthon IO
-updated: 2026-05-03
-scope: current managed-runtime and control-plane framing for enterprise agents through May 2026
+updated: 2026-06-14
+scope: current managed-runtime, partner-delivery, and control-plane framing for enterprise agents through June 2026
 status: draft
 ---
 
@@ -19,8 +19,10 @@ control plane across them.
 The immediate triggers are Microsoft's April 28, 2026 framing around
 `Intelligence + Trust`, where Microsoft IQ carries business context and Agent
 365 carries observability, governance, and security across both Microsoft's own
-agent surfaces and third-party environments, and AWS's April 28, 2026 launch
-framing for Bedrock Managed Agents and AgentCore.
+agent surfaces and third-party environments, AWS's April 28, 2026 launch
+framing for Bedrock Managed Agents and AgentCore, and Anthropic's June 2026
+Claude Partner Network signals around TCS and DXC bringing Claude into
+regulated and mission-critical enterprise systems.
 
 ## Why It Matters
 
@@ -28,6 +30,7 @@ Agent-platform comparisons often collapse into model access, orchestration UX,
 or framework ergonomics. That misses two different buying questions:
 
 - how much of the runtime should stay managed for the team
+- who operates the deployment surface inside regulated industries
 - how does an organization observe, govern, and secure a growing set of agents
   that span multiple runtimes and vendors?
 
@@ -35,6 +38,9 @@ This note helps contributors keep two layers separate:
 
 - the managed-runtime layer that handles inference, memory, execution, and
   runtime security for one agent workload
+- the partner-delivery layer where consultancies, systems integrators, and
+  forward-deployed engineers adapt agent systems to industry-specific
+  controls, legacy estates, and compliance requirements
 - the control-plane layer that enforces trust, visibility, and policy across
   many agents and environments
 
@@ -55,6 +61,8 @@ Included:
 - Agent 365 as the observability, governance, and security layer
 - AWS's launch framing for Bedrock Managed Agents
 - AgentCore as the underlying open platform beneath the managed runtime
+- Anthropic's Claude Partner Network framing for TCS and DXC deployments in
+  regulated industries
 - implications for later ecosystem and systems refreshes in this repo
 
 Excluded:
@@ -94,10 +102,25 @@ Excluded:
   the official Microsoft framework repo gives contributors a useful contrast
   point between an open framework surface and Microsoft's separate Agent 365
   control-plane positioning.
+- [TCS and Anthropic partner to bring Claude to regulated industries](https://www.anthropic.com/news/tcs-anthropic-partnership):
+  Anthropic says TCS will use Claude internally, build Claude-powered products
+  for clients in financial services, healthcare, public services, aviation,
+  telecom, medical technology, and other regulated industries, and create
+  reusable Claude Code skills and plugins for domains such as claims
+  adjudication and lending advisory.
+- [DXC will integrate Claude into the systems banks, airlines, and other regulated industries rely on](https://www.anthropic.com/news/dxc-anthropic-alliance):
+  Anthropic frames DXC as a forward-deployed engineering partner that will
+  bring Claude into long-running customer systems for banks, airlines,
+  insurers, manufacturers, and government agencies, with DXC OASIS and its
+  agentic workflows as an internal proof point.
+- [Anthropic invests $100 million into the Claude Partner Network](https://www.anthropic.com/news/claude-partner-network):
+  the network page positions partners as the delivery and adoption layer that
+  helps enterprises navigate deployment requirements, compliance, change
+  management, training, certification, and production rollout.
 
 ## Synthesis
 
-Four contributor-facing takeaways matter most:
+Five contributor-facing takeaways matter most:
 
 - Enterprise agent discussion is shifting beyond model choice. AWS is pushing a
   managed-runtime story, while Microsoft is pushing a control-plane story.
@@ -108,9 +131,13 @@ Four contributor-facing takeaways matter most:
   Agents packages inference, memory, execution, and auditability inside a
   hosted environment before the question becomes "which framework should we
   write?"
+- Partner delivery is becoming its own enterprise-agent layer. Anthropic's TCS
+  and DXC announcements are less about a new model interface and more about
+  who carries Claude into regulated business processes, legacy systems,
+  reusable skills, certification, and ongoing operation.
 - A useful lab comparison axis is emerging: open framework, managed runtime,
-  and control plane. That split can sharpen both systems pages and ecosystem
-  pages without hard-coding one vendor's naming.
+  partner delivery, and control plane. That split can sharpen both systems
+  pages and ecosystem pages without hard-coding one vendor's naming.
 
 For the handbook, the durable lesson is not the vendor label. It is the
 category boundary that contributors should preserve when comparing agent
@@ -131,12 +158,18 @@ platforms and enterprise deployment stories.
 - Revisit [Agent Platforms And Low-Code Builders](/ecosystem/agent-platforms-and-low-code-builders)
   if more official sources begin using managed runtime versus control plane as a
   stable comparison frame.
+- Revisit ecosystem pages if partner networks, certifications, and
+  forward-deployed engineering practices become durable comparison criteria for
+  enterprise agent platforms.
 - Add future sources when other first-party platforms describe comparable
   managed-runtime or fleet-governance surfaces explicitly enough to compare
   without guesswork.
 
 ## Update Log
 
+- 2026-06-14: Added Anthropic's TCS, DXC, and Claude Partner Network signals
+  so contributors can compare partner-delivery layers alongside managed
+  runtimes and control planes for regulated enterprise agent deployments.
 - 2026-05-03: Expanded the note with AWS Bedrock Managed Agents and AgentCore
   so contributors can separate open frameworks, managed runtimes, and control
   planes.

--- a/contributor-kit/reference-notes/index.mdx
+++ b/contributor-kit/reference-notes/index.mdx
@@ -24,8 +24,8 @@ material and they are not replacements for lab pages.
   a product-agnostic education workshop planning note on shared AI language,
   teacher-led implementation, peer learning, and practical roadmaps.
 - [Enterprise Agent Control Planes](/contributor-kit/reference-notes/enterprise-agent-control-planes):
-  a contributor-facing note on treating observability, governance, and security
-  as a separate enterprise control-plane layer for agent systems.
+  a contributor-facing note on separating managed runtime, partner delivery,
+  observability, governance, and security layers for enterprise agent systems.
 - [Deep Research Product Signals](/contributor-kit/reference-notes/deep-research-product-signals): a
   contributor-facing comparison of current OpenAI and Google deep-research
   product signals.

--- a/zh-Hans/contributor-kit/reference-notes/enterprise-agent-control-planes.mdx
+++ b/zh-Hans/contributor-kit/reference-notes/enterprise-agent-control-planes.mdx
@@ -1,8 +1,8 @@
 ---
 title: 企业级智能体控制平面
 owner: Prompthon IO
-updated: 2026-05-03
-scope: current managed-runtime and control-plane framing for enterprise agents through May 2026
+updated: 2026-06-14
+scope: current managed-runtime, partner-delivery, and control-plane framing for enterprise agents through June 2026
 status: draft
 ---
 
@@ -14,18 +14,20 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 这份 note 为贡献者提供一个紧凑的 source map，用来比较企业级智能体的两个相关维度：围绕智能体的 managed runtime，以及横跨智能体的 control plane。
 
-直接触发点包括 Microsoft 在 2026 年 4 月 28 日围绕 `Intelligence + Trust` 的 framing：Microsoft IQ 承载业务上下文，Agent 365 承载覆盖 Microsoft 自家智能体表面和第三方环境的 observability、governance 与 security；以及 AWS 在 2026 年 4 月 28 日围绕 Bedrock Managed Agents 和 AgentCore 的发布 framing。
+直接触发点包括 Microsoft 在 2026 年 4 月 28 日围绕 `Intelligence + Trust` 的 framing：Microsoft IQ 承载业务上下文，Agent 365 承载覆盖 Microsoft 自家智能体表面和第三方环境的 observability、governance 与 security；AWS 在 2026 年 4 月 28 日围绕 Bedrock Managed Agents 和 AgentCore 的发布 framing；以及 Anthropic 在 2026 年 6 月围绕 Claude Partner Network、TCS 与 DXC 的信号，即把 Claude 带入受监管行业和关键企业系统。
 
 ## 为什么这很重要
 
 智能体平台比较很容易被压缩成模型访问、编排体验或框架人体工学。但这会漏掉两个不同的采购问题：
 
 - 团队应把多少运行时留给托管层负责
+- 谁在受监管行业中运营部署表面
 - 当组织中的智能体横跨多个运行时和供应商时，如何观察、治理和保护这一组不断增长的智能体
 
 这份 note 帮助贡献者把两个层次分开：
 
 - managed-runtime layer：为单个智能体工作负载处理推理、记忆、执行和运行时安全
+- partner-delivery layer：由咨询公司、系统集成商和 forward-deployed engineers 将 agent systems 适配到行业控制、遗留系统和合规要求中
 - control-plane layer：在多个智能体和环境之间执行 trust、visibility 和 policy
 
 它也帮助保留第三个边界：
@@ -43,6 +45,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 - Agent 365 作为 observability、governance 和 security layer
 - AWS 关于 Bedrock Managed Agents 的发布 framing
 - AgentCore 作为 managed runtime 底下的开放平台
+- Anthropic 关于 TCS 和 DXC 在受监管行业中部署 Claude 的 Claude Partner Network framing
 - 对本仓库后续 ecosystem 和 systems 刷新的启发
 
 不包含：
@@ -65,15 +68,22 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
   AWS 官方 sample repo 说明 AgentCore 不只是营销标签；它已经有覆盖 hosted runtimes、gateways、memory、observability、browser tooling 和 evaluation 的实质代码表面。
 - [microsoft/agent-framework](https://github.com/microsoft/agent-framework):
   Microsoft 官方 framework repo 为贡献者提供一个有用对照点：open framework surface 与 Microsoft 单独的 Agent 365 control-plane positioning 是分开的。
+- [TCS and Anthropic partner to bring Claude to regulated industries](https://www.anthropic.com/news/tcs-anthropic-partnership):
+  Anthropic 表示，TCS 会在内部使用 Claude，为金融服务、医疗保健、公共服务、航空、电信、医疗技术和其他受监管行业的客户构建 Claude-powered products，并为 claims adjudication 和 lending advisory 等领域创建可复用的 Claude Code skills 和 plugins。
+- [DXC will integrate Claude into the systems banks, airlines, and other regulated industries rely on](https://www.anthropic.com/news/dxc-anthropic-alliance):
+  Anthropic 将 DXC 描述为 forward-deployed engineering partner，会把 Claude 带入银行、航空公司、保险公司、制造商和政府机构长期依赖的客户系统，并把 DXC OASIS 及其中的 agentic workflows 作为内部 proof point。
+- [Anthropic invests $100 million into the Claude Partner Network](https://www.anthropic.com/news/claude-partner-network):
+  该网络页将 partners 定位为 delivery 和 adoption layer，帮助企业处理 deployment requirements、compliance、change management、training、certification 和 production rollout。
 
 ## 综合判断
 
-对贡献者来说，最重要的是四个结论：
+对贡献者来说，最重要的是五个结论：
 
 - 企业级智能体讨论正在超出模型选择本身。AWS 推出 managed-runtime 叙事，而 Microsoft 推出 control-plane 叙事。
 - Trust 正被定位成跨环境基础设施，而不只是某一个 assistant 或某一个 runtime 的属性。这意味着贡献者应区分本地运行时能力和 fleet-level governance。
 - Managed runtime 正在成为独立的比较层。Bedrock Managed Agents 在团队开始追问“我们该写哪个 framework？”之前，就把推理、记忆、执行和可审计性打包进 hosted environment。
-- 一个有用的 lab 比较轴正在出现：open framework、managed runtime 和 control plane。这个拆分可以同时强化 systems 页面和 ecosystem 页面，而不必硬编码某个供应商自己的命名。
+- Partner delivery 正在成为自己的企业级智能体层。Anthropic 关于 TCS 和 DXC 的公告不只是新的模型接口，而是说明谁把 Claude 带入受监管业务流程、遗留系统、可复用 skills、认证和持续运营。
+- 一个有用的 lab 比较轴正在出现：open framework、managed runtime、partner delivery 和 control plane。这个拆分可以同时强化 systems 页面和 ecosystem 页面，而不必硬编码某个供应商自己的命名。
 
 对于 handbook，真正持久的经验不是厂商标签，而是贡献者在比较 agent platform 和企业部署叙事时应保留的类别边界。
 
@@ -88,9 +98,11 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 - 未来可以刷新 [Systems: Evaluation and Observability](/zh-Hans/systems/evaluation-and-observability)，加入一小段区分 runtime instrumentation、organization-level control plane 和 managed-runtime defaults。
 - 如果更多官方来源开始把 managed runtime 与 control plane 当作稳定比较框架，可以再刷新 [Agent Platforms And Low-Code Builders](/zh-Hans/ecosystem/agent-platforms-and-low-code-builders)。
+- 如果 partner networks、certifications 和 forward-deployed engineering practices 成为企业级智能体平台的持久比较标准，可以再刷新 ecosystem 页面。
 - 当其他第一方平台足够明确地描述相近的 managed-runtime 或 fleet-governance surface 时，再补入后续来源，避免靠猜测做比较。
 
 ## 更新日志
 
+- 2026-06-14：加入 Anthropic 关于 TCS、DXC 和 Claude Partner Network 的信号，让贡献者可以在受监管企业级智能体部署中，把 partner-delivery layer 与 managed runtimes 和 control planes 一起比较。
 - 2026-05-03：加入 AWS Bedrock Managed Agents 和 AgentCore，让贡献者可以区分 open frameworks、managed runtimes 和 control planes。
 - 2026-04-29：新增一份面向贡献者的企业级智能体控制平面 note，以 Microsoft 的 `Intelligence + Trust` framing 作为当前 source spine。

--- a/zh-Hans/contributor-kit/reference-notes/index.mdx
+++ b/zh-Hans/contributor-kit/reference-notes/index.mdx
@@ -19,7 +19,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 ## 当前说明
 
-- [企业级智能体控制平面](/zh-Hans/contributor-kit/reference-notes/enterprise-agent-control-planes): 一份面向贡献者的 note，说明在企业级智能体系统里应区分 managed runtimes 和跨智能体 control planes。
+- [企业级智能体控制平面](/zh-Hans/contributor-kit/reference-notes/enterprise-agent-control-planes): 一份面向贡献者的 note，说明在企业级智能体系统里应区分 managed runtimes、partner delivery 和跨智能体 control planes。
 - [Deep Research Product Signals](/zh-Hans/contributor-kit/reference-notes/deep-research-product-signals): 面向贡献者的当前 OpenAI 和 Google deep-research 产品信号对比。
 - [Deep Research Source Map](/zh-Hans/contributor-kit/reference-notes/deep-research-source-map)
 - [Local Agent Tooling Source Map](/zh-Hans/contributor-kit/reference-notes/local-agent-tooling-source-map): 一份面向贡献者的简报，用于在未来草稿中保持本地运行时、技能、MCP roots、resources、connectors 和基于文件的工作流彼此区分，同时也把 prompt injection 与本地 authority boundary 保持明确。


### PR DESCRIPTION
## Summary
- add Anthropic TCS, DXC, and Claude Partner Network signals to the enterprise agent control-plane reference note
- introduce partner delivery as a separate enterprise-agent comparison layer beside managed runtime and control plane
- mirror the update in Simplified Chinese and refresh reference-note index blurbs

## Verification
- python3 scripts/verify_example_projects.py
- git diff --check

## Sources
- https://www.anthropic.com/news/tcs-anthropic-partnership
- https://www.anthropic.com/news/dxc-anthropic-alliance
- https://www.anthropic.com/news/claude-partner-network