### PR TITLE
[generalkim00] Refresh platform comparison for Gemini Interactions API

### DIFF
--- a/contributor-kit/reference-notes/README.md
+++ b/contributor-kit/reference-notes/README.md
@@ -21,8 +21,9 @@ material and they are not replacements for lab pages.
   contributor-facing note on separating managed runtimes from cross-agent
   control planes in enterprise agent systems.
 - [Deep Research Product Signals](./deep-research-product-signals.mdx): a
-  contributor-facing comparison of current OpenAI and Google deep-research
-  product signals.
+  contributor-facing comparison of current OpenAI deep-research positioning and
+  Google's Interactions-API-based developer surface for long-running research
+  agents.
 - [Deep Research Source Map](./deep-research-source-map.mdx)
 - [Local Agent Tooling Source Map](./local-agent-tooling-source-map.mdx): a
   contributor briefing for keeping local execution boundaries, runtimes,

--- a/contributor-kit/reference-notes/deep-research-product-signals.mdx
+++ b/contributor-kit/reference-notes/deep-research-product-signals.mdx
@@ -1,8 +1,8 @@
 ---
 title: Deep Research Product Signals
 owner: Prompthon IO
-updated: 2026-04-23
-scope: current deep research product signals through April 2026
+updated: 2026-06-24
+scope: current deep research and Gemini Interactions API signals through June 2026
 status: draft
 ---
 
@@ -30,7 +30,8 @@ Included:
 
 - OpenAI's current deep research positioning in ChatGPT
 - Google's developer API framing for Gemini Deep Research
-- Google's April 2026 Deep Research Max update
+- Google's June 2026 Interactions API general-availability shift
+- current Google ADK and A2A bridge signals for Interactions-based agents
 
 Excluded:
 
@@ -47,40 +48,76 @@ Excluded:
 - [Build with Gemini Deep Research](https://blog.google/innovation-and-ai/technology/developers-tools/deep-research-agent-gemini-api/):
   Google exposes Gemini Deep Research through the Interactions API and frames it
   as an embeddable agent for long-running context gathering and synthesis.
-- [Introducing Deep Research and Deep Research Max](https://blog.google/innovation-and-ai/models-and-research/gemini-models/next-generation-gemini-deep-research/):
-  Google positions the April 21, 2026 release around MCP support, native
-  visualizations, and better performance on long-horizon research workflows.
+- [Interactions API: our primary interface for Gemini models and agents](https://blog.google/innovation-and-ai/technology/developers-tools/interactions-api-general-availability/):
+  Google says the Interactions API reached general availability on June 22,
+  2026 and now serves as the primary interface for Gemini models and agents.
+- [Gemini API docs](https://ai.google.dev/gemini-api/docs) and
+  [Interactions overview](https://ai.google.dev/gemini-api/docs/interactions-overview):
+  the current docs recommend the Interactions API for new projects and frame
+  server-side state, background execution, and resumable interaction flows as
+  the default developer surface.
+- [Building agents with the ADK and the new Interactions API](https://developers.googleblog.com/building-agents-with-the-adk-and-the-new-interactions-api/)
+  plus the [Gemini Enterprise Agent Platform ADK guide](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/adk):
+  Google now connects the Interactions API to ADK-managed tools, A2A bridges,
+  and enterprise deployment paths instead of treating deep research as an
+  isolated product leaf.
 
 ## Synthesis
 
-Three stable signals stand out across these sources:
+Four stable signals stand out across these sources:
 
 - Deep research is being framed as work product, not just chat. OpenAI
   describes analyst-level reports built from many sources, while Google frames
   Deep Research as a long-running synthesis agent.
 - The product boundary is moving beyond public web search. OpenAI added MCP and
   app connections plus trusted-site restrictions in the February 10, 2026
-  update. Google's April 2026 update adds MCP support for custom and
-  professional data sources.
-- Deep research is splitting into both end-user and developer surfaces. OpenAI
-  centers ChatGPT usage, while Google now exposes the shape directly through the
-  Interactions API for embedded product use.
+  update. Google keeps pushing the same direction through connected data,
+  managed tools, and long-running interaction state.
+- Google is no longer only saying "Gemini Deep Research exists." The stronger
+  June 2026 signal is that Interactions API is now the primary interface for
+  Gemini models and agents, with Deep Research becoming one concrete surface on
+  top of that wider runtime model.
+- Developer-facing agent systems are absorbing more of the product shape.
+  Server-side state, resumable background work, tool execution, and A2A bridges
+  now show up in the same interface family that previously looked like a single
+  research-agent feature.
 
 This means the lab should treat deep research as a broader product category
-with shared traits such as planning, evidence gathering, traceability, and
-artifact quality rather than as one isolated feature from one vendor.
+with shared traits such as planning, evidence gathering, traceability,
+artifact quality, and long-running interaction state rather than as one
+isolated feature from one vendor.
+
+## Contributor Implications
+
+- Extend [Deep Research Agents](/case-studies/deep-research-agents) with a
+  short section that distinguishes end-user deep-research products from the
+  developer-facing runtime surfaces that now expose the same agent shape.
+- Cross-link future updates with [Agent Frameworks](/ecosystem/agent-frameworks),
+  [Protocols And Interoperability](/systems/protocols-and-interoperability),
+  and the
+  [Deep Research Agent Starter](/case-studies/examples/deep-research-agent-starter)
+  so the note points to durable implementation surfaces instead of remaining a
+  pure market snapshot.
+- Route future curation through the
+  [Reference Notes hub](/contributor-kit/reference-notes) and the
+  [Contributor reading path](/reading-paths/contributor) so product-signal
+  refreshes stay attached to repo-native drafting rules.
 
 ## Gaps And Follow-up
 
 - Expand [Deep Research Agents](/case-studies/deep-research-agents)
-  with a short product-signals section so the case study acknowledges current
-  market movement.
+  with a short product-signals section on Gemini Interactions API as a default
+  developer surface for long-running research agents.
 - Add a follow-up note focused on evaluation and trust boundaries for
-  long-running research agents.
+  long-running research agents that mix built-in agents with framework-owned
+  outer loops.
 - Revisit whether a starter project should support trusted-source constraints or
-  MCP-connected private data in a future iteration.
+  server-side interaction state alongside MCP-connected private data in a future
+  iteration.
 
 ## Update Log
 
+- 2026-06-24: Refreshed the note around Google's Interactions API general
+  availability and its new role as a primary Gemini agent interface.
 - 2026-04-23: Added a contributor-facing product-signals note based on current
   OpenAI and Google sources.

--- a/contributor-kit/reference-notes/index.mdx
+++ b/contributor-kit/reference-notes/index.mdx
@@ -27,8 +27,9 @@ material and they are not replacements for lab pages.
   a contributor-facing note on separating managed runtime, partner delivery,
   observability, governance, and security layers for enterprise agent systems.
 - [Deep Research Product Signals](/contributor-kit/reference-notes/deep-research-product-signals): a
-  contributor-facing comparison of current OpenAI and Google deep-research
-  product signals.
+  contributor-facing comparison of current OpenAI deep-research positioning and
+  Google's Interactions-API-based developer surface for long-running research
+  agents.
 - [Deep Research Source Map](/contributor-kit/reference-notes/deep-research-source-map)
 - [Local Agent Tooling Source Map](/contributor-kit/reference-notes/local-agent-tooling-source-map): a
   contributor briefing for keeping local execution boundaries, runtimes,

--- a/ecosystem/agent-platforms-and-low-code-builders.mdx
+++ b/ecosystem/agent-platforms-and-low-code-builders.mdx
@@ -1,7 +1,7 @@
 ---
 title: Agent Platforms And Low-Code Builders
 owner: Prompthon IO
-updated: 2026-05-01
+updated: 2026-06-24
 depth: intermediate
 region_tags:
   - global
@@ -14,6 +14,12 @@ external_readings:
     url: https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/agent-builder
   - title: Choose between Microsoft 365 Copilot and Copilot Studio to build your agent
     url: https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/copilot-studio-experience
+  - title: Interactions API: our primary interface for Gemini models and agents
+    url: https://blog.google/innovation-and-ai/technology/developers-tools/interactions-api-general-availability/
+  - title: Interactions API | Gemini API
+    url: https://ai.google.dev/gemini-api/docs/interactions-overview
+  - title: Introducing Managed Agents in the Gemini API
+    url: https://blog.google/innovation-and-ai/technology/developers-tools/managed-agents-gemini-api/
   - title: Amazon Bedrock Managed Agents, powered by OpenAI
     url: https://aws.amazon.com/bedrock/managed-agents-openai/
   - title: Automate tasks in your application using AI agents - Amazon Bedrock
@@ -30,10 +36,10 @@ import SupportCTA from "/snippets/support-cta.mdx";
 ## Summary
 
 Low-code agent platforms turn recurring application patterns into visual,
-configuration-first, workspace-native, or cloud-managed building blocks. In
-2026, the comparison surface includes not only standalone builder products but
-also agent builders that live inside existing productivity suites and managed
-cloud runtimes.
+configuration-first, workspace-native, API-first managed, or cloud-managed
+building blocks. In 2026, the comparison surface includes not only standalone
+builder products but also agent builders that live inside existing productivity
+suites and managed cloud runtimes.
 
 ## Why It Matters
 
@@ -42,11 +48,11 @@ need to validate a product surface, connect common services, or let
 non-engineer stakeholders participate in building the workflow.
 
 That is where builder-first, platform-first, automation-first,
-workspace-native, and cloud-managed surfaces become attractive.
+workspace-native, and managed-runtime surfaces become attractive.
 
 ## Mental Model
 
-The current platform market points to seven useful anchors:
+The current platform market points to eight useful anchors:
 
 - `Coze`: builder-first experience for quick assembly, plugins, and publishing
 - `Dify`: application platform for orchestration, plugins, knowledge, and
@@ -59,6 +65,9 @@ The current platform market points to seven useful anchors:
   declarative scenarios
 - `Copilot Studio`: broader Microsoft platform for larger audiences, custom
   integrations, and more advanced control
+- `Gemini Managed Agents`: an agent-first API surface where Google hosts the
+  sandbox, state, and long-running execution while builders still author
+  instructions and skills
 - `Bedrock Managed Agents`: AWS-managed agent runtime for OpenAI-powered agents
   that need cloud governance, service proximity, and managed operations
 
@@ -66,7 +75,8 @@ These are different choices, not direct substitutes.
 
 - builder-first products optimize fast creation and operator friendliness
 - workspace-native builders optimize shared agents inside an existing suite
-- cloud-managed builders optimize enterprise runtime ownership and governance
+- cloud-managed and API-first managed surfaces optimize enterprise runtime
+  ownership and governance
 - application platforms optimize broader product and deployment control
 - automation platforms optimize integration into existing business processes
 
@@ -81,6 +91,7 @@ flowchart LR
   Choice --> App["Application platform"]
   Choice --> Automation["Automation-first"]
   Workspace --> OpenAI["Workspace agents / Agent Builder"]
+  Managed --> Gemini["Gemini Managed Agents"]
   Managed --> Bedrock["Bedrock Managed Agents"]
   Builder --> Coze["Coze-style"]
   App --> Dify["Dify / Copilot Studio style"]
@@ -100,6 +111,12 @@ flowchart LR
 - Copilot Studio matters when the audience is larger, the workflow is more
   complex, or the agent needs custom integrations and stronger deployment
   management than Agent Builder is designed to provide.
+- Gemini Managed Agents and the Interactions API point to an API-first managed
+  surface: one interface for model calls, Deep Research, and custom managed
+  agents with server-side state, background execution, and hosted Linux
+  sandboxes. This sits between a framework and a hosted platform because the
+  builder still defines instructions and skills, but Google owns the runtime
+  boundary.
 - Bedrock Managed Agents points to a cloud-managed enterprise surface: teams can
   run OpenAI-powered agents on AWS infrastructure while relying on the provider
   for runtime concerns such as inference, memory, skills, identity, audit logs,
@@ -119,6 +136,9 @@ flowchart LR
 - Choose workspace-native builders when the team already lives inside the host
   suite and wants shared agents with built-in governance and familiar
   permissions.
+- Choose agent-first managed APIs when the team wants code-first control over
+  instructions and tools but does not want to own sandbox infrastructure,
+  background execution, or server-side state handling.
 - Choose cloud-managed agents when the team already standardizes on a cloud
   provider's data boundaries, governance model, and adjacent services.
 - Choose builder-first platforms when quick iteration and cross-functional
@@ -140,6 +160,9 @@ flowchart LR
 - Cloud-managed agents reduce runtime ownership, but they increase dependence on
   provider-specific capabilities, pricing, regional availability, and release
   timing.
+- API-first managed surfaces speed up long-running tool use and hosted
+  sandboxes, but they also bind you to provider-specific interaction-state
+  semantics, tool contracts, and observability surfaces.
 - Visual platforms improve accessibility, but complex flows can still become
   hard to debug.
 - Rich plugin ecosystems accelerate capability growth, but they also create
@@ -150,6 +173,8 @@ flowchart LR
 Useful defaults:
 
 - use suite-native builders to validate shared internal workflows quickly
+- use agent-first managed APIs when you need hosted sandboxes, resumable
+  execution, or one endpoint for both models and agents
 - use cloud-managed agents when service proximity, auditability, and managed
   runtime operations matter more than framework portability
 - move to a broader platform or custom code when the host surface becomes the
@@ -165,11 +190,15 @@ Useful defaults:
 ## Reading Extensions
 
 - [Agent Frameworks](/ecosystem/agent-frameworks)
+- [Deep Research Product Signals](/contributor-kit/reference-notes/deep-research-product-signals)
+- [Protocols And Interoperability](/systems/protocols-and-interoperability)
 - [Agents Vs Workflows](/foundations/agents-vs-workflows)
 - [Ecosystem Overview](/ecosystem)
 
 ## Update Log
 
+- 2026-06-24: Added Gemini Interactions API and Managed Agents as an API-first
+  managed platform signal in the 2026 comparison.
 - 2026-05-01: Added Bedrock Managed Agents as a cloud-managed enterprise agent
   platform signal from the seven-day trend run.
 - 2026-04-23: Refreshed the page with current workspace-agent and Microsoft

--- a/ecosystem/agent-platforms-and-low-code-builders.mdx
+++ b/ecosystem/agent-platforms-and-low-code-builders.mdx
@@ -14,7 +14,7 @@ external_readings:
     url: https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/agent-builder
   - title: Choose between Microsoft 365 Copilot and Copilot Studio to build your agent
     url: https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/copilot-studio-experience
-  - title: Interactions API: our primary interface for Gemini models and agents
+  - title: "Interactions API: our primary interface for Gemini models and agents"
     url: https://blog.google/innovation-and-ai/technology/developers-tools/interactions-api-general-availability/
   - title: Interactions API | Gemini API
     url: https://ai.google.dev/gemini-api/docs/interactions-overview
@@ -86,7 +86,7 @@ These are different choices, not direct substitutes.
 flowchart LR
   Need["Team need"] --> Choice{"Platform style"}
   Choice --> Workspace["Workspace-native"]
-  Choice --> Managed["Cloud-managed"]
+  Choice --> Managed["Managed runtime"]
   Choice --> Builder["Builder-first"]
   Choice --> App["Application platform"]
   Choice --> Automation["Automation-first"]

--- a/zh-Hans/contributor-kit/reference-notes/README.md
+++ b/zh-Hans/contributor-kit/reference-notes/README.md
@@ -14,7 +14,7 @@
 ## 当前说明
 
 - [企业级智能体控制平面](./enterprise-agent-control-planes.mdx): 一份面向贡献者的 note，说明在企业级智能体系统里应区分 managed runtimes 和跨智能体 control planes。
-- [Deep Research Product Signals](./deep-research-product-signals.mdx): 面向贡献者的当前 OpenAI 和 Google deep-research 产品信号对比。
+- [Deep Research Product Signals](./deep-research-product-signals.mdx): 面向贡献者的当前 OpenAI deep-research 定位与 Google 基于 Interactions API 的长时间运行研究智能体开发者表面对比。
 - [Deep Research Source Map](./deep-research-source-map.mdx)
 - [Local Agent Tooling Source Map](./local-agent-tooling-source-map.mdx): 一份面向贡献者的简报，用于在未来草稿中保持本地执行边界、运行时、技能、MCP roots、resources、connectors 和基于文件的工作流彼此区分，同时也把 prompt injection 与本地 authority boundary 保持明确。
 - [开放式智能体环境](./open-agent-environments.mdx): 一份面向贡献者的说明，用于区分 agentic RL 中的环境契约、harness、trainer 与 MCP-native 执行表面。

--- a/zh-Hans/contributor-kit/reference-notes/deep-research-product-signals.mdx
+++ b/zh-Hans/contributor-kit/reference-notes/deep-research-product-signals.mdx
@@ -1,8 +1,8 @@
 ---
 title: 深度研究产品信号
 owner: Prompthon IO
-updated: 2026-04-23
-scope: current deep research product signals through April 2026
+updated: 2026-06-24
+scope: current deep research and Gemini Interactions API signals through June 2026
 status: draft
 ---
 
@@ -24,7 +24,8 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 - OpenAI 目前在 ChatGPT 中对 deep research 的定位
 - Google 面向 Gemini Deep Research 的开发者 API 表述
-- Google 2026 年 4 月 Deep Research Max 更新
+- Google 在 2026 年 6 月将 Interactions API 推向 GA 并提升为主接口
+- Google 当前围绕 Interactions-based agents 的 ADK 和 A2A bridge 信号
 
 不包含：
 
@@ -38,25 +39,39 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
   OpenAI 将 deep research 描述为一种多步骤互联网研究智能体，并指出 2026 年 2 月 10 日的更新新增了 MCP 和应用连接、受信任站点搜索控制，以及改进的进度跟踪。
 - [Build with Gemini Deep Research](https://blog.google/innovation-and-ai/technology/developers-tools/deep-research-agent-gemini-api/):
   Google 通过 Interactions API 提供 Gemini Deep Research，并将其定位为可嵌入的智能体，用于长时间运行的上下文收集与综合。
-- [Introducing Deep Research and Deep Research Max](https://blog.google/innovation-and-ai/models-and-research/gemini-models/next-generation-gemini-deep-research/):
-  Google 将 2026 年 4 月 21 日的发布定位为围绕 MCP 支持、原生可视化，以及在长周期研究工作流上的更好表现。
+- [Interactions API: our primary interface for Gemini models and agents](https://blog.google/innovation-and-ai/technology/developers-tools/interactions-api-general-availability/):
+  Google 表示 Interactions API 已于 2026 年 6 月 22 日达到 GA，并成为 Gemini models and agents 的主接口。
+- [Gemini API docs](https://ai.google.dev/gemini-api/docs) 和
+  [Interactions overview](https://ai.google.dev/gemini-api/docs/interactions-overview):
+  当前文档建议新项目优先使用 Interactions API，并将 server-side state、background execution 与 resumable interaction flows 作为默认开发者表面。
+- [Building agents with the ADK and the new Interactions API](https://developers.googleblog.com/building-agents-with-the-adk-and-the-new-interactions-api/)
+  以及 [Gemini Enterprise Agent Platform ADK guide](https://docs.cloud.google.com/gemini-enterprise-agent-platform/build/adk):
+  Google 已将 Interactions API 与 ADK-managed tools、A2A bridges 以及 enterprise deployment 路径连接起来，而不是把 deep research 视为孤立的产品叶子节点。
 
 ## 综合
 
-从这些来源中可以看出三个稳定信号：
+从这些来源中可以看出四个稳定信号：
 
 - Deep research 正被定位为工作产物，而不仅仅是聊天。OpenAI 描述的是基于多种来源生成的分析师级报告，而 Google 则将 Deep Research 定位为一种长时间运行的综合智能体。
-- 产品边界正在超越公开网页搜索。OpenAI 在 2026 年 2 月 10 日的更新中加入了 MCP 和应用连接，以及受信任站点限制。Google 2026 年 4 月的更新则为自定义和专业数据源增加了 MCP 支持。
-- Deep research 正在分化为面向终端用户和面向开发者的两类入口。OpenAI 以 ChatGPT 用法为中心，而 Google 现在通过 Interactions API 直接暴露这种形态，用于嵌入式产品使用。
+- 产品边界正在超越公开网页搜索。OpenAI 在 2026 年 2 月 10 日的更新中加入了 MCP 和应用连接，以及受信任站点限制。Google 则继续通过 connected data、managed tools 和长时间运行的 interaction state 推动同一方向。
+- Google 已不再只是说“Gemini Deep Research 存在”。更强的 2026 年 6 月信号是：Interactions API 现在是 Gemini models and agents 的主接口，而 Deep Research 只是这一更广泛 runtime model 上的一个具体表面。
+- 面向开发者的 agent systems 正在吸收越来越多原本属于产品层的形态。Server-side state、resumable background work、tool execution 和 A2A bridges，如今都出现在此前看起来像单一 research-agent 功能的同一家接口族中。
 
-这意味着实验室应将 deep research 视为一个更广义的产品类别，其共享特征包括规划、证据收集、可追溯性和产物质量，而不是某一家供应商的一个孤立功能。
+这意味着实验室应将 deep research 视为一个更广义的产品类别，其共享特征包括规划、证据收集、可追溯性、产物质量以及长时间运行的 interaction state，而不是某一家供应商的一个孤立功能。
+
+## 对贡献者的含义
+
+- 扩展 [Deep Research Agents](/zh-Hans/case-studies/deep-research-agents)，补上一段内容，明确区分面向终端用户的 deep-research 产品与如今暴露同一智能体形态的面向开发者 runtime surfaces。
+- 将未来更新与 [Agent Frameworks](/zh-Hans/ecosystem/agent-frameworks)、[Protocols And Interoperability](/zh-Hans/systems/protocols-and-interoperability) 以及 [Deep Research Agent Starter](/zh-Hans/case-studies/examples/deep-research-agent-starter) 交叉链接，让这份说明指向持久的实现表面，而不是停留在市场快照。
+- 通过 [Reference Notes hub](/zh-Hans/contributor-kit/reference-notes) 和 [Contributor reading path](/zh-Hans/reading-paths/contributor) 来组织后续整理工作，使产品信号刷新持续依附于仓库原生的起草规则。
 
 ## 差距与后续
 
-- 扩展 [Deep Research Agents](/zh-Hans/case-studies/deep-research-agents)，增加一个简短的产品信号部分，让案例研究体现当前的市场动向。
-- 添加一条后续说明，聚焦于长时间运行研究智能体的评估与信任边界。
-- 重新评估未来的入门项目是否应支持可信来源约束，或支持 MCP 连接的私有数据。
+- 扩展 [Deep Research Agents](/zh-Hans/case-studies/deep-research-agents)，补上一段关于 Gemini Interactions API 作为长时间运行研究智能体默认开发者表面的产品信号内容。
+- 添加一条后续说明，聚焦于混合 built-in agents 与 framework-owned outer loops 的长时间运行研究智能体的评估与信任边界。
+- 重新评估未来的入门项目是否应支持可信来源约束，或在 MCP 连接的私有数据之外加入 server-side interaction state。
 
 ## 更新日志
 
+- 2026-06-24：围绕 Google Interactions API 的 GA 以及其作为主要 Gemini agent interface 的新角色刷新本说明。
 - 2026-04-23：基于当前 OpenAI 和 Google 来源，新增一份面向贡献者的产品信号说明。

--- a/zh-Hans/contributor-kit/reference-notes/index.mdx
+++ b/zh-Hans/contributor-kit/reference-notes/index.mdx
@@ -20,7 +20,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 ## 当前说明
 
 - [企业级智能体控制平面](/zh-Hans/contributor-kit/reference-notes/enterprise-agent-control-planes): 一份面向贡献者的 note，说明在企业级智能体系统里应区分 managed runtimes、partner delivery 和跨智能体 control planes。
-- [Deep Research Product Signals](/zh-Hans/contributor-kit/reference-notes/deep-research-product-signals): 面向贡献者的当前 OpenAI 和 Google deep-research 产品信号对比。
+- [Deep Research Product Signals](/zh-Hans/contributor-kit/reference-notes/deep-research-product-signals): 面向贡献者的当前 OpenAI deep-research 定位与 Google 基于 Interactions API 的长时间运行研究智能体开发者表面对比。
 - [Deep Research Source Map](/zh-Hans/contributor-kit/reference-notes/deep-research-source-map)
 - [Local Agent Tooling Source Map](/zh-Hans/contributor-kit/reference-notes/local-agent-tooling-source-map): 一份面向贡献者的简报，用于在未来草稿中保持本地执行边界、运行时、技能、MCP roots、resources、connectors 和基于文件的工作流彼此区分，同时也把 prompt injection 与本地 authority boundary 保持明确。
 - [开放式智能体环境](/zh-Hans/contributor-kit/reference-notes/open-agent-environments): 一份面向贡献者的说明，用于区分 agentic RL 中的环境契约、harness、trainer 与 MCP-native 执行表面。

--- a/zh-Hans/ecosystem/agent-platforms-and-low-code-builders.mdx
+++ b/zh-Hans/ecosystem/agent-platforms-and-low-code-builders.mdx
@@ -1,7 +1,7 @@
 ---
 title: 智能体平台与低代码构建者
 owner: Prompthon IO
-updated: 2026-05-01
+updated: 2026-06-24
 depth: intermediate
 region_tags:
   - global
@@ -14,6 +14,12 @@ external_readings:
     url: https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/agent-builder
   - title: Choose between Microsoft 365 Copilot and Copilot Studio to build your agent
     url: https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/copilot-studio-experience
+  - title: Interactions API: our primary interface for Gemini models and agents
+    url: https://blog.google/innovation-and-ai/technology/developers-tools/interactions-api-general-availability/
+  - title: Interactions API | Gemini API
+    url: https://ai.google.dev/gemini-api/docs/interactions-overview
+  - title: Introducing Managed Agents in the Gemini API
+    url: https://blog.google/innovation-and-ai/technology/developers-tools/managed-agents-gemini-api/
   - title: Amazon Bedrock Managed Agents, powered by OpenAI
     url: https://aws.amazon.com/bedrock/managed-agents-openai/
   - title: Automate tasks in your application using AI agents - Amazon Bedrock
@@ -29,17 +35,17 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 
 ## 概要
 
-低代码智能体平台会把重复出现的应用模式转化为可视化、配置优先、工作区原生或云托管的构建模块。到了 2026 年，比较范围不仅包括独立的构建产品，也包括存在于现有生产力套件内部的智能体构建器，以及托管云运行时。
+低代码智能体平台会把重复出现的应用模式转化为可视化、配置优先、工作区原生、API 优先托管式或云托管的构建模块。到了 2026 年，比较范围不仅包括独立的构建产品，也包括存在于现有生产力套件内部的智能体构建器，以及托管云运行时。
 
 ## 为什么这很重要
 
 并非每个有用的智能体都需要从自定义框架开始。许多团队首先需要验证产品界面、连接常见服务，或者让非工程背景的利益相关者参与到工作流构建中。
 
-这正是构建者优先、平台优先、自动化优先、工作区原生和云托管界面变得有吸引力的地方。
+这正是构建者优先、平台优先、自动化优先、工作区原生和托管运行时界面变得有吸引力的地方。
 
 ## 心智模型
 
-当前平台市场指向七个有用的锚点：
+当前平台市场指向八个有用的锚点：
 
 - `Coze`：面向快速组装、插件和发布的构建者优先体验
 - `Dify`：面向编排、插件、知识和部署控制的应用平台
@@ -47,13 +53,14 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 - `Workspace agents`：ChatGPT 和 Slack 中的共享云端智能体，用于长时间运行的团队工作流
 - `Agent Builder`：Microsoft 365 中的上下文内智能体创建，用于快速声明式场景
 - `Copilot Studio`：面向更大受众、自定义集成和更高级控制的更广泛 Microsoft 平台
+- `Gemini Managed Agents`：一种智能体优先的 API 界面，由 Google 托管 sandbox、state 和长时间执行，而构建者仍然编写 instructions 与 skills
 - `Bedrock Managed Agents`：面向 OpenAI 驱动智能体的 AWS 托管运行时，适合需要云治理、服务就近性和托管运维的场景
 
 这些是不同的选择，不是直接替代品。
 
 - 构建者优先产品优化快速创建和操作者友好性
 - 工作区原生构建器优化现有套件中的共享智能体
-- 云托管构建器优化企业运行时所有权和治理
+- 云托管与 API 优先托管界面优化企业运行时所有权和治理
 - 应用平台优化更广泛的产品与部署控制
 - 自动化平台优化与现有业务流程的集成
 
@@ -68,6 +75,7 @@ flowchart LR
   Choice --> App["应用平台"]
   Choice --> Automation["自动化优先"]
   Workspace --> OpenAI["Workspace agents / Agent Builder"]
+  Managed --> Gemini["Gemini Managed Agents"]
   Managed --> Bedrock["Bedrock Managed Agents"]
   Builder --> Coze["Coze-style"]
   App --> Dify["Dify / Copilot Studio style"]
@@ -81,6 +89,7 @@ flowchart LR
 - Workspace agents 展示了一种新的工作区原生构建器界面，团队可以在 ChatGPT 内创建共享云端智能体，在后台运行长时间任务，并将智能体保持在现有组织控制之内。
 - Agent Builder 在 Microsoft 侧展示了同样的方向：在上下文中使用 Microsoft 365 知识源构建快速声明式智能体，可在套件内共享，但有意比 Copilot Studio 更窄。
 - 当受众更大、工作流更复杂，或者智能体需要比 Agent Builder 设计目标更强的自定义集成和部署管理时，Copilot Studio 就变得很重要。
+- Gemini Managed Agents 与 Interactions API 指向一种 API 优先的托管界面：模型调用、Deep Research 和自定义托管智能体都走同一套接口，并提供 server-side state、background execution 与托管 Linux sandbox。它处在 framework 和 hosted platform 之间，因为构建者仍然定义 instructions 与 skills，但 runtime boundary 由 Google 持有。
 - Bedrock Managed Agents 指向一种云托管的企业界面：团队可以在 AWS 基础设施上运行 OpenAI 驱动的智能体，同时把推理、记忆、技能、身份、审计日志、服务连接和云边界内运维等运行时问题交给提供商处理。
 - Dify 仍然代表更广泛的开源应用平台模式，其中编排、部署控制和可扩展性需要同时成立。
 - n8n 仍然代表自动化优先模式，在这种模式下，智能体只是运营流水线中的一个步骤，而不是整个产品界面。
@@ -92,6 +101,7 @@ flowchart LR
 ### 选择标准
 
 - 当团队已经在宿主套件中工作，并希望获得带有内置治理和熟悉权限的共享智能体时，选择工作区原生构建器。
+- 当团队希望对 instructions 和 tools 保持代码优先控制，但又不想自行承担 sandbox 基础设施、后台执行或 server-side state 处理时，选择智能体优先的托管 API。
 - 当团队已经标准化在某个云提供商的数据边界、治理模型和相邻服务上时，选择云托管智能体。
 - 当快速迭代和跨职能参与最重要时，选择构建者优先平台。
 - 当你需要在原型、编排和可部署产品界面之间建立更强桥梁时，选择应用平台。
@@ -103,6 +113,7 @@ flowchart LR
 - 更快的组装通常意味着比代码更弱的细粒度控制。
 - 工作区原生构建器之所以有吸引力，是因为它们减少了设置工作并与现有权限保持一致，但它们受限于宿主套件的扩展模型、发布节奏和定价。
 - 云托管智能体减少了运行时所有权，但会提高对提供商特定能力、定价、区域可用性和发布时机的依赖。
+- API 优先的托管界面可以加快长时间工具执行与托管 sandbox 的采用，但也会把你绑定到提供商特定的 interaction/state 语义、tool contract 和 observability surface。
 - 可视化平台提升了可访问性，但复杂流程仍然可能变得难以调试。
 - 丰富的插件生态可以加速能力增长，但也会带来依赖和信任问题。
 - 内置存储、记忆或检索层对原型可能很方便，但对生产级持久性来说可能不够。
@@ -110,6 +121,7 @@ flowchart LR
 实用默认做法：
 
 - 使用套件原生构建器快速验证共享内部工作流
+- 当你需要托管 sandbox、可恢复执行，或希望同一端点同时覆盖 models 与 agents 时，使用智能体优先的托管 API
 - 当服务就近性、可审计性和托管运行时运维比框架可移植性更重要时，使用云托管智能体
 - 当宿主界面成为阻碍时，迁移到更广泛的平台或自定义代码
 - 尽早将原型便利性与生产需求分开考虑
@@ -122,11 +134,14 @@ flowchart LR
 ## 延伸阅读
 
 - [智能体框架](/zh-Hans/ecosystem/agent-frameworks)
+- [深度研究产品信号](/zh-Hans/contributor-kit/reference-notes/deep-research-product-signals)
+- [协议与互操作性](/zh-Hans/systems/protocols-and-interoperability)
 - [智能体与工作流](/zh-Hans/foundations/agents-vs-workflows)
 - [生态概览](/zh-Hans/ecosystem)
 
 ## 更新日志
 
+- 2026-06-24：把 Gemini Interactions API 与 Managed Agents 加入 2026 年对比，作为一种 API 优先的托管平台信号。
 - 2026-05-01：根据七天趋势运行结果，加入 Bedrock Managed Agents 作为云托管企业智能体平台信号。
 - 2026-04-23：根据当前 workspace-agent 和 Microsoft 构建者平台信号刷新页面。
 - 2026-04-21：基于导入的参考材料和实验室重写规则形成的仓库原生初稿。

--- a/zh-Hans/ecosystem/agent-platforms-and-low-code-builders.mdx
+++ b/zh-Hans/ecosystem/agent-platforms-and-low-code-builders.mdx
@@ -14,7 +14,7 @@ external_readings:
     url: https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/agent-builder
   - title: Choose between Microsoft 365 Copilot and Copilot Studio to build your agent
     url: https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/copilot-studio-experience
-  - title: Interactions API: our primary interface for Gemini models and agents
+  - title: "Interactions API: our primary interface for Gemini models and agents"
     url: https://blog.google/innovation-and-ai/technology/developers-tools/interactions-api-general-availability/
   - title: Interactions API | Gemini API
     url: https://ai.google.dev/gemini-api/docs/interactions-overview
@@ -70,7 +70,7 @@ import SupportCTA from "/snippets/support-cta-zh-Hans.mdx";
 flowchart LR
   Need["团队需求"] --> Choice{"平台风格"}
   Choice --> Workspace["工作区原生"]
-  Choice --> Managed["云托管"]
+  Choice --> Managed["托管运行时"]
   Choice --> Builder["构建者优先"]
   Choice --> App["应用平台"]
   Choice --> Automation["自动化优先"]


### PR DESCRIPTION
## Summary
- add Gemini Interactions API and Managed Agents as an API-first managed platform signal in the ecosystem comparison
- explain when to choose agent-first managed APIs versus suite-native or cloud-managed builder surfaces
- mirror the same content update in zh-Hans to keep the translation aligned with the English canonical page

## Sources
- https://blog.google/innovation-and-ai/technology/developers-tools/interactions-api-general-availability/
- https://ai.google.dev/gemini-api/docs/interactions-overview
- https://blog.google/innovation-and-ai/technology/developers-tools/managed-agents-gemini-api/
- https://github.com/google-gemini/cookbook
- https://github.com/google/adk-python

## Validation
- python3 scripts/verify_example_projects.py