### PR TITLE
[jiafenglu0623] Refresh local agent tooling note for agentic resource discovery

### DIFF
--- a/contributor-kit/reference-notes/README.md
+++ b/contributor-kit/reference-notes/README.md
@@ -26,9 +26,9 @@ material and they are not replacements for lab pages.
 - [Deep Research Source Map](./deep-research-source-map.mdx)
 - [Local Agent Tooling Source Map](./local-agent-tooling-source-map.mdx): a
   contributor briefing for keeping local execution boundaries, runtimes,
-  skills, MCP roots, resources, connectors, and file-grounded workflows
-  distinct in future drafts while adding prompt-injection and local
-  authority-boundary guidance.
+  skills, discovery registries, MCP roots, resources, connectors, and
+  file-grounded workflows distinct in future drafts while adding
+  prompt-injection and local authority-boundary guidance.
 - [Open Agent Environments](./open-agent-environments.mdx): a contributor note
   on separating environment contracts, harnesses, trainers, and MCP-native
   execution surfaces in agentic RL work.

--- a/contributor-kit/reference-notes/index.mdx
+++ b/contributor-kit/reference-notes/index.mdx
@@ -32,8 +32,9 @@ material and they are not replacements for lab pages.
 - [Deep Research Source Map](/contributor-kit/reference-notes/deep-research-source-map)
 - [Local Agent Tooling Source Map](/contributor-kit/reference-notes/local-agent-tooling-source-map): a
   contributor briefing for keeping local execution boundaries, runtimes,
-  skills, MCP roots, resources, connectors, prompt-injection trust
-  boundaries, and file-grounded workflows distinct in future drafts.
+  skills, discovery registries, MCP roots, resources, connectors,
+  prompt-injection trust boundaries, and file-grounded workflows distinct in
+  future drafts.
 - [Open Agent Environments](/contributor-kit/reference-notes/open-agent-environments):
   a contributor note on separating environment contracts, harnesses, trainers,
   and MCP-native execution surfaces in agentic RL work.

--- a/contributor-kit/reference-notes/local-agent-tooling-source-map.mdx
+++ b/contributor-kit/reference-notes/local-agent-tooling-source-map.mdx
@@ -1,8 +1,8 @@
 ---
 title: Local Agent Tooling Source Map
 owner: Prompthon IO
-updated: 2026-06-06
-scope: local agent tooling, execution boundaries, skills, roots, resources, connectors, and file-grounded workflows
+updated: 2026-06-21
+scope: local agent tooling, agentic resource discovery, execution boundaries, skills, roots, resources, connectors, and file-grounded workflows
 status: draft
 ---
 
@@ -19,6 +19,7 @@ workflow instructions rather than operating only as a remote chat surface.
 Use it when a draft needs to explain what "local" actually means. The durable
 pattern is not the location of one model. It is the combination of:
 
+- a discovery path for finding relevant capabilities
 - an execution environment or local tool boundary
 - reusable skill or workflow packaging
 - explicit filesystem or document scope
@@ -29,6 +30,7 @@ pattern is not the location of one model. It is the combination of:
 
 This is a source map, not a full article. Future contributors should use it to:
 
+- decide whether the draft is about discovery, connection, or execution
 - define the boundary before describing the agent
 - choose the right source for the claim they are making
 - keep local files, selected resources, skills, and connectors separate
@@ -39,6 +41,7 @@ This is a source map, not a full article. Future contributors should use it to:
 Local-agent topics are becoming easy to overstate. A useful handbook treatment
 should separate several concerns that are often mixed together:
 
+- `discovery`: how an agent finds a relevant capability at runtime
 - `runtime`: where commands, scripts, files, or containers run
 - `skills`: how reusable task knowledge is packaged
 - `roots`: which local filesystem areas a tool-facing server may see
@@ -51,6 +54,7 @@ pretending that every integration is the same kind of agent capability.
 
 | Term | Reader question | Common mistake |
 | --- | --- | --- |
+| `discovery` | How does the agent find a new capability? | Treating search or registry results as permission to use the tool |
 | `runtime` | Where does the work execute? | Treating all agent work as a chat reply |
 | `skills` | What reusable task knowledge is packaged? | Hiding stale instructions inside one long prompt |
 | `roots` | Which filesystem boundaries are in scope? | Saying "file access" without naming the boundary |
@@ -61,6 +65,7 @@ pretending that every integration is the same kind of agent capability.
 
 Included:
 
+- official ARD material on catalogs, registries, and trust metadata
 - official OpenAI source material on Responses API tools, file search, remote
   MCP support, and computer environments
 - current OpenAI documentation for approval-gated connectors and remote MCP
@@ -82,6 +87,17 @@ Excluded:
 
 ## Source Map
 
+- [Hugging Face: Agentic Resource Discovery - Let agents search](https://huggingface.co/blog/agentic-resource-discovery-launch):
+  use this for the current discovery-layer framing, why install-first agent
+  wiring does not scale, and how registries let agents search for relevant
+  capabilities at runtime.
+- [Google Developers: Announcing the Agentic Resource Discovery specification](https://developers.googleblog.com/announcing-the-agentic-resource-discovery-specification/):
+  use this for the cleanest explanation of catalogs, registries, trust
+  metadata, and the handoff from discovery into a capability's native
+  protocol.
+- [Microsoft: Introducing the Agentic Resource Discovery specification](https://commandline.microsoft.com/agentic-resource-discovery-specification-ard/):
+  use this when the draft needs a practical problem statement for why manual
+  capability wiring breaks down as more agentic resources are published.
 - [OpenAI Responses API tools and remote MCP support](https://openai.com/index/new-tools-and-features-in-the-responses-api/):
   use this for claims about hosted tools, remote MCP support, file search, and
   long-running background work.
@@ -131,16 +147,23 @@ Excluded:
 - [promptfoo/promptfoo](https://github.com/promptfoo/promptfoo):
   use this as a high-signal implementation repo for red-teaming and CI-level
   prompt-injection checks around agents, tools, and RAG systems.
+- [ards-project/ard-spec](https://github.com/ards-project/ard-spec):
+  use this as the canonical draft specification repo for ARD schemas,
+  conformance artifacts, and trust-model wording.
+- [huggingface/hf-discover](https://github.com/huggingface/hf-discover):
+  use this as a concrete ARD client/server implementation that searches
+  skills, spaces, and MCP servers.
 
 ## Synthesis
 
 The strongest local-agent spine is a layered one:
 
 1. The user or host application chooses an operating boundary.
-2. Tools and servers expose capabilities inside that boundary.
-3. Resources and roots describe which context can be read or selected.
-4. Skills package repeatable task knowledge.
-5. The agent produces an artifact or action that can be reviewed.
+2. Discovery surfaces help the agent find relevant capabilities.
+3. Tools and servers expose capabilities inside that boundary.
+4. Resources and roots describe which context can be read or selected.
+5. Skills package repeatable task knowledge.
+6. The agent produces an artifact or action that can be reviewed.
 
 For handbook purposes, this is more useful than saying "the agent has access to
 files." Local access should always be explained with the boundary attached:
@@ -152,10 +175,16 @@ agent how to perform a task, but it should not be treated as current evidence.
 A connector can expose a useful system, but it should not imply permission to
 read or act on every object in that system.
 
+Agentic resource discovery adds one more boundary that contributors should name
+explicitly. Discovery answers "what exists?" It does not answer "what is
+allowed here?" Catalog or registry results still need approval, pinning,
+auth, and scope review before an agent should connect or execute.
+
 The June 2026 refresh is a useful reminder that the stable handbook term is
-not just "local agent tooling." It is `local agent execution boundaries`:
-where the work runs, which approvals exist, which roots or resources are in
-scope, and what review surface remains after the action completes.
+not just "local agent tooling." It is `local agent discovery and execution
+boundaries`: where the work runs, how new capabilities are found, which
+approvals exist, which roots or resources are in scope, and what review
+surface remains after the action completes.
 
 ## Production-Readiness Note
 
@@ -188,6 +217,7 @@ surfaces side by side instead of treating them all as "tool access."
 | Direct local script | As a process on the user's machine | repo path, shell command, and explicit read/write scope | Broad shell authority turns one bad instruction into immediate file or credential access. | Minimal default privileges, explicit input review, isolated runtime, and auditable outputs. |
 | Local `stdio` MCP server | As a local process started by the client | startup-command review, project scope, `CLAUDE_PROJECT_DIR`, and `roots/list` | A trusted-looking local server can execute opaque startup commands or overreach into local files. | Exact startup-command review, sandboxing, restricted filesystem access, and narrow directory scope. |
 | Remote MCP server or connector | On a remote service | `server_url`, allowed tools, auth scope, and approval requirements | Over-broad tokens or weak auth let untrusted content trigger high-impact remote actions. | Scope minimization, short-lived tokens, authenticated transport, per-action confirmation, and request logging. |
+| ARD-style discovery registry | As a searchable catalog or federated registry service | catalog provenance, trust metadata, registry URL, and pinning rules | Discovery results can look trustworthy enough to skip real scope review, or can route an agent toward the wrong capability class. | Verify publisher identity, pin chosen capabilities, keep discovery separate from execution approval, and log which registry result was selected. |
 | Hosted computer environment | Inside a provider-managed container workspace | isolated filesystem, restricted network access, and explicit tool outputs | The platform hides the transport, so prompt injection can surface as plan drift or silent data overreach, or the runtime can drift from the developer's local machine. | Layered prompt-injection defenses, tool-chain analysis, human confirmation, and policy-level review of high-risk actions. |
 
 ## Where To Deepen This In The Handbook
@@ -195,7 +225,8 @@ surfaces side by side instead of treating them all as "tool access."
 - [Reference Notes](/contributor-kit/reference-notes): keep the source-map and
   contributor-briefing layer clear before drafting durable handbook pages.
 - [Protocols and Interoperability](/systems/protocols-and-interoperability):
-  use this when the draft needs the MCP, A2A, and remote-boundary comparison.
+  use this when the draft needs the MCP, A2A, ARD, and remote-boundary
+  comparison.
 - [Agent Runtime Building Blocks](/patterns/agent-runtime-building-blocks):
   use this when the draft needs a reusable breakdown of execution, memory,
   interface, and action layers inside an agent system.
@@ -220,6 +251,8 @@ Good local-agent case studies should make the boundary visible:
 - customer-support email agent: inbound message path plus local policy
   document path
 - coding agent: repository root plus issue, test, and branch permissions
+- registry-backed coding agent: ARD or catalog search result plus a pinned
+  remote MCP or skill decision before execution
 - operations agent: dashboard or database resource plus read-only query rules
 - research agent: source folder plus citation artifact output
 
@@ -237,6 +270,9 @@ requires human review.
 
 ## Update Log
 
+- 2026-06-21: Added agentic resource discovery sources, clarified discovery
+  versus connection boundaries, and extended the execution-boundary matrix to
+  include ARD-style registries.
 - 2026-06-06: Added current OpenAI MCP/connectors guidance and refreshed the
   matrix around explicit local-versus-hosted execution boundaries.
 - 2026-05-27: Replaced older prompt-injection sources with current OpenAI and

--- a/zh-Hans/contributor-kit/reference-notes/README.md
+++ b/zh-Hans/contributor-kit/reference-notes/README.md
@@ -16,5 +16,5 @@
 - [企业级智能体控制平面](./enterprise-agent-control-planes.mdx): 一份面向贡献者的 note，说明在企业级智能体系统里应区分 managed runtimes 和跨智能体 control planes。
 - [Deep Research Product Signals](./deep-research-product-signals.mdx): 面向贡献者的当前 OpenAI 和 Google deep-research 产品信号对比。
 - [Deep Research Source Map](./deep-research-source-map.mdx)
-- [Local Agent Tooling Source Map](./local-agent-tooling-source-map.mdx): 一份面向贡献者的简报，用于在未来草稿中保持本地执行边界、运行时、技能、MCP roots、resources、connectors 和基于文件的工作流彼此区分，同时也把 prompt injection 与本地 authority boundary 保持明确。
+- [Local Agent Tooling Source Map](./local-agent-tooling-source-map.mdx): 一份面向贡献者的简报，用于在未来草稿中保持本地执行边界、运行时、技能、discovery registries、MCP roots、resources、connectors 和基于文件的工作流彼此区分，同时也把 prompt injection 与本地 authority boundary 保持明确。
 - [开放式智能体环境](./open-agent-environments.mdx): 一份面向贡献者的说明，用于区分 agentic RL 中的环境契约、harness、trainer 与 MCP-native 执行表面。

--- a/zh-Hans/contributor-kit/reference-notes/index.mdx
+++ b/zh-Hans/contributor-kit/reference-notes/index.mdx
@@ -22,5 +22,5 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 - [企业级智能体控制平面](/zh-Hans/contributor-kit/reference-notes/enterprise-agent-control-planes): 一份面向贡献者的 note，说明在企业级智能体系统里应区分 managed runtimes、partner delivery 和跨智能体 control planes。
 - [Deep Research Product Signals](/zh-Hans/contributor-kit/reference-notes/deep-research-product-signals): 面向贡献者的当前 OpenAI 和 Google deep-research 产品信号对比。
 - [Deep Research Source Map](/zh-Hans/contributor-kit/reference-notes/deep-research-source-map)
-- [Local Agent Tooling Source Map](/zh-Hans/contributor-kit/reference-notes/local-agent-tooling-source-map): 一份面向贡献者的简报，用于在未来草稿中保持本地执行边界、运行时、技能、MCP roots、resources、connectors 和基于文件的工作流彼此区分，同时也把 prompt injection 与本地 authority boundary 保持明确。
+- [Local Agent Tooling Source Map](/zh-Hans/contributor-kit/reference-notes/local-agent-tooling-source-map): 一份面向贡献者的简报，用于在未来草稿中保持本地执行边界、运行时、技能、discovery registries、MCP roots、resources、connectors 和基于文件的工作流彼此区分，同时也把 prompt injection 与本地 authority boundary 保持明确。
 - [开放式智能体环境](/zh-Hans/contributor-kit/reference-notes/open-agent-environments): 一份面向贡献者的说明，用于区分 agentic RL 中的环境契约、harness、trainer 与 MCP-native 执行表面。

--- a/zh-Hans/contributor-kit/reference-notes/local-agent-tooling-source-map.mdx
+++ b/zh-Hans/contributor-kit/reference-notes/local-agent-tooling-source-map.mdx
@@ -1,8 +1,8 @@
 ---
 title: 本地智能体工具链来源图谱
 owner: Prompthon IO
-updated: 2026-06-06
-scope: local agent tooling, execution boundaries, skills, roots, resources, connectors, and file-grounded workflows
+updated: 2026-06-21
+scope: local agent tooling, agentic resource discovery, execution boundaries, skills, roots, resources, connectors, and file-grounded workflows
 status: draft
 ---
 
@@ -16,6 +16,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 当草稿需要解释“本地”究竟意味着什么时，可以使用它。真正持久的模式不是某个模型所在的位置，而是以下要素的组合：
 
+- 用于寻找相关能力的 discovery 路径
 - 执行环境或本地工具边界
 - 可复用的技能或工作流打包
 - 明确的文件系统或文档作用范围
@@ -26,6 +27,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 这是一张来源图谱，不是一篇完整文章。后续贡献者应使用它来：
 
+- 先判断草稿讨论的是 discovery、connection 还是 execution
 - 在描述智能体之前先定义边界
 - 为所做的主张选择合适的来源
 - 将本地文件、所选资源、技能和连接器区分开来
@@ -35,6 +37,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 本地智能体相关话题很容易被夸大。一本有用的手册应当区分几个经常混在一起的关注点：
 
+- `discovery`: 智能体如何在运行时找到相关能力？
 - `runtime`: 工作在哪里执行？
 - `skills`: 可复用的任务知识如何打包？
 - `roots`: 工具面向的服务器可以看到哪些本地文件系统区域？
@@ -45,6 +48,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 | 术语 | 读者问题 | 常见错误 |
 | --- | --- | --- |
+| `discovery` | 智能体如何找到新的能力？ | 把搜索或 registry 结果直接当作使用该工具的权限 |
 | `runtime` | 工作在哪里执行？ | 把所有智能体工作都当作聊天回复 |
 | `skills` | 可复用的任务知识如何打包？ | 把过时指令藏在一个很长的提示词里 |
 | `roots` | 哪些文件系统边界在作用范围内？ | 不说明边界，只说“文件访问” |
@@ -55,6 +59,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 包括：
 
+- 关于 catalogs、registries 和 trust metadata 的官方 ARD 材料
 - 关于 Responses API 工具、文件搜索、远程 MCP 支持和计算环境的 OpenAI 官方来源材料
 - 关于需要审批的 connectors 与远程 MCP servers 的当前 OpenAI 官方文档
 - 关于 indirect prompt injection、沙箱、scope minimization 与本地智能体信任边界的 OpenAI、Microsoft、Claude Code 与 MCP 官方安全指引
@@ -70,6 +75,15 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 ## 来源图谱
 
+- [Hugging Face: Agentic Resource Discovery - Let agents search](https://huggingface.co/blog/agentic-resource-discovery-launch):
+  适用于说明当前 discovery layer 的 framing、为什么 install-first 的
+  agent wiring 无法扩展，以及 registry 如何让智能体在运行时搜索相关能力。
+- [Google Developers: Announcing the Agentic Resource Discovery specification](https://developers.googleblog.com/announcing-the-agentic-resource-discovery-specification/):
+  适用于解释 catalogs、registries、trust metadata，以及 discovery
+  如何把能力交回其原生协议。
+- [Microsoft: Introducing the Agentic Resource Discovery specification](https://commandline.microsoft.com/agentic-resource-discovery-specification-ard/):
+  当草稿需要一个清晰的问题陈述，说明为什么随着 agentic resources
+  增多，手工 wiring 会失效时使用。
 - [OpenAI Responses API tools and remote MCP support](https://openai.com/index/new-tools-and-features-in-the-responses-api/):
   适用于关于托管工具、远程 MCP 支持、文件搜索和长时间运行后台工作的主张。
 - [OpenAI MCP and Connectors guide](https://developers.openai.com/api/docs/guides/tools-connectors-mcp):
@@ -100,22 +114,31 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
   当草稿需要一个评估 indirect prompt-injection robustness 的具体 benchmark 仓库示例时使用。
 - [promptfoo/promptfoo](https://github.com/promptfoo/promptfoo):
   适合作为针对 agents、tools 与 RAG systems 的 red teaming 与 CI 级 prompt-injection 检查的高信号实现仓库。
+- [ards-project/ard-spec](https://github.com/ards-project/ard-spec):
+  适合作为 ARD 的标准草案仓库，用于查看 schemas、conformance artifacts
+  与 trust-model 表述。
+- [huggingface/hf-discover](https://github.com/huggingface/hf-discover):
+  适合作为具体的 ARD client/server 实现，用于搜索 skills、spaces 与
+  MCP servers。
 
 ## 综合归纳
 
 最强的本地智能体主干是分层的：
 
 1. 用户或宿主应用选择一个运行边界。
-2. 工具和服务器在该边界内暴露能力。
-3. resources 和 roots 描述哪些上下文可以被读取或选择。
-4. skills 打包可重复的任务知识。
-5. 智能体生成可供审阅的产物或动作。
+2. discovery 表面帮助智能体找到相关能力。
+3. 工具和服务器在该边界内暴露能力。
+4. resources 和 roots 描述哪些上下文可以被读取或选择。
+5. skills 打包可重复的任务知识。
+6. 智能体生成可供审阅的产物或动作。
 
 就手册而言，这比简单说“智能体可以访问文件”更有用。本地访问应始终附带边界来说明：哪些文件、哪个服务器、哪种传输、哪些权限，以及什么产物。
 
 同样的原则也适用于 skills 和 connectors。skill 可以告诉智能体如何执行某项任务，但不应被当作最新证据。connector 可以暴露一个有用的系统，但不应暗示有权读取或操作该系统中的所有对象。
 
-这次 2026 年 6 月的刷新也提醒我们，一个更稳定的手册术语并不只是 “local agent tooling”，而是 `local agent execution boundaries`：工作在哪里运行、有哪些审批、哪些 roots 或 resources 在作用范围内，以及动作完成后还留下了什么可审阅的表面。
+agentic resource discovery 又补上了一个贡献者需要单独命名的边界。discovery 回答的是“有什么可用？”，并不回答“这里允许做什么？”。catalog 或 registry 的结果仍然需要经过 approval、pinning、auth 与 scope review，智能体才应连接或执行。
+
+这次 2026 年 6 月的刷新也提醒我们，一个更稳定的手册术语并不只是 “local agent tooling”，而是 `local agent discovery and execution boundaries`：工作在哪里运行、如何发现新能力、有哪些审批、哪些 roots 或 resources 在作用范围内，以及动作完成后还留下了什么可审阅的表面。
 
 ## 生产就绪提示
 
@@ -136,12 +159,13 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 | 直接本地脚本 | 作为用户机器上的进程运行 | 仓库路径、shell 命令和显式读写范围 | 过宽的 shell authority 会把一条坏指令立刻放大成文件或凭证访问。 | 最小默认权限、显式输入审阅、隔离运行时，以及可审计的输出。 |
 | 本地 `stdio` MCP server | 作为由客户端启动的本地进程运行 | 启动命令审阅、project scope、`CLAUDE_PROJECT_DIR` 和 `roots/list` | 看似可信的本地 server 也可能执行不透明的启动命令，或越权读取本地文件。 | 完整启动命令审阅、沙箱、受限文件系统访问，以及窄目录范围。 |
 | 远程 MCP server 或 connector | 运行在远程服务上 | `server_url`、allowed tools、auth scope 和 approval requirements | 过宽 token 或薄弱认证会让不可信内容触发高影响远程动作。 | scope minimization、短时 token、受认证传输、逐动作确认，以及请求日志。 |
+| ARD 风格 discovery registry | 运行在可搜索的 catalog 或 federated registry 服务上 | catalog provenance、trust metadata、registry URL 和 pinning rules | discovery 结果看起来足够可信，容易让人跳过真正的 scope review，或把智能体路由到错误的能力类型。 | 校验 publisher identity、pin 住选中的 capability、把 discovery 与 execution approval 分离，并记录选用了哪个 registry 结果。 |
 | 托管计算环境 | 运行在 provider 托管的容器工作区里 | 隔离文件系统、受限网络访问和显式工具输出 | 平台隐藏了传输层，因此 prompt injection 往往会表现成 plan drift、静默数据越界，或让运行时逐渐偏离开发者的本地机器。 | 分层 prompt-injection 防御、tool-chain analysis、人工确认，以及高风险动作的策略级审查。 |
 
 ## 在手册中继续展开的位置
 
 - [参考说明](/zh-Hans/contributor-kit/reference-notes)：在起草长期页面前，先把 source-map 与 contributor briefing 这一层讲清楚。
-- [协议与互操作性](/zh-Hans/systems/protocols-and-interoperability)：当草稿需要 MCP、A2A 与远程边界的对比时使用。
+- [协议与互操作性](/zh-Hans/systems/protocols-and-interoperability)：当草稿需要 MCP、A2A、ARD 与远程边界的对比时使用。
 - [Agent Runtime Building Blocks](/zh-Hans/patterns/agent-runtime-building-blocks)：当草稿需要一个关于 execution、memory、interface 与 action layers 的可复用拆解时使用。
 - [智能体 UI 协议与生成式 UI](/zh-Hans/systems/agent-ui-protocols-and-generative-ui)：当草稿需要把工具权限与 UI 状态分开时使用。
 - [Weather MCP Server Starter](/zh-Hans/systems/examples/weather-mcp-server-starter)：适合作为解释 MCP 边界的仓库内可运行示例表面。
@@ -155,6 +179,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 - 客户支持邮件智能体：传入消息路径 + 本地政策文档路径
 - 编码智能体：仓库根目录 + issue、测试和分支权限
+- 基于 registry 的编码智能体：ARD 或 catalog 搜索结果 + 在执行前对远程 MCP 或 skill 的 pinning 决策
 - 运维智能体：仪表盘或数据库资源 + 只读查询规则
 - 研究智能体：来源文件夹 + 引用产物输出
 
@@ -168,6 +193,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 ## 更新日志
 
+- 2026-06-21：加入 agentic resource discovery 来源，明确 discovery 与 connection 的边界，并把执行边界矩阵扩展到 ARD 风格 registry。
 - 2026-06-06：加入当前 OpenAI MCP/connectors 指引，并围绕显式的本地与托管执行边界刷新矩阵。
 - 2026-05-27：把较旧的 prompt-injection 来源替换为当前的 OpenAI 与 Microsoft 指引，补上 authority-boundary matrix，并把这份说明连接到相关手册表面。
 - 2026-05-17：为本地智能体来源图谱补充了 prompt injection、沙箱、信任边界和 red-teaming 指引。


### PR DESCRIPTION
## Summary
- refresh the local agent tooling reference note around agentic resource discovery, catalogs, registries, and trust metadata
- add current primary-source links for ARD, MCP/OpenAI guidance, and concrete implementation repos
- mirror the same discovery-versus-connection framing in the zh-Hans note and reference indexes

## Verification
- python3 scripts/verify_example_projects.py
- git diff --check