### PR TITLE
[dprat0821] Prevent published .mdx link regressions

### DIFF
--- a/.github/workflows/validate-mintlify.yml
+++ b/.github/workflows/validate-mintlify.yml
@@ -21,6 +21,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check published internal links
+        run: |
+          python3 -m unittest scripts/check_published_links_test.py
+          python3 scripts/check_published_links.py
+
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat .node-version)" >> "$GITHUB_OUTPUT"

--- a/scripts/check_published_links.py
+++ b/scripts/check_published_links.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Reject internal MDX links that publish as `.mdx` site routes."""
+
+from __future__ import annotations
+
+import posixpath
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from urllib.parse import urlsplit
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FENCE_RE = re.compile(r"^\s{0,3}(?P<marker>`{3,}|~{3,})")
+INTERNAL_MDX_LINK_RE = re.compile(
+    r"(?<!!)\[[^\]\n]+\]\("
+    r"(?P<target>(?:/|\./|\.\./)[^)\s]+?\.mdx(?:[?#][^)\s]*)?)"
+    r"(?:\s+[\"'][^)\n]*[\"'])?\)",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: Path
+    line_number: int
+    target: str
+    suggested_route: str
+
+
+def discover_mdx_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return sorted(
+        REPO_ROOT / relative_path
+        for relative_path in result.stdout.splitlines()
+        if relative_path.lower().endswith(".mdx")
+    )
+
+
+def extensionless_route(source_path: Path, target: str) -> str:
+    parsed = urlsplit(target)
+    target_path = parsed.path
+
+    if target_path.startswith("/"):
+        repo_path = PurePosixPath(target_path.lstrip("/"))
+    else:
+        source_parent = PurePosixPath(source_path.relative_to(REPO_ROOT).parent.as_posix())
+        repo_path = PurePosixPath(posixpath.normpath((source_parent / target_path).as_posix()))
+
+    route_path = repo_path.as_posix()[: -len(".mdx")]
+    if route_path == "index":
+        route_path = ""
+    elif route_path.endswith("/index"):
+        route_path = route_path[: -len("/index")]
+
+    route = f"/{route_path}" if route_path else "/"
+    if parsed.query:
+        route += f"?{parsed.query}"
+    if parsed.fragment:
+        route += f"#{parsed.fragment}"
+    return route
+
+
+def find_violations(path: Path) -> list[Violation]:
+    violations: list[Violation] = []
+    fence: tuple[str, int] | None = None
+
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        fence_match = FENCE_RE.match(line)
+        if fence_match:
+            marker = fence_match.group("marker")
+            if fence is None:
+                fence = (marker[0], len(marker))
+            elif marker[0] == fence[0] and len(marker) >= fence[1]:
+                fence = None
+            continue
+
+        if fence is not None:
+            continue
+
+        for match in INTERNAL_MDX_LINK_RE.finditer(line):
+            target = match.group("target")
+            violations.append(
+                Violation(
+                    path=path,
+                    line_number=line_number,
+                    target=target,
+                    suggested_route=extensionless_route(path, target),
+                )
+            )
+
+    return violations
+
+
+def main() -> int:
+    try:
+        violations = [
+            violation
+            for path in discover_mdx_files()
+            for violation in find_violations(path)
+        ]
+    except (OSError, subprocess.CalledProcessError) as exc:
+        print(f"Unable to check published links: {exc}", file=sys.stderr)
+        return 2
+
+    if not violations:
+        print("Published internal link check passed.")
+        return 0
+
+    print("Internal MDX links must use extensionless published routes:")
+    for violation in violations:
+        relative_path = violation.path.relative_to(REPO_ROOT)
+        print(
+            f"  - {relative_path}:{violation.line_number}: "
+            f"{violation.target} -> {violation.suggested_route}"
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_published_links_test.py
+++ b/scripts/check_published_links_test.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import check_published_links
+
+
+class PublishedLinkCheckTests(unittest.TestCase):
+    def test_extensionless_route_normalizes_relative_index_target(self) -> None:
+        source = check_published_links.REPO_ROOT / "reading-paths" / "practitioner.mdx"
+
+        route = check_published_links.extensionless_route(
+            source,
+            "../workshops/index.mdx#setup",
+        )
+
+        self.assertEqual(route, "/workshops#setup")
+
+    def test_finds_rendered_mdx_link_but_ignores_fenced_example(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repo_root = Path(temporary_directory)
+            source = repo_root / "reading-paths" / "practitioner.mdx"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                "\n".join(
+                    [
+                        "[Broken](../systems/context-engineering.mdx)",
+                        "",
+                        "```md",
+                        "[Example](../systems/example.mdx)",
+                        "```",
+                        "",
+                        "[Healthy](/systems/context-engineering)",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.object(check_published_links, "REPO_ROOT", repo_root):
+                violations = check_published_links.find_violations(source)
+
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(
+            violations[0].suggested_route,
+            "/systems/context-engineering",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a focused checker that rejects internal Markdown page links ending in `.mdx`
- report each source line with the correct extensionless route suggestion
- ignore fenced Markdown examples to avoid false positives
- add unit coverage and run both tests and the repository scan in `Validate Mintlify`

## Why a custom check
Both `npx mint validate` and `npx mint broken-links` pass the broken pattern even though Mintlify publishes the `.mdx` URL and the live route returns 404.

## Branch repair
- #206 is merged into `develop`
- #207 was restacked onto the merged commit so its diff contains only the workflow and two checker files

## Validation
- red test before #206: checker found all 33 affected links
- green test after #206: checker reports no violations
- `python3 -m unittest scripts/check_published_links_test.py`
- `python3 -m py_compile scripts/check_published_links.py scripts/check_published_links_test.py`
- `python3 scripts/verify_example_projects.py`
- `npx --yes mint validate` on Node 20.17.0
- `npx --yes mint broken-links` on Node 20.17.0
- `git diff --check`

Fixes #205