### PR TITLE
[dprat0821] Fix published reading-path links

### DIFF
--- a/radar/2026-06-agent-first-devices-watch.mdx
+++ b/radar/2026-06-agent-first-devices-watch.mdx
@@ -111,7 +111,7 @@ That comparison question can later strengthen a systems page or a runnable
 starter once the examples are less launch-shaped. Until then, contributors
 should resist collapsing this into `AI PC` hype or generic local-agent prose.
 
-If you want to extend this note, use the [Contributor Kit](/contributor-kit/index.mdx)
+If you want to extend this note, use the [Contributor Kit](/contributor-kit)
 and keep future additions grounded in first-party runtime, containment, and
 control-plane evidence.
 

--- a/reading-paths/builder.mdx
+++ b/reading-paths/builder.mdx
@@ -11,29 +11,29 @@ applications.
 
 ## Shared starting points
 
-- [Environment Setup](./environment-setup.mdx): the shared local setup guide for
+- [Environment Setup](/reading-paths/environment-setup): the shared local setup guide for
   running starter-code checks before deeper implementation work.
-- [Sample Projects](./sample-projects.mdx): the public guide to current example
+- [Sample Projects](/reading-paths/sample-projects): the public guide to current example
   starters and where they live in the repo.
 
 ## Suggested sequence
 
 
-1. [The Agent Systems](../foundations/the-agent-system.mdx)
-2. [History Of Agent Ideas](../foundations/history-of-agent-ideas.mdx)
-3. [LLM Foundations For Agent Systems](../foundations/llm-foundations-for-agent-systems.mdx)
-4. [Agents Vs Workflows](../foundations/agents-vs-workflows.mdx)
-5. [Reasoning And Control Patterns](../patterns/reasoning-and-control-patterns.mdx)
-6. [Planning And Reflection](../patterns/planning-and-reflection.mdx)
-7. [Agent Memory And Retrieval](../patterns/agent-memory-and-retrieval.mdx)
-8. [Agent Runtime Building Blocks](../patterns/agent-runtime-building-blocks.mdx)
-9. [Context Engineering](../systems/context-engineering.mdx)
-10. [Protocols And Interoperability](../systems/protocols-and-interoperability.mdx)
-11. [Evaluation And Observability](../systems/evaluation-and-observability.mdx)
-12. [Deep Research Agents](../case-studies/deep-research-agents.mdx)
-13. [Agent Frameworks](../ecosystem/agent-frameworks.mdx)
-14. [Agent Platforms And Low-Code Builders](../ecosystem/agent-platforms-and-low-code-builders.mdx)
-15. [Radar](../radar/index.mdx)
+1. [The Agent Systems](/foundations/the-agent-system)
+2. [History Of Agent Ideas](/foundations/history-of-agent-ideas)
+3. [LLM Foundations For Agent Systems](/foundations/llm-foundations-for-agent-systems)
+4. [Agents Vs Workflows](/foundations/agents-vs-workflows)
+5. [Reasoning And Control Patterns](/patterns/reasoning-and-control-patterns)
+6. [Planning And Reflection](/patterns/planning-and-reflection)
+7. [Agent Memory And Retrieval](/patterns/agent-memory-and-retrieval)
+8. [Agent Runtime Building Blocks](/patterns/agent-runtime-building-blocks)
+9. [Context Engineering](/systems/context-engineering)
+10. [Protocols And Interoperability](/systems/protocols-and-interoperability)
+11. [Evaluation And Observability](/systems/evaluation-and-observability)
+12. [Deep Research Agents](/case-studies/deep-research-agents)
+13. [Agent Frameworks](/ecosystem/agent-frameworks)
+14. [Agent Platforms And Low-Code Builders](/ecosystem/agent-platforms-and-low-code-builders)
+15. [Radar](/radar)
 
 
 ## What this path optimizes for

--- a/reading-paths/practitioner.mdx
+++ b/reading-paths/practitioner.mdx
@@ -16,24 +16,24 @@ tutorial track.
 
 ## Shared starting points
 
-- [Environment Setup](./environment-setup.mdx): the shared local setup guide for
+- [Environment Setup](/reading-paths/environment-setup): the shared local setup guide for
   trying the repo-owned starter code.
-- [Workshops](../workshops/index.mdx): guided setup tracks for OpenClaw, local desktop agents,
+- [Workshops](/workshops): guided setup tracks for OpenClaw, local desktop agents,
   and skills.
-- [Sample Projects](./sample-projects.mdx): the public guide to current example
+- [Sample Projects](/reading-paths/sample-projects): the public guide to current example
   starters across the repo.
-- [Practitioner Skills](../skills/index.mdx): installable Codex skill packages for local-first,
+- [Practitioner Skills](/skills): installable Codex skill packages for local-first,
   repeatable daily workflows.
 
 ## Suggested sequence
 
-1. [Deep Research Agents](../case-studies/deep-research-agents.mdx)
-2. [Agents Vs Workflows](../foundations/agents-vs-workflows.mdx)
-3. [Workshops](../workshops/index.mdx)
-4. [Agent Platforms And Low-Code Builders](../ecosystem/agent-platforms-and-low-code-builders.mdx)
-5. [Practitioner Skills](../skills/index.mdx)
-6. [Agent Memory And Retrieval](../patterns/agent-memory-and-retrieval.mdx)
-7. [Radar](../radar/index.mdx)
+1. [Deep Research Agents](/case-studies/deep-research-agents)
+2. [Agents Vs Workflows](/foundations/agents-vs-workflows)
+3. [Workshops](/workshops)
+4. [Agent Platforms And Low-Code Builders](/ecosystem/agent-platforms-and-low-code-builders)
+5. [Practitioner Skills](/skills)
+6. [Agent Memory And Retrieval](/patterns/agent-memory-and-retrieval)
+7. [Radar](/radar)
 
 ## What this path optimizes for
 
@@ -45,6 +45,6 @@ tutorial track.
 
 If you want the production-minded view of evaluation, interoperability,
 reliability, and operations, continue into
-[Context Engineering](../systems/context-engineering.mdx),
-[Protocols And Interoperability](../systems/protocols-and-interoperability.mdx),
-and [Evaluation And Observability](../systems/evaluation-and-observability.mdx).
+[Context Engineering](/systems/context-engineering),
+[Protocols And Interoperability](/systems/protocols-and-interoperability),
+and [Evaluation And Observability](/systems/evaluation-and-observability).

--- a/zh-Hans/radar/2026-06-agent-first-devices-watch.mdx
+++ b/zh-Hans/radar/2026-06-agent-first-devices-watch.mdx
@@ -82,7 +82,7 @@ Agent 365、MXC 沙箱，以及 Foundry Local，一起指向一个新的运行�
 
 等到样例不再那么像 launch framing 之后，这个比较问题才适合进一步沉淀到 systems 页面或可运行 starter。当前阶段，贡献者应避免把它写成 `AI PC` 热词或泛化的本地智能体叙事。
 
-如果你想继续扩展这条笔记，请从 [Contributor Kit](/zh-Hans/contributor-kit/index.mdx)
+如果你想继续扩展这条笔记，请从 [Contributor Kit](/zh-Hans/contributor-kit)
 开始，并坚持使用第一方 runtime、containment 与 control-plane 证据。
 
 ## 更新日志


### PR DESCRIPTION
## Summary
- replace every remaining internal `.mdx` content URL with its extensionless Mintlify route
- repair all Practitioner and Builder reading-path destinations
- repair the last English and Simplified Chinese radar-note occurrences

## Root cause
PR #102 optimized the links for GitHub source browsing by adding `.mdx`. Mintlify now emits those suffixes into the public URLs, where they return 404.

## Validation
- `python3 scripts/verify_example_projects.py`
- `npx --yes mint validate` on Node 20.17.0
- `npx --yes mint broken-links` on Node 20.17.0
- `git diff --check`
- local Mintlify preview at `/reading-paths/practitioner`
- Playwright verified all 18 unique internal links in the page main area return 200, including all 12 content destinations
- repository scan found no remaining internal Markdown links ending in `.mdx`

A separate Builder-track follow-up in #205 adds CI coverage for the validation gap.

Fixes #204