### PR TITLE
[gongxiaojing0825] Refresh prompt-cache starter for runtime cost controls

### DIFF
--- a/patterns/examples/prompt-cache-agent-starter/SOURCE_NOTES.md
+++ b/patterns/examples/prompt-cache-agent-starter/SOURCE_NOTES.md
@@ -5,22 +5,31 @@ copying implementation code or long-form text.
 
 ## First-Party References
 
+- Anthropic Agent SDK cost tracking:
+  https://code.claude.com/docs/en/agent-sdk/cost-tracking
+- Anthropic Usage and Cost API:
+  https://platform.claude.com/docs/en/manage-claude/usage-cost-api
 - Anthropic prompt caching:
   https://platform.claude.com/docs/en/build-with-claude/prompt-caching
 - Anthropic pricing:
   https://platform.claude.com/docs/en/about-claude/pricing
+- OpenAI prompt caching:
+  https://developers.openai.com/api/docs/guides/prompt-caching
+- OpenAI current model guidance:
+  https://developers.openai.com/api/docs/guides/latest-model
 
 These sources inform the concepts of cache writes, cache reads, stable prompt
-prefixes, and provider pricing columns. The starter keeps pricing values as
-caller-supplied inputs because provider prices can change.
+prefixes, prompt-cache routing keys, authoritative usage reporting, and
+provider pricing columns. The starter keeps pricing values as caller-supplied
+inputs because provider prices and billing rules can change.
 
-## Community Signal
+## Current Trend Signal
 
-- Community prompt-cache harness discussion:
-  https://www.reddit.com/r/artificial/comments/1syw5al/87_cost_savings_sub3s_latency_i_built_a_warmcache/
+- Seven-day stored article signal for this handbook refresh:
+  https://arstechnica.com/ai/2026/06/anthropic-pauses-token-based-billing-for-its-claude-agent-sdk/
 
-The Reddit post was used only as the issue's topic signal. No code, examples,
-or prose from that post are copied into this starter.
+This article was used only as the topic signal for the refresh. Current claims
+in the handbook-facing page come from the first-party docs above.
 
 ## Attribution Boundary
 

--- a/patterns/examples/prompt-cache-agent-starter/index.mdx
+++ b/patterns/examples/prompt-cache-agent-starter/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Prompt Cache Agent Starter"
+description: "A runnable starter for agent runtime cost controls, prompt caching boundaries, and cold-versus-warm usage checks."
 ---
 
 import SupportCTA from "/snippets/support-cta.mdx";
@@ -8,9 +9,9 @@ import SupportCTA from "/snippets/support-cta.mdx";
 
 ## Summary
 
-This starter shows a small prompt-cache-aware agent loop: stable prompt layers
-first, dynamic memory later, and a tiny benchmark surface for comparing cold
-and warm run metadata.
+This starter shows a small prompt-cache-aware agent loop for agent runtime cost
+controls: stable prompt layers first, dynamic memory later, and a tiny
+benchmark surface for comparing cold and warm run metadata.
 
 ## Status
 
@@ -30,11 +31,32 @@ instructions, and stable reference context as cacheable layers, while durable
 memory summaries and current tasks stay outside the cached prefix unless the
 builder intentionally promotes them.
 
+## Agent Runtime Cost Controls
+
+Recent agent SDK changes are a reminder that provider billing rules and pricing
+tables can move faster than a handbook page. The durable lesson is to keep the
+runtime cost boundary inspectable:
+
+- treat tools, system instructions, and shared reference context as the stable
+  prefix
+- move user-specific memory, current-turn tasks, and volatile tool outputs
+  later in the request
+- track cache writes and cache reads separately so a warm rerun is verifiably
+  cheaper instead of only shorter
+- compare SDK-side estimates with provider-side usage reporting before turning
+  token math into budgets or customer billing
+
+This starter stays provider-agnostic, but current Anthropic and OpenAI docs now
+reinforce the same pattern: stable prefixes improve cache reuse, runtime usage
+fields reveal whether cache hits actually happened, and explicit cost controls
+belong in the operator loop instead of guesswork.
+
 ## Related Lab Pages
 
 - [Agent Memory And Retrieval](/patterns/agent-memory-and-retrieval)
 - [Agent Runtime Building Blocks](/patterns/agent-runtime-building-blocks)
 - [Patterns Overview](/patterns)
+- [Contribution Workflow](/contributor-kit/contribution-workflow)
 
 ## Folder Structure
 
@@ -65,6 +87,12 @@ The starter may:
 - calculate where the stable prefix ends
 - compare cache-read and cache-write shares
 - estimate input cost when current pricing values are supplied
+
+When you map it to a real runtime, preserve three separate checks:
+
+- a stop condition or budget control before the loop runs too far
+- cache-specific usage fields that show whether repeated prefixes were reused
+- an authoritative usage export or admin API outside local estimates
 
 The starter must not:
 

--- a/patterns/index.mdx
+++ b/patterns/index.mdx
@@ -45,4 +45,5 @@ They should stay useful even as individual frameworks rise or fall.
   inputs, citations, and durable artifacts.
 - [Prompt Cache Agent Starter](/patterns/examples/prompt-cache-agent-starter):
   a small code sketch for keeping stable prompt prefixes separate from dynamic
-  memory and current-turn inputs.
+  memory and current-turn inputs so agent runtime cost controls stay
+  inspectable.

--- a/zh-Hans/patterns/examples/prompt-cache-agent-starter/index.mdx
+++ b/zh-Hans/patterns/examples/prompt-cache-agent-starter/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Prompt Cache Agent Starter"
+description: "一个可运行的 starter，用于讲清 agent runtime cost controls、提示词缓存边界，以及冷启动与热启动使用量检查。"
 ---
 
 import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
@@ -8,9 +9,9 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 ## 摘要
 
-这个 starter 展示一个很小的、感知提示词缓存边界的智能体循环：
-先放稳定提示词层，再放动态记忆，并用一个小型 benchmark 表面比较
-冷启动和热启动运行元数据。
+这个 starter 展示一个很小的、围绕 agent runtime cost controls 组织的
+提示词缓存感知型智能体循环：先放稳定提示词层，再放动态记忆，并用
+一个小型 benchmark 表面比较冷启动和热启动运行元数据。
 
 ## 状态
 
@@ -28,11 +29,30 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 参考上下文视为可缓存层，而把持久化记忆摘要和当前任务放在缓存
 前缀之外，除非构建者有意提升它们。
 
+## Agent Runtime Cost Controls
+
+最近的 agent SDK 变化再次说明，提供方的计费规则和价格表可能比一页
+handbook 更新得更快。更持久的经验是把运行时成本边界保持为可检查的
+对象：
+
+- 把工具、系统指令和共享参考上下文视为稳定前缀
+- 把用户特定记忆、当前回合任务和易变工具输出放到请求后段
+- 分开跟踪 cache write 和 cache read，这样 warm rerun 是否真的更便宜
+  就可以被验证，而不只是更短
+- 在把 token 计算变成预算或客户计费之前，把 SDK 侧估算与提供方侧的
+  使用量报告分开比较
+
+这个 starter 仍然保持提供方无关，但 Anthropic 和 OpenAI 当前文档现在
+都在强化同一个模式：稳定前缀会提高缓存复用率，运行时使用量字段会揭示
+缓存命中是否真的发生，而显式成本控制应该放在 operator loop 中，而不是
+靠猜测。
+
 ## 相关实验室页面
 
 - [Agent Memory And Retrieval](/zh-Hans/patterns/agent-memory-and-retrieval)
 - [Agent Runtime Building Blocks](/zh-Hans/patterns/agent-runtime-building-blocks)
 - [Patterns Overview](/zh-Hans/patterns)
+- [Contribution Workflow](/zh-Hans/contributor-kit/contribution-workflow)
 
 ## 文件结构
 
@@ -63,6 +83,12 @@ prompt-cache-agent-starter/
 - 计算稳定前缀在哪里结束
 - 比较缓存读取和缓存写入占比
 - 在提供当前价格值时估算输入成本
+
+当你把它映射到真实运行时里时，请保留三类分开的检查：
+
+- 一个在循环跑太远之前就生效的 stop condition 或 budget control
+- 能显示重复前缀是否真的被复用的 cache-specific 使用量字段
+- 一个独立于本地估算之外的 authoritative usage export 或 admin API
 
 这个 starter 不应：
 

--- a/zh-Hans/patterns/index.mdx
+++ b/zh-Hans/patterns/index.mdx
@@ -41,5 +41,5 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 - [Agent Memory Retrieval Starter](/zh-Hans/patterns/examples/agent-memory-retrieval-starter):
   一个用于分离活动笔记、可验证 RAG 检索输入、citations 和持久化工件的小型代码示意。
 - [Prompt Cache Agent Starter](/zh-Hans/patterns/examples/prompt-cache-agent-starter):
-  一个用于把稳定提示词前缀与动态记忆、当前回合输入分开的
-  小型代码示意。
+  一个用于把稳定提示词前缀与动态记忆、当前回合输入分开，
+  让 agent runtime cost controls 保持可检查的小型代码示意。


### PR DESCRIPTION
### Summary

- refresh the `prompt-cache-agent-starter` around `agent runtime cost controls`
- add a handbook-facing section on stable prefixes, cache-specific usage fields, and authoritative billing checks
- mirror the same structure and meaning in `zh-Hans/` and tighten the `patterns` index blurb
- update the starter source notes to point at current Anthropic and OpenAI cost-tracking and prompt-caching docs

### Sources

- https://code.claude.com/docs/en/agent-sdk/cost-tracking
- https://platform.claude.com/docs/en/manage-claude/usage-cost-api
- https://platform.claude.com/docs/en/build-with-claude/prompt-caching
- https://platform.claude.com/docs/en/about-claude/pricing
- https://developers.openai.com/api/docs/guides/prompt-caching
- https://developers.openai.com/api/docs/guides/latest-model
- https://github.com/anthropics/claude-agent-sdk-typescript
- https://github.com/anthropics/claude-agent-sdk-python
- https://github.com/openai/openai-cookbook
