### PR TITLE
Release develop to main — 2026-08-11

### DIFF
--- a/.github/workflows/validate-mintlify.yml
+++ b/.github/workflows/validate-mintlify.yml
@@ -21,6 +21,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check published internal links
+        run: |
+          python3 -m unittest scripts/check_published_links_test.py
+          python3 scripts/check_published_links.py
+
       - name: Read Node.js version
         id: node-version
         run: echo "version=$(cat .node-version)" >> "$GITHUB_OUTPUT"

--- a/radar/2026-06-agent-first-devices-watch.mdx
+++ b/radar/2026-06-agent-first-devices-watch.mdx
@@ -111,7 +111,7 @@ That comparison question can later strengthen a systems page or a runnable
 starter once the examples are less launch-shaped. Until then, contributors
 should resist collapsing this into `AI PC` hype or generic local-agent prose.
 
-If you want to extend this note, use the [Contributor Kit](/contributor-kit/index.mdx)
+If you want to extend this note, use the [Contributor Kit](/contributor-kit)
 and keep future additions grounded in first-party runtime, containment, and
 control-plane evidence.
 

--- a/reading-paths/builder.mdx
+++ b/reading-paths/builder.mdx
@@ -11,29 +11,29 @@ applications.
 
 ## Shared starting points
 
-- [Environment Setup](./environment-setup.mdx): the shared local setup guide for
+- [Environment Setup](/reading-paths/environment-setup): the shared local setup guide for
   running starter-code checks before deeper implementation work.
-- [Sample Projects](./sample-projects.mdx): the public guide to current example
+- [Sample Projects](/reading-paths/sample-projects): the public guide to current example
   starters and where they live in the repo.
 
 ## Suggested sequence
 
 
-1. [The Agent Systems](../foundations/the-agent-system.mdx)
-2. [History Of Agent Ideas](../foundations/history-of-agent-ideas.mdx)
-3. [LLM Foundations For Agent Systems](../foundations/llm-foundations-for-agent-systems.mdx)
-4. [Agents Vs Workflows](../foundations/agents-vs-workflows.mdx)
-5. [Reasoning And Control Patterns](../patterns/reasoning-and-control-patterns.mdx)
-6. [Planning And Reflection](../patterns/planning-and-reflection.mdx)
-7. [Agent Memory And Retrieval](../patterns/agent-memory-and-retrieval.mdx)
-8. [Agent Runtime Building Blocks](../patterns/agent-runtime-building-blocks.mdx)
-9. [Context Engineering](../systems/context-engineering.mdx)
-10. [Protocols And Interoperability](../systems/protocols-and-interoperability.mdx)
-11. [Evaluation And Observability](../systems/evaluation-and-observability.mdx)
-12. [Deep Research Agents](../case-studies/deep-research-agents.mdx)
-13. [Agent Frameworks](../ecosystem/agent-frameworks.mdx)
-14. [Agent Platforms And Low-Code Builders](../ecosystem/agent-platforms-and-low-code-builders.mdx)
-15. [Radar](../radar/index.mdx)
+1. [The Agent Systems](/foundations/the-agent-system)
+2. [History Of Agent Ideas](/foundations/history-of-agent-ideas)
+3. [LLM Foundations For Agent Systems](/foundations/llm-foundations-for-agent-systems)
+4. [Agents Vs Workflows](/foundations/agents-vs-workflows)
+5. [Reasoning And Control Patterns](/patterns/reasoning-and-control-patterns)
+6. [Planning And Reflection](/patterns/planning-and-reflection)
+7. [Agent Memory And Retrieval](/patterns/agent-memory-and-retrieval)
+8. [Agent Runtime Building Blocks](/patterns/agent-runtime-building-blocks)
+9. [Context Engineering](/systems/context-engineering)
+10. [Protocols And Interoperability](/systems/protocols-and-interoperability)
+11. [Evaluation And Observability](/systems/evaluation-and-observability)
+12. [Deep Research Agents](/case-studies/deep-research-agents)
+13. [Agent Frameworks](/ecosystem/agent-frameworks)
+14. [Agent Platforms And Low-Code Builders](/ecosystem/agent-platforms-and-low-code-builders)
+15. [Radar](/radar)
 
 
 ## What this path optimizes for

--- a/reading-paths/practitioner.mdx
+++ b/reading-paths/practitioner.mdx
@@ -16,24 +16,24 @@ tutorial track.
 
 ## Shared starting points
 
-- [Environment Setup](./environment-setup.mdx): the shared local setup guide for
+- [Environment Setup](/reading-paths/environment-setup): the shared local setup guide for
   trying the repo-owned starter code.
-- [Workshops](../workshops/index.mdx): guided setup tracks for OpenClaw, local desktop agents,
+- [Workshops](/workshops): guided setup tracks for OpenClaw, local desktop agents,
   and skills.
-- [Sample Projects](./sample-projects.mdx): the public guide to current example
+- [Sample Projects](/reading-paths/sample-projects): the public guide to current example
   starters across the repo.
-- [Practitioner Skills](../skills/index.mdx): installable Codex skill packages for local-first,
+- [Practitioner Skills](/skills): installable Codex skill packages for local-first,
   repeatable daily workflows.
 
 ## Suggested sequence
 
-1. [Deep Research Agents](../case-studies/deep-research-agents.mdx)
-2. [Agents Vs Workflows](../foundations/agents-vs-workflows.mdx)
-3. [Workshops](../workshops/index.mdx)
-4. [Agent Platforms And Low-Code Builders](../ecosystem/agent-platforms-and-low-code-builders.mdx)
-5. [Practitioner Skills](../skills/index.mdx)
-6. [Agent Memory And Retrieval](../patterns/agent-memory-and-retrieval.mdx)
-7. [Radar](../radar/index.mdx)
+1. [Deep Research Agents](/case-studies/deep-research-agents)
+2. [Agents Vs Workflows](/foundations/agents-vs-workflows)
+3. [Workshops](/workshops)
+4. [Agent Platforms And Low-Code Builders](/ecosystem/agent-platforms-and-low-code-builders)
+5. [Practitioner Skills](/skills)
+6. [Agent Memory And Retrieval](/patterns/agent-memory-and-retrieval)
+7. [Radar](/radar)
 
 ## What this path optimizes for
 
@@ -45,6 +45,6 @@ tutorial track.
 
 If you want the production-minded view of evaluation, interoperability,
 reliability, and operations, continue into
-[Context Engineering](../systems/context-engineering.mdx),
-[Protocols And Interoperability](../systems/protocols-and-interoperability.mdx),
-and [Evaluation And Observability](../systems/evaluation-and-observability.mdx).
+[Context Engineering](/systems/context-engineering),
+[Protocols And Interoperability](/systems/protocols-and-interoperability),
+and [Evaluation And Observability](/systems/evaluation-and-observability).

--- a/scripts/check_published_links.py
+++ b/scripts/check_published_links.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Reject internal MDX links that publish as `.mdx` site routes."""
+
+from __future__ import annotations
+
+import posixpath
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from urllib.parse import urlsplit
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FENCE_RE = re.compile(r"^\s{0,3}(?P<marker>`{3,}|~{3,})")
+INTERNAL_MDX_LINK_RE = re.compile(
+    r"(?<!!)\[[^\]\n]+\]\("
+    r"(?P<target>(?:/|\./|\.\./)[^)\s]+?\.mdx(?:[?#][^)\s]*)?)"
+    r"(?:\s+[\"'][^)\n]*[\"'])?\)",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: Path
+    line_number: int
+    target: str
+    suggested_route: str
+
+
+def discover_mdx_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return sorted(
+        REPO_ROOT / relative_path
+        for relative_path in result.stdout.splitlines()
+        if relative_path.lower().endswith(".mdx")
+    )
+
+
+def extensionless_route(source_path: Path, target: str) -> str:
+    parsed = urlsplit(target)
+    target_path = parsed.path
+
+    if target_path.startswith("/"):
+        repo_path = PurePosixPath(target_path.lstrip("/"))
+    else:
+        source_parent = PurePosixPath(source_path.relative_to(REPO_ROOT).parent.as_posix())
+        repo_path = PurePosixPath(posixpath.normpath((source_parent / target_path).as_posix()))
+
+    route_path = repo_path.as_posix()[: -len(".mdx")]
+    if route_path == "index":
+        route_path = ""
+    elif route_path.endswith("/index"):
+        route_path = route_path[: -len("/index")]
+
+    route = f"/{route_path}" if route_path else "/"
+    if parsed.query:
+        route += f"?{parsed.query}"
+    if parsed.fragment:
+        route += f"#{parsed.fragment}"
+    return route
+
+
+def find_violations(path: Path) -> list[Violation]:
+    violations: list[Violation] = []
+    fence: tuple[str, int] | None = None
+
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        fence_match = FENCE_RE.match(line)
+        if fence_match:
+            marker = fence_match.group("marker")
+            if fence is None:
+                fence = (marker[0], len(marker))
+            elif marker[0] == fence[0] and len(marker) >= fence[1]:
+                fence = None
+            continue
+
+        if fence is not None:
+            continue
+
+        for match in INTERNAL_MDX_LINK_RE.finditer(line):
+            target = match.group("target")
+            violations.append(
+                Violation(
+                    path=path,
+                    line_number=line_number,
+                    target=target,
+                    suggested_route=extensionless_route(path, target),
+                )
+            )
+
+    return violations
+
+
+def main() -> int:
+    try:
+        violations = [
+            violation
+            for path in discover_mdx_files()
+            for violation in find_violations(path)
+        ]
+    except (OSError, subprocess.CalledProcessError) as exc:
+        print(f"Unable to check published links: {exc}", file=sys.stderr)
+        return 2
+
+    if not violations:
+        print("Published internal link check passed.")
+        return 0
+
+    print("Internal MDX links must use extensionless published routes:")
+    for violation in violations:
+        relative_path = violation.path.relative_to(REPO_ROOT)
+        print(
+            f"  - {relative_path}:{violation.line_number}: "
+            f"{violation.target} -> {violation.suggested_route}"
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_published_links_test.py
+++ b/scripts/check_published_links_test.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import check_published_links
+
+
+class PublishedLinkCheckTests(unittest.TestCase):
+    def test_extensionless_route_normalizes_relative_index_target(self) -> None:
+        source = check_published_links.REPO_ROOT / "reading-paths" / "practitioner.mdx"
+
+        route = check_published_links.extensionless_route(
+            source,
+            "../workshops/index.mdx#setup",
+        )
+
+        self.assertEqual(route, "/workshops#setup")
+
+    def test_finds_rendered_mdx_link_but_ignores_fenced_example(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repo_root = Path(temporary_directory)
+            source = repo_root / "reading-paths" / "practitioner.mdx"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                "\n".join(
+                    [
+                        "[Broken](../systems/context-engineering.mdx)",
+                        "",
+                        "```md",
+                        "[Example](../systems/example.mdx)",
+                        "```",
+                        "",
+                        "[Healthy](/systems/context-engineering)",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.object(check_published_links, "REPO_ROOT", repo_root):
+                violations = check_published_links.find_violations(source)
+
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(
+            violations[0].suggested_route,
+            "/systems/context-engineering",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zh-Hans/radar/2026-06-agent-first-devices-watch.mdx
+++ b/zh-Hans/radar/2026-06-agent-first-devices-watch.mdx
@@ -82,7 +82,7 @@ Agent 365、MXC 沙箱，以及 Foundry Local，一起指向一个新的运行�
 
 等到样例不再那么像 launch framing 之后，这个比较问题才适合进一步沉淀到 systems 页面或可运行 starter。当前阶段，贡献者应避免把它写成 `AI PC` 热词或泛化的本地智能体叙事。
 
-如果你想继续扩展这条笔记，请从 [Contributor Kit](/zh-Hans/contributor-kit/index.mdx)
+如果你想继续扩展这条笔记，请从 [Contributor Kit](/zh-Hans/contributor-kit)
 开始，并坚持使用第一方 runtime、containment 与 control-plane 证据。
 
 ## 更新日志


### PR DESCRIPTION
## Summary

Promote the current same-repository `develop` branch to production `main`. This release contains the published reading-path link repair and its regression guard; it introduces no additional release-only source changes.

Included changes:

- #206 — fix published Practitioner, Builder, and radar-note links that Mintlify rendered as `.mdx` 404 routes
- #207 — add CI coverage that rejects future internal `.mdx` content URLs

## Target Branch

- Base: `main`
- Head: same-repository `develop`
- Authorized release maintainer: `dprat0821`

## Validation

The included develop commits passed:

- `prompthon-track-guard`
- `validate-mintlify`
- `verify-example-projects`
- published-link unit and repository checks
- local Mintlify verification of all 18 unique Practitioner destinations

Fresh release-PR checks must pass again before merge.

## Deployment

Merging this PR with a merge commit promotes the validated develop state to production. The `Release Main` workflow will then create the date-based GitHub release, and the production Mintlify surface must be verified separately after the merge.

Related issues: #204, #205
