### PR TITLE
Fix track guard for bilingual course contributions and PR comments

### DIFF
--- a/.github/prompthon-track-guard.md
+++ b/.github/prompthon-track-guard.md
@@ -1,0 +1,38 @@
+# Contribution track guard
+
+The guard reads the first linked issue's track, then falls back to the PR's
+`track: explorer`, `track: practitioner`, or `track: builder` label. Link an
+issue with a closing keyword such as `Closes #123`. A maintainer-approved
+direct PR without an issue still needs a track label on the PR itself.
+Adding or changing a PR label triggers a new check.
+
+The allowed paths are defined in `scripts/prompthon-activity-policy.mjs`
+relative to this `.github/` directory. Entries ending in `/` allow a
+directory; all other entries match one exact repository-relative filename.
+
+Practitioner contributions include skills, snippets, workshops, templates,
+specialization pages, and their matching `zh-Hans/` directories. Course
+contributions may also update `docs.json`, the environment setup and sample
+projects reading-path pages, and their Chinese translations. This does not
+allow unrelated reading paths, foundations, repository scripts, or workflows.
+
+The workflow checks out the PR's base branch, so editing policy inside a PR
+does not authorize that PR's paths. A policy repair must first pass review
+and merge into the base branch. Then re-run the failed check using a run
+whose event already includes the correct track label, or change the PR label
+to trigger a fresh event. All normal review and required CI checks still apply.
+
+The workflow uses `issues: read` to inspect linked issues and
+`pull-requests: write` for PR failure comments. It executes only the trusted
+base-branch guard and does not persist checkout credentials. Validation
+failures are also written to the Actions log and job summary, even if the
+comment request fails. Comment delivery never decides whether paths pass.
+
+Run the regression checks locally:
+
+```sh
+node --test .github/scripts/prompthon-activity-policy.test.mjs .github/scripts/prompthon-track-guard.test.mjs
+```
+
+The read-only `validate-mintlify` PR workflow runs these tests against proposed
+code; the privileged track guard continues to execute base-branch code only.

--- a/.github/scripts/prompthon-activity-policy.mjs
+++ b/.github/scripts/prompthon-activity-policy.mjs
@@ -52,6 +52,18 @@ export const TRACK_ALLOWED_PATHS = {
     "snippets/",
     "workshops/",
     "templates/",
+    "specializations/",
+    "zh-Hans/skills/",
+    "zh-Hans/snippets/",
+    "zh-Hans/workshops/",
+    "zh-Hans/templates/",
+    "zh-Hans/specializations/",
+    // Course navigation and onboarding pages accompany practitioner material.
+    "docs.json",
+    "reading-paths/environment-setup.mdx",
+    "reading-paths/sample-projects.mdx",
+    "zh-Hans/reading-paths/environment-setup.mdx",
+    "zh-Hans/reading-paths/sample-projects.mdx",
   ],
   builder: [
     "scripts/",
@@ -168,7 +180,9 @@ export function findLinkedIssueNumbers(text) {
 export function validateChangedFilesForTrack(track, changedFiles, pathPolicy = TRACK_ALLOWED_PATHS) {
   const allowedPaths = pathPolicy[track] || [];
   const invalidFiles = changedFiles.filter((filePath) =>
-    !allowedPaths.some((allowedPath) => filePath.startsWith(allowedPath)),
+    !allowedPaths.some((allowedPath) => allowedPath.endsWith("/")
+      ? filePath.startsWith(allowedPath)
+      : filePath === allowedPath),
   );
   return {
     allowedPaths,

--- a/.github/scripts/prompthon-activity-policy.test.mjs
+++ b/.github/scripts/prompthon-activity-policy.test.mjs
@@ -136,3 +136,42 @@ test("validates practitioner and builder path policy", () => {
     true,
   );
 });
+
+test("accepts a bilingual course specialization with its navigation and setup guides", () => {
+  const validation = validateChangedFilesForTrack("practitioner", [
+    "docs.json",
+    "reading-paths/environment-setup.mdx",
+    "reading-paths/sample-projects.mdx",
+    "skills/course-support/README.md",
+    "skills/index.mdx",
+    "skills/professional-ai-agent-course.mdx",
+    "specializations/ai-native-internship.mdx",
+    "zh-Hans/reading-paths/environment-setup.mdx",
+    "zh-Hans/reading-paths/sample-projects.mdx",
+    "zh-Hans/skills/index.mdx",
+    "zh-Hans/skills/professional-ai-agent-course.mdx",
+    "zh-Hans/specializations/ai-native-internship.mdx",
+  ]);
+  assert.equal(validation.valid, true);
+  assert.deepEqual(validation.invalidFiles, []);
+});
+
+test("course support paths do not allow unrelated content, CI, or lookalike filenames", () => {
+  const invalidFiles = [
+    ".github/workflows/prompthon-track-guard.yml",
+    "scripts/check_filename_casing.py",
+    "foundations/the-agent-system.mdx",
+    "zh-Hans/foundations/the-agent-system.mdx",
+    "reading-paths/advanced-agents.mdx",
+    "docs.json.backup",
+    "reading-paths/environment-setup.mdx.bak",
+    "zh-Hans/reading-paths/sample-projects.mdx/other.md",
+    "specializations-private/notes.md",
+  ];
+  const validation = validateChangedFilesForTrack("practitioner", [
+    "skills/course-support/README.md",
+    ...invalidFiles,
+  ]);
+  assert.equal(validation.valid, false);
+  assert.deepEqual(validation.invalidFiles, invalidFiles);
+});

--- a/.github/scripts/prompthon-track-guard.mjs
+++ b/.github/scripts/prompthon-track-guard.mjs
@@ -3,6 +3,7 @@
 import fs from "node:fs";
 
 import {
+  TRACKS,
   extractLabelNames,
   extractTrackFromLabels,
   findLinkedIssueNumbers,
@@ -96,6 +97,15 @@ function failureComment({ allowedPaths, invalidFiles, track }) {
   ].join("\n");
 }
 
+function reportFailure(message) {
+  // Keep the actionable failure visible even when GitHub rejects the comment.
+  console.error(message);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${message}\n`);
+  }
+  process.exitCode = 1;
+}
+
 function isReleasePullRequest(pullRequest, repo) {
   return pullRequest.base?.ref === "main" &&
     pullRequest.head?.ref === "develop" &&
@@ -128,20 +138,24 @@ async function main() {
   const issueLabels = extractLabelNames(linkedIssue?.labels);
   const prLabels = extractLabelNames(pullRequest.labels);
   const track = extractTrackFromLabels(issueLabels) || extractTrackFromLabels(prLabels);
-  const changedFiles = dryRun && Array.isArray(event.changed_files)
-    ? event.changed_files
-    : await listPullRequestFiles(repo, pullRequest.number);
-
   if (!track) {
-    const message = "prompthon-track-guard could not determine a contribution track from the linked issue or PR labels.";
+    const message = [
+      "prompthon-track-guard could not determine a contribution track from the linked issue or PR labels.",
+      `Add the matching label to this PR: ${TRACKS.map((value) => `\`track: ${value}\``).join(", ")}.`,
+      "Alternatively, link a labeled issue in the PR body using `Closes #123`.",
+      `Linked issue: ${linkedIssueNumber ? `#${linkedIssueNumber}` : "none"}.`,
+      "The selected track must allow every changed path; adding a label triggers a new check.",
+    ].join("\n");
+    reportFailure(message);
     if (!dryRun) {
       await tryUpsertFailureComment(repo, pullRequest.number, `${COMMENT_MARKER}\n${message}`);
     }
-    console.error(message);
-    process.exitCode = 1;
     return;
   }
 
+  const changedFiles = dryRun && Array.isArray(event.changed_files)
+    ? event.changed_files
+    : await listPullRequestFiles(repo, pullRequest.number);
   const validation = validateChangedFilesForTrack(track, changedFiles);
   const summary = {
     changedFiles,
@@ -151,11 +165,11 @@ async function main() {
   };
 
   if (!validation.valid) {
+    reportFailure(failureComment({ track, ...validation }));
     if (!dryRun) {
       await tryUpsertFailureComment(repo, pullRequest.number, failureComment({ track, ...validation }));
     }
     console.error(JSON.stringify(summary, null, 2));
-    process.exitCode = 1;
     return;
   }
 

--- a/.github/scripts/prompthon-track-guard.test.mjs
+++ b/.github/scripts/prompthon-track-guard.test.mjs
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(new URL("./prompthon-track-guard.mjs", import.meta.url));
+
+function runGuard(t, { labels = [], files = [], body = "", mockApi = false } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "track-guard-test-"));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  const eventPath = path.join(dir, "event.json");
+  const summaryPath = path.join(dir, "summary.md");
+  fs.writeFileSync(eventPath, JSON.stringify({
+    repository: { full_name: "example/handbook" },
+    pull_request: { number: 1, labels, body },
+    changed_files: files,
+  }));
+  const mockPath = path.join(dir, "mock-api.mjs");
+  fs.writeFileSync(mockPath, `
+    globalThis.fetch = async (url, options = {}) => {
+      if (url.endsWith("/issues/123")) {
+        return Response.json({ labels: [{ name: "track: practitioner" }] });
+      }
+      if (url.endsWith("/pulls/1/files?per_page=100&page=1")) {
+        return Response.json([{ filename: "skills/course-support/README.md" }]);
+      }
+      if (url.endsWith("/issues/1/comments?per_page=100")) {
+        return Response.json([]);
+      }
+      if (url.endsWith("/issues/1/comments") && options.method === "POST") {
+        return Response.json({ message: "Resource not accessible by integration" }, { status: 403 });
+      }
+      throw new Error("Unexpected network request: " + url);
+    };
+  `);
+  const result = spawnSync(process.execPath, [
+    "--import", mockPath, scriptPath, ...(mockApi ? [] : ["--dry-run"]),
+  ], {
+    env: {
+      ...process.env,
+      GITHUB_TOKEN: "test-token-never-sent",
+      GITHUB_EVENT_PATH: eventPath,
+      GITHUB_STEP_SUMMARY: summaryPath,
+    },
+    encoding: "utf8",
+    timeout: 10_000,
+  });
+  assert.ifError(result.error);
+  return {
+    ...result,
+    summary: fs.existsSync(summaryPath) ? fs.readFileSync(summaryPath, "utf8") : "",
+  };
+}
+
+test("an unlabeled direct PR fails with instructions in the log and summary", (t) => {
+  const result = runGuard(t, { files: ["skills/course-support/README.md"] });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /could not determine a contribution track/);
+  assert.match(result.summary, /track: practitioner/);
+  assert.match(result.summary, /Closes #123/);
+  assert.match(result.summary, /Linked issue: none/);
+});
+
+test("the PR label supports direct contributions without a linked issue", (t) => {
+  const result = runGuard(t, {
+    labels: [{ name: "track: practitioner" }],
+    files: ["skills/course-support/examples/lesson-2-organizer-student-files/incoming/school-reading.md"],
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(result.stdout).status, "passed");
+});
+
+test("a labeled PR can include bilingual specialization and navigation pages", (t) => {
+  const result = runGuard(t, {
+    labels: [{ name: "track: practitioner" }],
+    files: ["docs.json", "specializations/ai-native-internship.mdx", "zh-Hans/skills/index.mdx"],
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(JSON.parse(result.stdout).track, "practitioner");
+});
+
+test("a practitioner label still rejects changes to the guard itself", (t) => {
+  const result = runGuard(t, {
+    labels: [{ name: "track: practitioner" }],
+    files: ["skills/index.mdx", ".github/scripts/prompthon-track-guard.mjs"],
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.summary, /Invalid files:\n- `.github\/scripts\/prompthon-track-guard.mjs`/);
+});
+
+test("comment permission failures preserve the actionable validation error", (t) => {
+  const result = runGuard(t, { mockApi: true });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /GitHub API 403/);
+  assert.match(result.summary, /track: practitioner/);
+  assert.ok(result.stderr.indexOf("could not determine") < result.stderr.indexOf("GitHub API 403"));
+});
+
+test("a linked issue track still takes precedence over the PR track", (t) => {
+  const result = runGuard(t, {
+    body: "Closes #123",
+    labels: [{ name: "track: builder" }],
+    mockApi: true,
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.track, "practitioner");
+  assert.equal(output.linkedIssueNumber, 123);
+});

--- a/.github/workflows/prompthon-track-guard.yml
+++ b/.github/workflows/prompthon-track-guard.yml
@@ -13,8 +13,8 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: read
+  issues: read
+  pull-requests: write
 
 jobs:
   prompthon-track-guard:
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
+          persist-credentials: false
 
       - name: Validate changed paths
         env:

--- a/.github/workflows/validate-mintlify.yml
+++ b/.github/workflows/validate-mintlify.yml
@@ -40,5 +40,8 @@ jobs:
         with:
           node-version: ${{ steps.node-version.outputs.version }}
 
+      - name: Test contribution policy and track guard
+        run: node --test .github/scripts/prompthon-activity-policy.test.mjs .github/scripts/prompthon-track-guard.test.mjs
+
       - name: Validate Mintlify docs
         run: npx --yes mint validate


### PR DESCRIPTION
## Summary

Course and specialization PRs can fail the contribution guard even after receiving `track: practitioner`: the policy omitted bilingual course pages, specialization pages, and their navigation/setup companions. PR #229 exercises this case; PR #230 only needed its missing practitioner label, and its online guard now passes.

Allow practitioner specialization pages and matching Chinese directories, plus exact matches for `docs.json` and the English/Chinese environment-setup and sample-projects guides. Unrelated content and CI paths remain rejected. Give PR comments `pull-requests: write`, retain read-only issue access, and write actionable failures to the Actions summary before attempting a comment so a 403 does not obscure the actual cause.

## Target Branch

`develop`. The privileged guard still executes trusted base-branch code with checkout credentials persistence disabled. This repair must pass independent review and merge into `develop` before PR #229 can use it. It does not bypass branch protection or authorize itself from PR-head policy.

## Contribution Type and Placement

- Repo/process/meta; `track: builder`.
- Changes are confined to `.github/` policy, diagnostics, workflow permissions, tests, and operating notes.
- Maintainer-directed repair; no linked contribution issue.

## Validation

- All 15 policy and guard tests passed, including missing labels, direct PR labels, linked-issue precedence, forbidden CI paths, exact-file boundaries, and mocked comment 403 handling.
- Dry runs with the real changed-path lists passed for PR #229 (12 files) and PR #230 (18 files) using practitioner labels.
- All seven starter-project checks passed.
- Published-link unit tests and repository link check passed.
- `git diff --check` passed.
- The read-only `validate-mintlify` workflow now tests proposed policy/guard code. Remote `validate-mintlify` (including all 15 policy/guard tests), `verify-example-projects`, and `prompthon-track-guard` passed for commit `831a904356deeb905e8880246202eb2d632c71fa`. Ready for independent review.

## Activation

Both affected PRs now have `track: practitioner`. After this repair merges, re-run PR #229's latest labeled-event track-guard run so it checks the updated base-branch policy. The PR #229 and #230 content changes retain their own review and merge requirements. Live comment delivery remains to be verified after the workflow permission change becomes active.
