### PR TITLE
feat(skills): add organizer learning examples

### DIFF
--- a/skills/course-support/examples/lesson-2-organizer-freelancer-rules/incoming/client-invoice-2026-09.txt
+++ b/skills/course-support/examples/lesson-2-organizer-freelancer-rules/incoming/client-invoice-2026-09.txt
@@ -1,0 +1,8 @@
+SYNTHETIC COURSE DATA - FICTIONAL CLIENT INVOICE
+
+Invoice: FR-2026-09
+From: Rowan Lee Web Services
+To: Cedar Lane Bakery
+Service: September website updates
+Amount due: CAD 650.00
+Due date: September 30, 2026

--- a/skills/course-support/examples/lesson-2-organizer-freelancer-rules/incoming/client-meeting-notes.txt
+++ b/skills/course-support/examples/lesson-2-organizer-freelancer-rules/incoming/client-meeting-notes.txt
@@ -1,0 +1,7 @@
+SYNTHETIC COURSE DATA - FICTIONAL MEETING NOTES
+
+Client: Cedar Lane Bakery
+Date: September 3, 2026
+- Add the fall menu to the home page.
+- Replace three product photos.
+- Send a draft for review by September 12.

--- a/skills/course-support/examples/lesson-2-organizer-freelancer-rules/incoming/client-service-agreement.md
+++ b/skills/course-support/examples/lesson-2-organizer-freelancer-rules/incoming/client-service-agreement.md
@@ -1,0 +1,5 @@
+# Synthetic Client Service Agreement
+
+This fictional agreement is course data only.
+
+Rowan Lee Web Services will update the Cedar Lane Bakery website during September 2026. The client will provide text and images, and will pay CAD 650 after approving the completed work.

--- a/skills/course-support/examples/lesson-2-organizer-freelancer-rules/incoming/website-project-ideas.md
+++ b/skills/course-support/examples/lesson-2-organizer-freelancer-rules/incoming/website-project-ideas.md
@@ -1,0 +1,7 @@
+# Synthetic Website Project Ideas
+
+These fictional ideas are course data.
+
+- A simple portfolio for a local photographer
+- An online menu for a neighbourhood cafe
+- An event page for a community fundraiser

--- a/skills/course-support/examples/lesson-2-organizer-safe-recovery/incoming/Invoices/invoice-august.txt
+++ b/skills/course-support/examples/lesson-2-organizer-safe-recovery/incoming/Invoices/invoice-august.txt
@@ -1,0 +1,7 @@
+SYNTHETIC COURSE DATA - EARLIER FICTIONAL INVOICE
+
+Invoice: AUG-2026-18
+Vendor: Maple Office Supplies
+Item: Printer paper
+Earlier total: CAD 120.00
+Status: Reviewed and already filed

--- a/skills/course-support/examples/lesson-2-organizer-safe-recovery/incoming/coffee-receipt.txt
+++ b/skills/course-support/examples/lesson-2-organizer-safe-recovery/incoming/coffee-receipt.txt
@@ -1,0 +1,7 @@
+SYNTHETIC COURSE DATA - FICTIONAL RECEIPT
+
+Harbour Coffee
+Date: August 21, 2026
+Coffee: CAD 3.50
+Muffin: CAD 4.00
+Total: CAD 7.50

--- a/skills/course-support/examples/lesson-2-organizer-safe-recovery/incoming/expense-notes.md
+++ b/skills/course-support/examples/lesson-2-organizer-safe-recovery/incoming/expense-notes.md
@@ -1,0 +1,7 @@
+# Synthetic Monthly Expense Notes
+
+These fictional notes are course data for August 2026.
+
+- Office supplies invoice was revised after adding folders.
+- Coffee receipt was for a practice client meeting.
+- Review all receipts before filing the monthly total.

--- a/skills/course-support/examples/lesson-2-organizer-safe-recovery/incoming/invoice-august.txt
+++ b/skills/course-support/examples/lesson-2-organizer-safe-recovery/incoming/invoice-august.txt
@@ -1,0 +1,7 @@
+SYNTHETIC COURSE DATA - REVISED FICTIONAL INVOICE
+
+Invoice: AUG-2026-18
+Vendor: Maple Office Supplies
+Item: Printer paper and folders
+Revised total: CAD 145.00
+Status: Updated version awaiting review

--- a/skills/course-support/examples/lesson-2-organizer-safe-recovery/incoming/mystery.zzz
+++ b/skills/course-support/examples/lesson-2-organizer-safe-recovery/incoming/mystery.zzz
@@ -1,0 +1,4 @@
+SYNTHETIC COURSE DATA
+
+This intentionally unclassified file has an unknown .zzz type.
+Students can use it to practice leaving uncertain files in a safe location.

--- a/skills/course-support/examples/lesson-2-organizer-student-files/incoming/internship-resume.txt
+++ b/skills/course-support/examples/lesson-2-organizer-student-files/incoming/internship-resume.txt
@@ -1,0 +1,8 @@
+SYNTHETIC COURSE DATA - FICTIONAL RESUME
+
+Maya Chen
+Digital Communications Student
+
+Summary: Organized student seeking a summer communications internship.
+Skills: Clear writing, presentation design, and basic spreadsheet work.
+Experience: Volunteer newsletter assistant at a fictional community centre.

--- a/skills/course-support/examples/lesson-2-organizer-student-files/incoming/random-download.zzz
+++ b/skills/course-support/examples/lesson-2-organizer-student-files/incoming/random-download.zzz
@@ -1,0 +1,4 @@
+SYNTHETIC COURSE DATA
+
+This file uses an intentionally unknown .zzz type.
+It is included so students can see how the organizer handles an unrecognized download.

--- a/skills/course-support/examples/lesson-2-organizer-student-files/incoming/school-reading.md
+++ b/skills/course-support/examples/lesson-2-organizer-student-files/incoming/school-reading.md
@@ -1,0 +1,7 @@
+# Synthetic Course Reading List
+
+This is fictional course data for a learning exercise.
+
+- Week 1: *Clear Writing for Everyday Work*
+- Week 2: *Finding Reliable Online Sources*
+- Week 3: *Planning a Short Presentation*

--- a/skills/course-support/examples/lesson-2-organizer-student-files/incoming/tuition-invoice.txt
+++ b/skills/course-support/examples/lesson-2-organizer-student-files/incoming/tuition-invoice.txt
@@ -1,0 +1,8 @@
+SYNTHETIC COURSE DATA - NOT A REAL INVOICE
+
+Northview Learning College
+Tuition Invoice: STU-2026-104
+Student: Maya Chen
+Program: Digital Communications
+Fall tuition due: CAD 2,450.00
+Due date: September 15, 2026

--- a/skills/course-support/lessons/lesson-2.md
+++ b/skills/course-support/lessons/lesson-2.md
@@ -18,6 +18,175 @@ python3 skills/course-support/scripts/course_store.py context
 
 The first command prints three discoverable Codex skill names. The second creates `.local-state/course-demo/lesson-2/` without replacing existing work. A seeded incoming folder contains synthetic invoice/school files and an unknown extension; the research folder contains duplicate material and conflicting capacity statements. The context is a local demo, not a signed-in production account.
 
+## Optional expanded Organize practice
+
+An instructor can choose one example, or students can complete all three in
+order. The examples are independent, so work in one folder does not affect
+the others. Use only the synthetic files created by these commands. Do not
+practice on a real Downloads folder.
+
+In the exercises below, a **preview** shows proposed moves without making
+them, a **plan** saves those proposals for review, a **conflict** is a move
+that is safely skipped, and a **journal** records what happened during
+apply. See the Local Document Organizer
+[beginner terminology](../../local-document-organizer/README.md#beginner-terminology)
+for the other terms.
+
+Each seed command refuses to delete or replace an existing output directory.
+When repeating an exercise, keep the earlier work and add `--output` with a
+fresh path, for example `--output .local-state/course-demo/student-files-attempt-2`.
+
+### 1. Student files: preview only
+
+**Purpose.** Learn how readable filename and extension rules produce a plan,
+and see that an uncertain file stays where it is.
+
+**Setup.** Create a fresh copy of the synthetic student-files example:
+
+```bash
+python3 skills/course-support/scripts/seed_demo.py --scenario organizer-student-files
+```
+
+**Command.** Scan the incoming folder. This command looks and proposes; it
+does not move files.
+
+```bash
+python3 skills/local-document-organizer/scripts/course_organizer.py scan --folder .local-state/course-demo/lesson-2-organizer-student-files/incoming
+```
+
+**Sample Codex prompt.**
+
+```text
+Use $local-document-organizer to preview the student-files practice folder. Explain every proposed category and leave uncertain files in place. Do not move anything.
+```
+
+**Expected result.**
+
+- `tuition-invoice.txt` -> `Invoices/`
+- `school-reading.md` -> `School/`
+- `internship-resume.txt` -> `Resumes/`
+- `random-download.zzz` stays in place
+- the preview does not move any files
+
+**Reflection question.** Why is leaving an unknown file in place safer than
+guessing a category?
+
+### 2. Freelancer rules: customize classification
+
+**Purpose.** See how a specific filename rule can improve a classification,
+and why rule order changes the result.
+
+**Setup.** Create a fresh copy of the synthetic freelancer example:
+
+```bash
+python3 skills/course-support/scripts/seed_demo.py --scenario organizer-freelancer-rules
+```
+
+**Command.** Generate the first preview with the default rules:
+
+```bash
+python3 skills/local-document-organizer/scripts/course_organizer.py scan --folder .local-state/course-demo/lesson-2-organizer-freelancer-rules/incoming
+```
+
+At first, `client-meeting-notes.txt` goes to `Notes` because the generic
+text-extension rule matches `.txt`. In the canonical
+`skills/local-document-organizer/references/classification-rules.csv`, add
+this row before the generic `ext-text` rule:
+
+```csv
+keyword-meeting,Meetings,filename_keyword,meeting|minutes,medium,true
+```
+
+Before rerunning or invoking the skill, refresh the installed skill copy
+from the canonical package:
+
+```bash
+python3 skills/course-support/scripts/setup_course_skills.py --lesson 2
+```
+
+Run the same scan command again to generate a fresh plan. Do not edit an
+existing plan after it has been reviewed or approved.
+
+**Sample Codex prompt.**
+
+```text
+Use $local-document-organizer to compare the freelancer practice previews before and after the Meetings rule. Explain which rule matched each file. Do not apply either plan.
+```
+
+**Expected result.**
+
+- the invoice remains in `Invoices/`
+- the agreement remains in `Contracts/`
+- the meeting notes change from `Notes/` to `Meetings/`
+- the website project ideas remain in `Notes/`
+- rule order matters because the first matching rule wins
+
+Restore the rule afterward if you do not intend to keep this repository
+modification. If you remove the `Meetings` rule manually, run the same setup
+command again so the installed copy stays synchronized.
+
+**Reflection question.** Why must the more specific meeting rule appear
+before the generic text-extension rule?
+
+### 3. Safe recovery: conflict and undo
+
+**Purpose.** Practice approval, collision protection, partial results, and
+undo without risking real files.
+
+**Setup.** Create a fresh copy of the synthetic safe-recovery example:
+
+```bash
+python3 skills/course-support/scripts/seed_demo.py --scenario organizer-safe-recovery
+```
+
+**Command.** Scan the incoming folder:
+
+```bash
+python3 skills/local-document-organizer/scripts/course_organizer.py scan --folder .local-state/course-demo/lesson-2-organizer-safe-recovery/incoming
+```
+
+The preview proposes moving `invoice-august.txt` to `Invoices/`. That is
+only a proposal. The same-name collision is checked and enforced safely
+during apply.
+
+**Sample Codex prompt.**
+
+```text
+Use $local-document-organizer to preview the safe-recovery practice folder. Explain the proposed moves and the existing invoice collision, then wait for my explicit approval before applying anything.
+```
+
+After reviewing the preview, replace `<printed-plan-path>` with the actual
+plan path printed by the scan command, including any generated identifier:
+
+```bash
+python3 skills/local-document-organizer/scripts/course_organizer.py apply --plan <printed-plan-path> --confirm ORGANIZE
+```
+
+**Expected result after apply.**
+
+- the invoice move is recorded as `conflict`
+- the existing CAD 120 invoice is not overwritten
+- the revised CAD 145 invoice remains at its source
+- the coffee receipt and expense notes move successfully
+- the run status is `partial`
+- `mystery.zzz` stays in place
+
+Next, replace `<printed-journal-path>` with the actual journal path printed
+by apply:
+
+```bash
+python3 skills/local-document-organizer/scripts/course_organizer.py undo --log <printed-journal-path> --confirm UNDO
+```
+
+**Expected result after undo.**
+
+- successfully moved files return to their original locations
+- the conflicted invoice is not incorrectly moved
+- both invoice versions remain unchanged
+
+**Reflection question.** Why does undo use the action journal instead of
+trying to reverse every move from the original preview?
+
 ## Exercise (20–30 minutes)
 
 1. Ask `$local-document-organizer` to scan `.local-state/course-demo/lesson-2/incoming`. Inspect the plan and category counts. No files move during preview. Add one classification rule and compare a fresh preview.

--- a/skills/course-support/scripts/seed_demo.py
+++ b/skills/course-support/scripts/seed_demo.py
@@ -6,18 +6,32 @@ from pathlib import Path
 from course_runtime import CourseError, REPO, cli_main, emit, write_json
 
 
+SCENARIOS = {
+    "organizer-student-files": "lesson-2-organizer-student-files",
+    "organizer-freelancer-rules": "lesson-2-organizer-freelancer-rules",
+    "organizer-safe-recovery": "lesson-2-organizer-safe-recovery",
+}
+
+
 def main():
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--output", type=Path, default=REPO / ".local-state/course-demo/lesson-2")
+    p.add_argument("--scenario", choices=SCENARIOS)
+    p.add_argument("--output", type=Path)
     p.add_argument("--dry-run", action="store_true")
     a = p.parse_args()
-    target = a.output.resolve()
-    if a.output.is_symlink() or target.exists():
+    scenario = a.scenario or "lesson-2"
+    fixture_name = SCENARIOS.get(a.scenario, "lesson-2")
+    source = Path(__file__).resolve().parents[1] / "examples" / fixture_name
+    output = a.output or REPO / ".local-state/course-demo" / fixture_name
+    target = output.resolve()
+    if not source.is_dir():
+        raise CourseError("MISSING_FIXTURE", "The selected synthetic source fixture is unavailable.")
+    if output.is_symlink() or target.exists():
         raise CourseError("WOULD_OVERWRITE", "Choose a fresh output folder; existing course work is preserved.")
     if not a.dry_run:
         target.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copytree(Path(__file__).resolve().parents[1] / "examples/lesson-2", target)
-        write_json(target / ".course-demo.json", {"synthetic": True, "lesson": 2})
+        shutil.copytree(source, target)
+        write_json(target / ".course-demo.json", {"synthetic": True, "lesson": 2, "scenario": scenario})
     emit({"status": "preview" if a.dry_run else "seeded", "output": str(target), "synthetic": True})
 
 

--- a/skills/course-support/tests/test_lesson2.py
+++ b/skills/course-support/tests/test_lesson2.py
@@ -33,6 +33,7 @@ def load(name, relative):
 organizer = load("course_organizer", "skills/local-document-organizer/scripts/course_organizer.py")
 knowledge = load("course_knowledge", "skills/personal-knowledge-capture/scripts/course_knowledge.py")
 workflow = load("course_workflow", "skills/personal-workflow-automation/scripts/workflow.py")
+SEED_DEMO = REPO / "skills/course-support/scripts/seed_demo.py"
 
 
 class LessonTwoTests(unittest.TestCase):
@@ -44,11 +45,110 @@ class LessonTwoTests(unittest.TestCase):
         self.fixture = self.root / "fixture"
         shutil.copytree(REPO / "skills/course-support/examples/lesson-2", self.fixture)
 
-    def scan(self):
-        a = argparse.Namespace(folder=self.fixture / "incoming", rules=organizer.baseline.DEFAULT_RULES, include_low_confidence=False, dry_run=False)
+    def seed_demo(self, scenario, output, *, dry_run=False):
+        command = [sys.executable, str(SEED_DEMO), "--scenario", scenario, "--output", str(output)]
+        if dry_run:
+            command.append("--dry-run")
+        return subprocess.run(command, capture_output=True, text=True)
+
+    def scan(self, fixture=None):
+        a = argparse.Namespace(folder=(fixture or self.fixture) / "incoming", rules=organizer.baseline.DEFAULT_RULES, include_low_confidence=False, dry_run=False)
         with contextlib.redirect_stdout(io.StringIO()):
             organizer.scan(a, self.store)
         return next((self.store.root / "organizer").glob("*-plan.json"))
+
+    def scenario_plan(self, scenario):
+        fixture = self.root / scenario
+        seeded = self.seed_demo(scenario, fixture)
+        self.assertEqual(0, seeded.returncode, seeded.stderr or seeded.stdout)
+        plan_path = self.scan(fixture)
+        plan = read_json(plan_path)
+        root = Path(plan["folder"])
+        moves = {Path(item["old_path"]).name: Path(item["new_path"]).relative_to(root).as_posix()
+                 for item in plan["suggestions"]}
+        skipped = {Path(item["path"]).name for item in plan["skipped"]}
+        return fixture, plan_path, moves, skipped
+
+    def test_seed_demo_supports_organizer_scenarios_safely(self):
+        scenarios = ("organizer-student-files", "organizer-freelancer-rules", "organizer-safe-recovery")
+        for scenario in scenarios:
+            with self.subTest(scenario=scenario):
+                dry_output = self.root / f"{scenario}-dry-run"
+                dry_run = self.seed_demo(scenario, dry_output, dry_run=True)
+                self.assertEqual(0, dry_run.returncode, dry_run.stderr or dry_run.stdout)
+                self.assertFalse(dry_output.exists())
+
+                output = self.root / f"{scenario}-seeded"
+                seeded = self.seed_demo(scenario, output)
+                self.assertEqual(0, seeded.returncode, seeded.stderr or seeded.stdout)
+                self.assertEqual({"synthetic": True, "lesson": 2, "scenario": scenario},
+                                 read_json(output / ".course-demo.json"))
+
+                repeated = self.seed_demo(scenario, output)
+                self.assertEqual(2, repeated.returncode)
+                self.assertEqual("WOULD_OVERWRITE", json.loads(repeated.stdout)["error"])
+
+    def test_organizer_student_files_suggestions(self):
+        fixture, _, moves, skipped = self.scenario_plan("organizer-student-files")
+        self.assertEqual({
+            "tuition-invoice.txt": "Invoices/tuition-invoice.txt",
+            "school-reading.md": "School/school-reading.md",
+            "internship-resume.txt": "Resumes/internship-resume.txt",
+        }, moves)
+        self.assertIn("random-download.zzz", skipped)
+        self.assertTrue((fixture / "incoming/random-download.zzz").is_file())
+
+    def test_organizer_freelancer_default_rule_suggestions(self):
+        _, _, moves, _ = self.scenario_plan("organizer-freelancer-rules")
+        self.assertEqual({
+            "client-invoice-2026-09.txt": "Invoices/client-invoice-2026-09.txt",
+            "client-service-agreement.md": "Contracts/client-service-agreement.md",
+            "client-meeting-notes.txt": "Notes/client-meeting-notes.txt",
+            "website-project-ideas.md": "Notes/website-project-ideas.md",
+        }, moves)
+
+    def test_organizer_safe_recovery_collision_apply_and_undo(self):
+        fixture, plan_path, moves, skipped = self.scenario_plan("organizer-safe-recovery")
+        incoming = fixture / "incoming"
+        revised_invoice = incoming / "invoice-august.txt"
+        reviewed_invoice = incoming / "Invoices/invoice-august.txt"
+        revised_content = revised_invoice.read_text()
+        reviewed_content = reviewed_invoice.read_text()
+        self.assertEqual({
+            "invoice-august.txt": "Invoices/invoice-august.txt",
+            "coffee-receipt.txt": "Receipts/coffee-receipt.txt",
+            "expense-notes.md": "Notes/expense-notes.md",
+        }, moves)
+        self.assertIn("mystery.zzz", skipped)
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            result = organizer.apply(argparse.Namespace(plan=plan_path, confirm="ORGANIZE", dry_run=False), self.store)
+        self.assertEqual(1, result)
+        log = next((self.store.root / "organizer").glob("*-actions.json"))
+        actions = {Path(item["old_path"]).name: item for item in read_json(log)["actions"]}
+        self.assertEqual("conflict", actions["invoice-august.txt"]["status"])
+        self.assertEqual("moved", actions["coffee-receipt.txt"]["status"])
+        self.assertEqual("moved", actions["expense-notes.md"]["status"])
+        self.assertEqual(revised_content, revised_invoice.read_text())
+        self.assertEqual(reviewed_content, reviewed_invoice.read_text())
+        self.assertFalse((incoming / "coffee-receipt.txt").exists())
+        self.assertTrue((incoming / "Receipts/coffee-receipt.txt").is_file())
+        self.assertFalse((incoming / "expense-notes.md").exists())
+        self.assertTrue((incoming / "Notes/expense-notes.md").is_file())
+        self.assertTrue((incoming / "mystery.zzz").is_file())
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            organizer.undo(argparse.Namespace(log=log, dry_run=False, confirm="UNDO"), self.store)
+        undone = {Path(item["old_path"]).name: item for item in read_json(log)["actions"]}
+        self.assertNotIn("undo_status", undone["invoice-august.txt"])
+        self.assertEqual("restored", undone["coffee-receipt.txt"]["undo_status"])
+        self.assertEqual("restored", undone["expense-notes.md"]["undo_status"])
+        self.assertTrue((incoming / "coffee-receipt.txt").is_file())
+        self.assertTrue((incoming / "expense-notes.md").is_file())
+        self.assertFalse((incoming / "Receipts/coffee-receipt.txt").exists())
+        self.assertFalse((incoming / "Notes/expense-notes.md").exists())
+        self.assertEqual(revised_content, revised_invoice.read_text())
+        self.assertEqual(reviewed_content, reviewed_invoice.read_text())
 
     def test_organize_preview_approval_apply_undo_and_no_overwrite(self):
         source = self.fixture / "incoming"

--- a/skills/course-support/zh-Hans/lesson-2.md
+++ b/skills/course-support/zh-Hans/lesson-2.md
@@ -18,6 +18,170 @@ python3 skills/course-support/scripts/course_store.py context
 
 第一条命令列出三个 Codex Skill 名称；第二条在 `.local-state/course-demo/lesson-2/` 创建数据，不覆盖旧作业。incoming 中有发票、学校资料和未知扩展名；research 中有重复资料和容量冲突。此时是本地演示身份，不代表已登录生产账号。
 
+## 可选扩展练习：文件整理
+
+老师可以选择其中一个案例，也可以让学生按顺序完成三个案例。三个
+案例彼此独立，在一个文件夹中的操作不会影响另外两个。只使用以下
+命令生成的合成练习文件，不要用真实的 Downloads 文件夹练习。
+
+在下面的练习中，**预览（preview）**只展示建议，不移动文件；
+**计划（plan）**是保存建议移动操作的文件；**冲突（conflict）**是
+为了安全而跳过的操作；**操作日志（journal）**记录实际执行结果。
+其他术语请参阅 Local Document Organizer 的
+[入门术语表](../../local-document-organizer/README.md#beginner-terminology)。
+
+每条 seed 命令都会拒绝删除或替换已有的输出目录。重复练习时，请
+保留之前的作业，并用 `--output` 指定一个新路径，例如
+`--output .local-state/course-demo/student-files-attempt-2`。
+
+### 1. 学生文件：只预览
+
+**目的。** 了解清晰可读的文件名和扩展名规则如何生成计划，并观察
+无法确定类别的文件如何留在原处。
+
+**准备。** 生成一份新的合成学生文件案例：
+
+```bash
+python3 skills/course-support/scripts/seed_demo.py --scenario organizer-student-files
+```
+
+**命令。** 扫描 incoming 文件夹。这条命令只查看并提出建议，不会
+移动文件。
+
+```bash
+python3 skills/local-document-organizer/scripts/course_organizer.py scan --folder .local-state/course-demo/lesson-2-organizer-student-files/incoming
+```
+
+**Codex 示例提示。**
+
+```text
+使用 $local-document-organizer 预览学生文件练习文件夹。解释每个建议分类，把不确定的文件留在原处。不要移动任何文件。
+```
+
+**预期结果。**
+
+- `tuition-invoice.txt` -> `Invoices/`
+- `school-reading.md` -> `School/`
+- `internship-resume.txt` -> `Resumes/`
+- `random-download.zzz` 留在原处
+- 预览不会移动任何文件
+
+**思考问题。** 为什么把未知文件留在原处，比猜测一个类别更安全？
+
+### 2. 自由职业者规则：自定义分类
+
+**目的。** 观察更具体的文件名规则如何改善分类，并理解规则顺序
+为什么会改变结果。
+
+**准备。** 生成一份新的合成自由职业者案例：
+
+```bash
+python3 skills/course-support/scripts/seed_demo.py --scenario organizer-freelancer-rules
+```
+
+**命令。** 先使用默认规则生成第一次预览：
+
+```bash
+python3 skills/local-document-organizer/scripts/course_organizer.py scan --folder .local-state/course-demo/lesson-2-organizer-freelancer-rules/incoming
+```
+
+一开始，`client-meeting-notes.txt` 会进入 `Notes`，因为通用的文本
+扩展名规则匹配了 `.txt`。在规范源文件
+`skills/local-document-organizer/references/classification-rules.csv` 中，
+把下面这一行加在通用 `ext-text` 规则之前：
+
+```csv
+keyword-meeting,Meetings,filename_keyword,meeting|minutes,medium,true
+```
+
+再次扫描或调用 Skill 前，先从规范包刷新已安装的 Skill 副本：
+
+```bash
+python3 skills/course-support/scripts/setup_course_skills.py --lesson 2
+```
+
+再次运行同一条扫描命令，生成一份新计划。不要修改已经审阅或批准的
+现有计划。
+
+**Codex 示例提示。**
+
+```text
+使用 $local-document-organizer 比较加入 Meetings 规则前后的自由职业者练习预览。解释每个文件匹配了哪条规则。不要应用任何一个计划。
+```
+
+**预期结果。**
+
+- 发票仍在 `Invoices/`
+- 协议仍在 `Contracts/`
+- 会议记录从 `Notes/` 变为 `Meetings/`
+- 网站项目想法仍在 `Notes/`
+- 规则采用首条匹配结果，因此顺序很重要
+
+如果不打算保留这项仓库修改，请在练习后恢复该规则。手动删除
+`Meetings` 规则后，再运行一次相同的 setup 命令，使已安装副本与
+规范包保持同步。
+
+**思考问题。** 为什么更具体的会议规则必须放在通用 `ext-text`
+规则之前？
+
+### 3. 安全恢复：冲突与撤销
+
+**目的。** 使用合成文件练习审批、重名保护、部分成功结果和撤销，
+不让真实文件承担风险。
+
+**准备。** 生成一份新的合成安全恢复案例：
+
+```bash
+python3 skills/course-support/scripts/seed_demo.py --scenario organizer-safe-recovery
+```
+
+**命令。** 扫描 incoming 文件夹：
+
+```bash
+python3 skills/local-document-organizer/scripts/course_organizer.py scan --folder .local-state/course-demo/lesson-2-organizer-safe-recovery/incoming
+```
+
+预览会建议把 `invoice-august.txt` 移到 `Invoices/`。这仍然只是建议；
+真正 apply 时，系统才会安全检查并执行同名冲突保护。
+
+**Codex 示例提示。**
+
+```text
+使用 $local-document-organizer 预览安全恢复练习文件夹。解释建议移动操作和已有发票造成的冲突，然后等待我明确批准，再执行任何操作。
+```
+
+审阅预览后，把 `<printed-plan-path>` 替换为扫描命令实际打印的计划
+路径，包括其中生成的标识符：
+
+```bash
+python3 skills/local-document-organizer/scripts/course_organizer.py apply --plan <printed-plan-path> --confirm ORGANIZE
+```
+
+**apply 后的预期结果。**
+
+- 发票移动操作记录为 `conflict`
+- 已有的 CAD 120 发票不会被覆盖
+- 修订后的 CAD 145 发票仍留在源位置
+- 咖啡收据和支出备注成功移动
+- 符合条件的移动成功，但存在冲突，因此运行状态为 `partial`
+- `mystery.zzz` 留在原处
+
+接下来，把 `<printed-journal-path>` 替换为 apply 实际打印的操作日志
+路径：
+
+```bash
+python3 skills/local-document-organizer/scripts/course_organizer.py undo --log <printed-journal-path> --confirm UNDO
+```
+
+**undo 后的预期结果。**
+
+- 只有成功移动的文件返回原位置
+- 发生冲突的发票不会被错误移动
+- 两个版本的发票内容都保持不变
+
+**思考问题。** 为什么 undo 要依据操作日志，而不是尝试撤销原始
+预览中的每一项建议？
+
 ## 课堂练习（20–30 分钟）
 
 1. 让 `$local-document-organizer` 扫描 `.local-state/course-demo/lesson-2/incoming`，查看计划与分类数量。预览不移动文件。增加一条分类规则，再生成新预览。

--- a/skills/local-document-organizer/README.md
+++ b/skills/local-document-organizer/README.md
@@ -33,25 +33,42 @@ It is most useful for requests such as:
 - preview what would happen before any file is touched
 - reverse a previous organization run
 
-## End-to-End Workflow
+## A Simple Mental Model
 
-The workflow is split into three commands so each phase has a clear
-boundary:
+Think of the workflow as three separate steps:
 
-1. **Scan.** The user names a folder. The skill walks it, classifies each
-   file using the rules in `references/classification-rules.csv`, and writes
-   a Markdown report plus a JSON plan. No files are moved.
-2. **Apply.** After the user reviews the preview and explicitly approves,
-   the skill runs `apply --confirm ORGANIZE` against the plan. It creates
-   category subfolders, moves files, and writes an action log. Conflicts
-   and permission errors are recorded as skipped actions.
-3. **Undo.** If the user wants to revert the run, the skill reads the
-   action log and moves each file back to its original path.
+1. **Scan means looking and proposing.** The user names a folder. The skill
+   checks its files and writes a readable preview plus a JSON plan. Nothing
+   moves during a scan.
+2. **Apply means carrying out only the reviewed plan.** After explicit
+   approval with `--confirm ORGANIZE`, the skill creates category folders,
+   performs the eligible moves, and records what happened. Conflicts and
+   permission errors stay visible instead of being hidden.
+3. **Undo means reversing recorded moves.** The skill reads the action log
+   and restores only files that were successfully moved. It still refuses
+   to overwrite anything.
 
 The agent surfaces the report, the plan, the action log path, and the
 results. The user owns the decision to apply and the decision to undo.
 
+## Beginner Terminology
+
+| Term | Plain-language meaning |
+| --- | --- |
+| Preview | A readable description of the moves the skill proposes. A preview does not move files. |
+| Plan | The saved JSON record of proposed source and destination paths that `apply` can review and use. |
+| Confidence | The strength assigned by the matching rule. Low confidence normally means the file stays where it is. |
+| Approval | The user's explicit permission to apply a reviewed plan, given with the required `ORGANIZE` confirmation token. |
+| SHA-256 / hash | A fingerprint of a file's contents. The skill uses it to notice when a file has changed since the plan was created. |
+| Journal / action log | A durable record of attempted moves and their results. It provides the evidence needed for recovery. |
+| Conflict | A move that cannot safely happen, often because a file with the same name already exists at the destination. The existing file is not overwritten. |
+| Undo | A recovery operation that uses the action log to reverse moves that actually succeeded. |
+
 ## What The Package Actually Does
+
+This skill organizes files with readable filename keywords and file
+extensions. It does not understand, interpret, or summarize the knowledge
+inside a document. That is a different kind of task.
 
 - Reads classification rules from a small CSV (extension and filename
   keyword matches with confidence scores).
@@ -97,6 +114,45 @@ If you are a student reading the repo, the main lessons are:
    accident than a free-form "yes"
 3. an action log is the difference between a regret and a recovery
 
+## Three Progressive Learning Examples
+
+Each example uses independent synthetic course files. Run its generation
+command once from the repository root. The command refuses to replace an
+existing output folder.
+
+### Student files
+
+Preview how an invoice, school reading, and internship resume are classified
+while an unknown file stays in place.
+
+```bash
+python3 skills/course-support/scripts/seed_demo.py --scenario organizer-student-files
+```
+
+### Freelancer rules
+
+Observe that meeting notes initially go to `Notes`. Add a readable
+`Meetings` filename rule, make a fresh preview, and compare the proposed
+destinations before applying anything.
+
+```bash
+python3 skills/course-support/scripts/seed_demo.py --scenario organizer-freelancer-rules
+```
+
+### Safe recovery
+
+Approve the eligible moves and observe that an existing same-name invoice
+is protected from overwrite. Inspect the partial result, then undo the moves
+that succeeded.
+
+```bash
+python3 skills/course-support/scripts/seed_demo.py --scenario organizer-safe-recovery
+```
+
+The [Lesson 2 teaching guide](../course-support/lessons/lesson-2.md) contains
+the detailed command-by-command exercises. This README keeps the mental
+model and safety boundaries close at hand.
+
 ## Professional AI Agent Course: Organize
 
 ### What you will learn
@@ -126,7 +182,11 @@ The preview proposes an invoice and a school document; the unknown extension sta
 
 ### 20–30 minute classroom exercise
 
-Read the emitted plan and report. Approve only those moves; run `course_organizer.py apply --plan <printed-plan-path> --confirm ORGANIZE`. Inspect the action journal and moved files. Run `course_organizer.py undo --log <printed-journal-path> --confirm UNDO`, then compare file hashes to prove restoration. Resolve `workflow.py` / `course_organizer.py` command shorthand to this package's `scripts/` directory.
+Follow the [Lesson 2 teaching guide](../course-support/lessons/lesson-2.md)
+for the full exercise. It covers reviewing the plan and report, approving
+moves, inspecting the action journal, undoing a run, and comparing hashes
+to prove restoration. Command shorthand such as `course_organizer.py`
+resolves to this package's `scripts/` directory.
 
 ### What to modify
 


### PR DESCRIPTION
## Summary

This PR adds three independent, progressive learning examples for the Lesson 2 Local Document Organizer skill. Students can preview everyday file classifications, customize a filename rule, and practice collision protection with selective undo. It also adds local scenario generation, focused automated tests, beginner-friendly terminology, and matching English and Simplified Chinese teaching instructions.

This PR was opened directly with maintainer approval.

## Target Branch

- `develop`

## Pull Request Stage

- Ready for review — the scoped change and required Lesson 2 checks are complete.

## Contribution Type

- practitioner skill package

## Placement

- Target paths:
  - `skills/local-document-organizer/README.md`
  - `skills/course-support/scripts/seed_demo.py`
  - `skills/course-support/tests/test_lesson2.py`
  - `skills/course-support/examples/lesson-2-organizer-*/`
  - `skills/course-support/lessons/lesson-2.md`
  - `skills/course-support/zh-Hans/lesson-2.md`
- Links or indexes updated:
  - Local Document Organizer README links to the detailed Lesson 2 teaching guide.
  - English and Simplified Chinese Lesson 2 guides contain matching exercise structures.
- Related issue:
  - None. A maintainer approved opening this contribution directly as a PR.

## Learning Examples

### Student files

Students preview invoice, school, and resume classifications while an unknown file remains safely in place. No files move during preview.

### Freelancer rules

Students observe meeting notes initially classified as `Notes`, add a more specific `Meetings` filename rule, refresh the installed skill copy, and compare a fresh preview.

### Safe recovery

Students apply a reviewed plan containing a deliberate same-name invoice collision. The existing file is not overwritten, eligible files move successfully, the run reports `partial`, and undo restores only successful moves.

## Source Lineage

No external prose, code, screenshots, or personal data were copied into this contribution. The change follows the existing repository structure and behavior documented in:

- `skills/local-document-organizer/README.md`
- `skills/local-document-organizer/SKILL.md`
- `skills/local-document-organizer/references/classification-rules.csv`
- `skills/course-support/examples/lesson-2/`
- the existing English and Simplified Chinese Lesson 2 guides

All example identities, documents, invoices, amounts, and file contents are synthetic.

## Safety

- The examples use synthetic files only.
- Students are explicitly told not to practice on a real Downloads folder.
- Existing output directories are never overwritten.
- Preview does not move files.
- Destination collisions remain protected.
- Runtime plans, journals, and course state stay under ignored `.local-state`.
- The existing approval, hash verification, no-overwrite, and undo behavior remains unchanged.

## Validation

- [x] `python3 skills/course-support/tests/test_lesson2.py` — 15 tests passed
- [x] Lesson 2 course/runtime verification — 25 relevant tests passed
- [x] Manual student-files preview
- [x] Manual freelancer rule comparison
- [x] Manual collision, `partial` apply, and undo exercise
- [x] `python3 scripts/check_filename_casing.py`
- [x] `python3 scripts/check_published_links.py`
- [x] `git diff --check`
- [x] English and Simplified Chinese exercise structures compared

The full cross-course verification later reached an unrelated Lesson 4 XLSX test that requires the optional `openpyxl` dependency. The focused Lesson 2 checks completed successfully.

## Review Checklist

- [x] The contribution type is explicit.
- [x] The files and folders are in the existing skill and course-support paths.
- [x] I followed the repository's practitioner skill and course patterns.
- [x] The change stays repo-native and does not copy upstream material into public tracked paths.
- [x] Source and attribution boundaries are clear.
- [x] The relevant README and teaching guides were updated for discoverability.
- [x] The existing skill package includes both a human-facing `README.md` and an agent-facing `SKILL.md`.
- [x] Existing safety and maintenance expectations remain clear.
- [x] Related issue labels are not applicable because a maintainer approved a direct PR.
- [x] The new files are synthetic course fixtures rather than source-project example code; focused Lesson 2 tests cover their behavior.
- [x] Filename casing was checked for all new paths.